### PR TITLE
fix(test): make simulate-buffs e2e test deterministic

### DIFF
--- a/test/fight/simulate-buffs.e2e-spec.ts
+++ b/test/fight/simulate-buffs.e2e-spec.ts
@@ -35,7 +35,7 @@ describe('Simulate fight with buffs', () => {
             speed: 50,
             agility: 20,
             accuracy: 25,
-            criticalChance: 0.1,
+            criticalChance: 0,
             skills: {
               special: {
                 kind: 'ATTACK',
@@ -74,7 +74,7 @@ describe('Simulate fight with buffs', () => {
             speed: 70,
             agility: 25,
             accuracy: 30,
-            criticalChance: 0.15,
+            criticalChance: 0,
             skills: {
               special: {
                 kind: 'ATTACK',
@@ -118,7 +118,7 @@ describe('Simulate fight with buffs', () => {
             speed: 60,
             agility: 20,
             accuracy: 25,
-            criticalChance: 0.1,
+            criticalChance: 0,
             skills: {
               special: {
                 kind: 'ATTACK',
@@ -155,7 +155,7 @@ describe('Simulate fight with buffs', () => {
             speed: 80,
             agility: 35,
             accuracy: 40,
-            criticalChance: 0.2,
+            criticalChance: 0,
             skills: {
               special: {
                 kind: 'ATTACK',


### PR DESCRIPTION
## Summary

- The `should handle buff skills in API` e2e test was flaky due to non-deterministic fight outcomes
- Archer (`criticalChance: 0.2`) could crit and one-shot DPS Warrior before it acted, shifting all step indices and breaking the assertion on `res.body[3]`
- Fixed by setting `criticalChance: 0` for all cards in the test scenario, ensuring the fight order is deterministic and DPS Warrior's turn-end buff always lands at step 3

## Root cause

The test asserts a specific step index:
```ts
expect(res.body[3]).toEqual({ kind: 'buff', source: { id: 'dps-warrior' }, ... })
```

Expected turn order: Archer (speed 80) → DPS Warrior (speed 70) → buff at step 3.

But when Archer crits DW (crit damage = 100×1.1×2 − 60 = 160 > DW health 150), DW dies before acting. The sequence becomes: attack → `status_change` DW dead → Support Paladin attacks, causing the test to fail non-deterministically (~20% of runs).

## Test plan

- [x] Run `npm run test:e2e` 20 consecutive times without failure
- [x] Run `npm run test` (unit tests) — no regression

https://claude.ai/code/session_01GjGSyT91Qqs1W2YFfKByoa