### PR TITLE
feat: implement event-bound effect termination mechanism

### DIFF
--- a/.claude/commands/speckit.flow.md
+++ b/.claude/commands/speckit.flow.md
@@ -1,0 +1,66 @@
+---
+description: Run the full speckit workflow end-to-end — specify, plan, tasks, implement, and review.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+This command orchestrates the complete speckit pipeline in sequence. Each step must fully complete before proceeding to the next. If any step fails or the user requests a stop, halt the pipeline. Each step must be execute in a new context.
+
+### Pipeline Steps
+
+Execute the following skills **in order**, one at a time:
+
+1. **Specify** — `/speckit.specify $ARGUMENTS`
+   - Creates the feature branch and writes the specification
+   - Wait for full completion (including any clarification questions)
+   - If the user cancels or the spec fails validation after 3 iterations, **stop the pipeline**
+
+2. **Plan** — `/speckit.plan`
+   - Generates the technical implementation plan from the spec
+   - Wait for full completion before proceeding
+
+3. **Tasks** — `/speckit.tasks`
+   - Breaks the plan into an actionable, dependency-ordered task list
+   - Wait for full completion before proceeding
+
+4. **Implement** — `/speckit.implement`
+   - Executes all tasks phase by phase following TDD approach
+   - Wait for full completion (all tasks marked done, tests passing)
+   - If implementation fails on a critical task, **stop the pipeline** and report status
+
+5. **Review** — `/speckit.review`
+   - Runs the comprehensive code review across all changed files
+   - Reports findings with the standard summary format
+
+### Execution Rules
+
+- **Sequential only**: Each step depends on the output of the previous one
+- **No skipping**: All 5 steps must run in order
+- **User interaction**: If any step requires user input (clarifications, checklist confirmation), pause and wait for the response before continuing
+- **Error handling**: On failure, report which step failed, what went wrong, and stop — do not attempt to continue with downstream steps
+- **Progress reporting**: After each step completes, print a brief status line:
+
+  ```
+  [1/5] Specify   — done
+  [2/5] Plan      — done
+  [3/5] Tasks     — done
+  [4/5] Implement — done
+  [5/5] Review    — done
+  ```
+
+### Completion
+
+After the review step finishes, provide the final summary:
+
+- Feature branch name
+- Spec, plan, tasks file paths
+- Review results (critical/important issues count)
+- Recommended next actions (fix issues, create PR, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # card-game Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-03-29
+Auto-generated from all feature plans. Last updated: 2026-04-03
 
 ## Active Technologies
 - N/A (stateless in-memory simulator) (003-composite-power)
@@ -24,6 +24,7 @@ npm test && npm run lint
 TypeScript on Node.js 24: Follow standard conventions
 
 ## Recent Changes
+- 004-event-bound-effect-termination: Added TypeScript on Node.js 24 + NestJS 11, class-validator, class-transformer
 - 003-composite-power: Added TypeScript on Node.js 24 + NestJS 11, class-validator, class-transformer
 
 - 002-event-bound-buff: Added TypeScript on Node.js 24 + NestJS 11, class-validator, class-transformer

--- a/docs/memory-bank/CODEBASE_STRUCTURE.md
+++ b/docs/memory-bank/CODEBASE_STRUCTURE.md
@@ -123,6 +123,7 @@ fight-simulator/
     ├── healing-report.ts   # Healing details
     ├── buff-report.ts      # Buff application
     ├── buff-removed-report.ts # Event-bound buff removal
+    ├── effect-removed-report.ts # Event-bound effect removal
     ├── debuff-report.ts    # Debuff application
     ├── state-effect-report.ts # Status effects
     ├── damage-report.ts    # Damage calculation

--- a/docs/memory-bank/backend/API_DOCS.md
+++ b/docs/memory-bank/backend/API_DOCS.md
@@ -155,7 +155,8 @@ Simulates a turn-based card battle between two players.
     debuffRate: number,
     duration: number,
     probability: number
-  }
+  },
+  terminationEvent?: string   // Event name that removes this effect when fired
 }
 ```
 
@@ -177,7 +178,7 @@ Simulates a turn-based card battle between two players.
 ```typescript
 {
   [stepNumber: number]: {
-    kind: "attack" | "special_attack" | "healing" | "status_change" | "state_effect" | "buff" | "debuff" | "buff_removed" | "targeting_override" | "targeting_reverted" | "winner" | "fight_end",
+    kind: "attack" | "special_attack" | "healing" | "status_change" | "state_effect" | "buff" | "debuff" | "buff_removed" | "effect_removed" | "targeting_override" | "targeting_reverted" | "winner" | "fight_end",
     // Additional properties vary by step kind
   }
 }
@@ -191,6 +192,16 @@ Simulates a turn-based card battle between two players.
   eventName: string,     // The end event name that triggered removal
   removed: { target: CardInfo, kind: BuffType, value: number }[],
   powerId?: string       // Present if the skill that emitted the end event belongs to a composite power
+}
+```
+
+**`effect_removed` step** (`EffectRemovedReport`): Emitted when an end event fires and removes event-bound status effects (poison, burn, freeze).
+```typescript
+{
+  kind: "effect_removed",
+  source: CardInfo,      // Card whose skill emitted the end event
+  eventName: string,     // The end event name that triggered removal
+  removed: { target: CardInfo, effectType: string }[]
 }
 ```
 
@@ -303,7 +314,7 @@ See @src/fight/core/fight-simulator/@types/ for complete type definitions:
 
 - `FightResult`: Map of step numbers to `Step` objects
 - `Step`: Union type with `kind` discriminator
-- `DamageReport`, `HealingReport`, `BuffReport`, `DebuffReport`, `StateEffectReport`, `StatusChangeReport`, `WinnerReport`, `BuffRemovedReport`, `TargetingOverrideReport`, `TargetingRevertedReport`: Specific step types
+- `DamageReport`, `HealingReport`, `BuffReport`, `DebuffReport`, `StateEffectReport`, `StatusChangeReport`, `WinnerReport`, `BuffRemovedReport`, `EffectRemovedReport`, `TargetingOverrideReport`, `TargetingRevertedReport`: Specific step types
 
 ## Dependencies
 

--- a/docs/memory-bank/backend/ARCHITECTURE.md
+++ b/docs/memory-bank/backend/ARCHITECTURE.md
@@ -194,10 +194,11 @@ sequenceDiagram
 - **Event-Driven**: Skills triggered by events (`turn-end`, `next-action`, `ally-death:<cardId>`), extensible trigger system. `AllyDeath` trigger matches string pattern `ally-death:<targetCardId>` enabling death-reactive abilities
 - **Unified Special Result**: `Special.launch()` returns `SpecialResult` containing both `actionResults` (AttackResult[] or HealingResult[]) and `buffResults` (BuffResults) for consistent handling across attack and healing specials
 - **Event-Bound Buff Termination**: `Buff` type has optional `terminationEvent?: string`. Skills have optional `activationLimit` and `endEvent`. When a skill reaches its activation limit (or its owner dies), it emits its `endEvent`. `EndEventProcessor` scans all playable cards and removes buffs matching that event name, emitting a `StepKind.BuffRemoved` step. `SkillResults` carries an optional `endEvent` field so callers know to trigger `EndEventProcessor`.
+- **Event-Bound Effect Termination**: `CardState` (poison, burn, freeze) has optional `terminationEvent?: string`. When `EndEventProcessor` fires an end event, it also scans all living cards for status effects matching that event and removes them, emitting a `StepKind.EffectRemoved` step. The `terminationEvent` flows from `EffectDto` → `AttackEffect` → `CardState`.
 - **Skill Lifecycle Interface**: `Skill` interface has two optional lifecycle methods: `tick?()` (advance internal state each turn) and `lifecycleEndEvent?()` (return end event name if skill is active and lifecycle-limited).
 - **Separation of Concerns**:
   - `Fight` orchestrates battle flow
   - `ActionStage` handles attack/heal resolution and extracts buff applications from special results
   - `TurnManager` handles turn-end effects
   - `CardSelector` determines turn order
-  - `EndEventProcessor` handles event-bound buff removal across all cards
+  - `EndEventProcessor` handles event-bound buff and effect removal across all cards

--- a/samples/cards.json
+++ b/samples/cards.json
@@ -91,15 +91,29 @@
           "name": "Griffes ardentes",
           "targetingStrategy": "position-based",
           "event": "next-action",
-          "rate": 0,
           "damages": [{ "type": "PHYSICAL", "rate": 0.4 }],
           "hits": 4,
           "interval": 3,
           "comboFinisher": [{ "type": "FIRE", "rate": 0.8 }]
         },
         {
+          "kind": "CONDITIONAL_ATTACK",
+          "name": "Explosion massive",
+          "targetingStrategy": "target-all",
+          "event": "ally-death",
+          "targetCardId": "kaelion",
+          "damages": [{ "type": "FIRE", "rate": 1.0 }],
+          "effect": {
+            "type": "BURN",
+            "rate": 0.3,
+            "level": 3,
+            "terminationEvent": "lion-heritage-end" // validate
+          },
+          "powerId": "lion-heritage"
+        },
+        {
           "kind": "BUFF",
-          "name": "Héritage du lion",
+          "name": "Buff Héroïque",
           "buffType": "attack",
           "rate": 0.4,
           "duration": 0,
@@ -108,7 +122,17 @@
           "targetCardId": "kaelion",
           "terminationEvent": "lion-heritage-end",
           "activationLimit": 1,
-          "endEvent": "lion-heritage-end"
+          "powerId": "lion-heritage"
+        },
+        {
+          "kind": "TARGETING_OVERRIDE",
+          "name": "Vengeance",
+          "targetingStrategy": "TODO", // validate
+          "event": "ally-death",
+          "targetCardId": "kaelion",
+
+          "terminationEvent": "lion-heritage-end",
+          "powerId": "lion-heritage"
         }
       ]
     },

--- a/specs/004-event-bound-effect-termination/checklists/requirements.md
+++ b/specs/004-event-bound-effect-termination/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Event-Bound Effect Termination
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for planning.
+- The spec references domain concepts (terminationEvent, EndEventProcessor) from the existing codebase in the Assumptions section, which is acceptable as these are domain language terms, not implementation details.

--- a/specs/004-event-bound-effect-termination/contracts/api-contract.md
+++ b/specs/004-event-bound-effect-termination/contracts/api-contract.md
@@ -1,0 +1,55 @@
+# API Contract: Event-Bound Effect Termination
+
+**Date**: 2026-04-03
+**Feature**: 004-event-bound-effect-termination
+
+## Modified Contract: POST /fight
+
+### EffectDto — updated
+
+```json
+{
+  "type": "BURN",
+  "rate": 0.3,
+  "level": 2,
+  "terminationEvent": "fire-shield-end",
+  "triggeredDebuff": {
+    "debuffType": "defense",
+    "debuffRate": 0.1,
+    "duration": 2,
+    "probability": 0.5
+  }
+}
+```
+
+**New field**: `terminationEvent` (optional string). When present, the effect will be removed from the affected card when the named event fires during the fight.
+
+### New response step: effect_removed
+
+```json
+{
+  "kind": "effect_removed",
+  "source": {
+    "name": "Healer",
+    "id": "healer-1"
+  },
+  "eventName": "fire-shield-end",
+  "removed": [
+    {
+      "target": {
+        "name": "Warrior",
+        "id": "warrior-1"
+      },
+      "effectType": "burn"
+    }
+  ]
+}
+```
+
+**When emitted**: During end event processing, after a skill emits its `endEvent`. Appears alongside existing `buff_removed` steps in the same processing pass.
+
+## Backwards Compatibility
+
+- `terminationEvent` is optional — omitting it preserves existing behavior (duration-based expiration only)
+- Existing payloads without `terminationEvent` continue to work identically
+- New `effect_removed` steps only appear when event-bound effects are configured and terminated

--- a/specs/004-event-bound-effect-termination/data-model.md
+++ b/specs/004-event-bound-effect-termination/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Event-Bound Effect Termination
+
+**Date**: 2026-04-03
+**Feature**: 004-event-bound-effect-termination
+
+## Modified Entities
+
+### CardState (interface)
+
+Existing interface gains one optional field:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| type | string | yes | Effect type identifier (poison, burn, freeze) |
+| level | EffectLevel | yes | Severity (1-3) |
+| remainingTurns | number | yes | Duration counter |
+| **terminationEvent** | **string** | **no** | **Event name that removes this effect when fired** |
+
+### AttackEffect (poison, burn, freeze)
+
+Each concrete attack effect gains one optional constructor parameter:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| rate | number | yes | Application chance |
+| level | EffectLevel | yes | Effect intensity |
+| triggeredDebuff | EffectTriggeredDebuff | no | Optional debuff on hit |
+| **terminationEvent** | **string** | **no** | **Passed through to CardState on application** |
+
+### FightingCard
+
+New method:
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| removeEventBoundEffects | eventName: string | `{ type: string, card: CardInfo }[]` | Removes effects matching the event, returns removed info |
+
+## New Entities
+
+### EffectRemovedReport
+
+New fight log step type:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| kind | 'effect_removed' | yes | Step discriminator |
+| source | CardInfo | yes | Card whose skill emitted the end event |
+| eventName | string | yes | Event name that triggered removal |
+| removed | `{ target: CardInfo, effectType: string }[]` | yes | List of removed effects per card |
+
+## DTO Changes
+
+### EffectDto
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| type | Effect enum | yes | POISON, BURN, FREEZE |
+| rate | number | yes | Application chance |
+| level | number | yes | Effect intensity |
+| triggeredDebuff | EffectTriggeredDebuffDto | no | Optional debuff |
+| **terminationEvent** | **string** | **no** | **Event name for effect termination** |

--- a/specs/004-event-bound-effect-termination/plan.md
+++ b/specs/004-event-bound-effect-termination/plan.md
@@ -1,0 +1,124 @@
+# Implementation Plan: Event-Bound Effect Termination
+
+**Branch**: `004-event-bound-effect-termination` | **Date**: 2026-04-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/004-event-bound-effect-termination/spec.md`
+
+## Summary
+
+Add an optional `terminationEvent` field to status effects (poison, burn, freeze) so they can be removed when a named event fires during battle. Extend the existing `EndEventProcessor` — which already removes event-bound buffs — to also scan and remove matching status effects from all living cards. Introduce a new `effect_removed` step kind in the fight log. The API gains an optional `terminationEvent` string on `EffectDto`.
+
+## Technical Context
+
+**Language/Version**: TypeScript on Node.js 24
+**Primary Dependencies**: NestJS 11, class-validator, class-transformer
+**Storage**: N/A (stateless in-memory simulator)
+**Testing**: Jest 29, ts-jest, supertest, @faker-js/faker
+**Target Platform**: Linux server (Docker, Heroku)
+**Project Type**: Web service (REST API, single POST /fight endpoint)
+**Performance Goals**: N/A (stateless request-response simulator)
+**Constraints**: Zero regression on existing fights; backwards compatibility for effects without terminationEvent
+**Scale/Scope**: Single endpoint, ~8 domain files affected
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Domain Isolation | PASS | terminationEvent flows through domain CardState; DTO mapping stays in HTTP layer |
+| II. Test-First Development | PASS | Plan follows Red-Green-Refactor for each capability |
+| III. Simplicity — No Over-Engineering | PASS | Reuses existing EndEventProcessor; adds one optional field to CardState; no new abstractions |
+| IV. Fail Fast — No Silent Errors | PASS | No silent fallbacks — effects without terminationEvent behave as today; dead cards skipped explicitly |
+| V. Clean Code — Eliminate Duplication | PASS | Extends EndEventProcessor rather than creating a parallel mechanism; same event-driven pattern as buffs |
+
+**Quality Gates**: `npm run format` → `npm run lint` → `npm run test:cov` → `npm run build` (all must pass before merge)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-event-bound-effect-termination/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── api-contract.md  # Updated POST /fight contract
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+src/fight/
+├── core/
+│   ├── cards/
+│   │   ├── fighting-card.ts              # Add removeEventBoundEffects() method
+│   │   └── @types/
+│   │       └── state/
+│   │           ├── card-state.ts          # Add optional terminationEvent field
+│   │           ├── card-state-poisoned.ts # Accept terminationEvent in constructor
+│   │           ├── card-state-burned.ts   # Accept terminationEvent in constructor
+│   │           └── card-state-frozen.ts   # Accept terminationEvent in constructor
+│   │       └── attack/
+│   │           ├── attack-poisoned-effect.ts  # Pass terminationEvent to CardState
+│   │           ├── attack-burned-effect.ts    # Pass terminationEvent to CardState
+│   │           └── attack-frozen-effect.ts    # Pass terminationEvent to CardState
+│   ├── fight-simulator/
+│   │   ├── end-event-processor.ts       # Extend to also remove event-bound effects
+│   │   └── @types/
+│   │       ├── step.ts                  # Add EffectRemoved step kind
+│   │       └── effect-removed-report.ts # NEW: report type for effect removal
+├── http-api/
+│   ├── dto/
+│   │   └── fight-data.dto.ts            # Add optional terminationEvent to EffectDto
+│   └── fight.controller.ts             # Pass terminationEvent from DTO to AttackEffect constructors
+
+test/
+├── helpers/
+│   └── effect.ts                        # Support terminationEvent in factory
+└── fight/
+    └── (e2e tests for event-bound effect termination)
+```
+
+**Structure Decision**: Follows existing hexagonal architecture. Extends existing types and EndEventProcessor. Single new file for the `EffectRemovedReport` type.
+
+## Key Design Decisions
+
+### 1. Extend CardState interface with optional terminationEvent
+
+**Current**: `CardState` has `type`, `level`, `remainingTurns`, and `applyState()`. No event-based termination.
+**Design**: Add optional `terminationEvent?: string` to the `CardState` interface. Each concrete implementation (poisoned, burned, frozen) accepts it in its constructor and stores it.
+
+**Rationale**: Mirrors the pattern already used by `Buff` type, keeping the mental model consistent.
+
+### 2. Add removeEventBoundEffects() to FightingCard
+
+**Current**: `FightingCard` has `removeEventBoundBuffs(eventName)` for buffs.
+**Design**: Add `removeEventBoundEffects(eventName)` that checks each active status effect (poisoned, burned, frozen) and removes those whose `terminationEvent` matches. Returns an array of removed effect info (type, card identity).
+
+**Rationale**: Parallels `removeEventBoundBuffs()` — same pattern, different target.
+
+### 3. Extend EndEventProcessor to handle effects
+
+**Current**: `EndEventProcessor.processEndEvent()` iterates all living cards and calls `removeEventBoundBuffs()`.
+**Design**: In the same pass, also call `removeEventBoundEffects()` on each card. Collect results and emit `StepKind.EffectRemoved` steps alongside existing `StepKind.BuffRemoved` steps.
+
+**Rationale**: Single processing point for all event-bound cleanup. No new class needed — just extend the existing processor.
+
+### 4. EffectRemovedReport step
+
+**Design**: New step kind `effect_removed` with fields: `source` (CardInfo of event emitter), `eventName`, `removed` array of `{ target: CardInfo, effectType: string }`.
+
+**Rationale**: Mirrors `BuffRemovedReport` structure for consistency.
+
+### 5. terminationEvent propagation from DTO to domain
+
+**Current**: `EffectDto` has `type`, `rate`, `level`, `triggeredDebuff?`. Controller creates `AttackEffect` instances.
+**Design**: Add `terminationEvent?: string` to `EffectDto`. Controller passes it through to `AttackPoisonedEffect`, `AttackBurnedEffect`, `AttackFrozenEffect` constructors. Each `applyEffect()` method passes it to the `CardState` constructor.
+
+## Complexity Tracking
+
+> No constitution violations. No complexity justification needed.

--- a/specs/004-event-bound-effect-termination/quickstart.md
+++ b/specs/004-event-bound-effect-termination/quickstart.md
@@ -1,0 +1,54 @@
+# Quickstart: Event-Bound Effect Termination
+
+**Date**: 2026-04-03
+**Feature**: 004-event-bound-effect-termination
+
+## What This Feature Does
+
+Allows status effects (poison, burn, freeze) to be automatically removed when a named event fires during a fight. This uses the same event system that already removes buffs.
+
+## Example: Burn removed when a skill ends
+
+A card inflicts a burn effect with `terminationEvent: "fire-aura-end"`. Another card has a skill with `endEvent: "fire-aura-end"` and `activationLimit: 3`. After 3 activations, the skill emits `"fire-aura-end"`, which removes both the event-bound buffs **and** the event-bound burn from all cards.
+
+### Request snippet
+
+```json
+{
+  "skills": {
+    "simpleAttack": {
+      "name": "Fire Strike",
+      "damages": [{ "type": "FIRE", "rate": 1.0 }],
+      "targetingStrategy": "position-based",
+      "effect": {
+        "type": "BURN",
+        "rate": 0.8,
+        "level": 2,
+        "terminationEvent": "fire-aura-end"
+      }
+    }
+  }
+}
+```
+
+### Expected fight log step on termination
+
+```json
+{
+  "kind": "effect_removed",
+  "source": { "name": "Fire Mage", "id": "fire-mage-1" },
+  "eventName": "fire-aura-end",
+  "removed": [
+    { "target": { "name": "Warrior", "id": "warrior-1" }, "effectType": "burn" }
+  ]
+}
+```
+
+## Development
+
+```bash
+npm run test        # Run all tests
+npm run test:cov    # Run with coverage
+npm run test:e2e    # End-to-end tests
+npm run build       # Build
+```

--- a/specs/004-event-bound-effect-termination/research.md
+++ b/specs/004-event-bound-effect-termination/research.md
@@ -1,0 +1,45 @@
+# Research: Event-Bound Effect Termination
+
+**Date**: 2026-04-03
+**Feature**: 004-event-bound-effect-termination
+
+## Research Tasks
+
+### 1. How does the existing EndEventProcessor work?
+
+**Finding**: `EndEventProcessor.processEndEvent(eventName, source, players, powerId?)` iterates all living cards across both players, calls `card.removeEventBoundBuffs(eventName)` on each, collects removed buffs, also calls `card.restoreAttackTargeting(eventName)` for targeting override cleanup, and returns an array of Steps (`BuffRemoved`, `TargetingReverted`).
+
+**Decision**: Extend this same method to also call a new `card.removeEventBoundEffects(eventName)` in the same loop, and append `EffectRemoved` steps to the result.
+
+**Rationale**: Single processing point; no new orchestration needed; consistent with existing pattern.
+
+### 2. How are CardState constructors called?
+
+**Finding**: Each `AttackEffect.applyEffect()` creates a `CardState` instance:
+- `new CardStatePoisoned(level, duration, damageValue)` 
+- `new CardStateBurned(level, duration, damageValue)`
+- `new CardStateFrozen(level, duration, damageRate)`
+
+The `AttackEffect` instances themselves are created in the controller from EffectDto, using `new AttackPoisonedEffect(rate, level, triggeredDebuff?)`.
+
+**Decision**: Add optional `terminationEvent` parameter to both `AttackEffect` constructors and `CardState` constructors. The chain: DTO → AttackEffect → CardState.
+
+**Alternatives considered**: Storing terminationEvent only on AttackEffect and checking at removal time — rejected because the CardState is the persisted state on the card; AttackEffect is transient (used only during attack resolution).
+
+### 3. How does FightingCard store and clear status effects?
+
+**Finding**: `FightingCard` has three private fields: `poisoned?: CardState`, `burned?: CardState`, `frozen?: CardState`. The `setState(state)` method sets the appropriate field based on `state.type`. Effects are cleared by setting the field to `undefined` when `remainingTurns` reaches 0 in `applyStateEffects()`.
+
+**Decision**: `removeEventBoundEffects(eventName)` will check each of the three fields. If the field is defined and its `terminationEvent === eventName`, set it to `undefined` and add it to the removed list. Return the list.
+
+**Rationale**: Direct and simple — three field checks, no iteration needed.
+
+### 4. What step kinds exist and how are they structured?
+
+**Finding**: `StepKind` enum in `step.ts` has: `Attack`, `SpecialAttack`, `Healing`, `StatusChange`, `StateEffect`, `Buff`, `Debuff`, `BuffRemoved`, `TargetingOverride`, `TargetingReverted`, `Winner`, `FightEnd`.
+
+**Decision**: Add `EffectRemoved = 'effect_removed'` to the enum. Create `EffectRemovedReport` interface mirroring `BuffRemovedReport` structure.
+
+## Summary
+
+No NEEDS CLARIFICATION items. All technical questions resolved. The implementation follows existing patterns closely — extending EndEventProcessor and CardState rather than introducing new mechanisms.

--- a/specs/004-event-bound-effect-termination/spec.md
+++ b/specs/004-event-bound-effect-termination/spec.md
@@ -1,0 +1,94 @@
+# Feature Specification: Event-Bound Effect Termination
+
+**Feature Branch**: `004-event-bound-effect-termination`  
+**Created**: 2026-04-03  
+**Status**: Draft  
+**Input**: User description: "Ajoute une condition d'arret aux effets. Par exemple je veux pouvoir être en mesure de stopper un effet de brulure lorsqu'un événement particulier est émis."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Remove a status effect when a named event fires (Priority: P1)
+
+As a game designer configuring a battle, I want to attach a termination event name to a status effect (poison, burn, or freeze) so that when that event is emitted during the fight, the effect is automatically removed from the affected card. This enables rich combat interactions such as a healer skill that "cleanses" burn from allies when it activates, or a burn that only persists while a specific buff skill is active.
+
+**Why this priority**: This is the core mechanic — without event-bound termination on effects, the entire feature has no value.
+
+**Independent Test**: Can be fully tested by configuring a card with a burn effect that has a termination event, triggering that event via a skill lifecycle, and verifying the burn is removed from the card.
+
+**Acceptance Scenarios**:
+
+1. **Given** a card has a burn effect with `terminationEvent: "fire-shield-end"`, **When** the event `"fire-shield-end"` is fired, **Then** the burn effect is removed from the card and a step is emitted in the fight log recording the removal.
+2. **Given** a card has a poison effect with `terminationEvent: "cleanse"`, **When** the event `"cleanse"` is fired, **Then** the poison effect is removed and the card no longer takes poison damage on subsequent turns.
+3. **Given** a card has a freeze effect with no termination event, **When** any event is fired, **Then** the freeze effect continues to apply normally (backwards compatibility).
+
+---
+
+### User Story 2 - Attach termination event to effects via the API (Priority: P1)
+
+As a developer integrating with the battle API, I want to specify an optional `terminationEvent` field on an effect definition in the fight request payload so that the simulator knows which event should remove that effect.
+
+**Why this priority**: Without API support, the feature cannot be used by consumers. Equal priority to the core mechanic.
+
+**Independent Test**: Can be tested by sending a POST /fight request with a status effect that includes a `terminationEvent` field and verifying the request is accepted and the effect behaves accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fight request with an effect containing `terminationEvent: "heal-wave"`, **When** the request is validated, **Then** it is accepted without error.
+2. **Given** a fight request with an effect that omits `terminationEvent`, **When** the request is validated, **Then** it is accepted (field is optional, backwards compatible).
+
+---
+
+### User Story 3 - Fight log reports effect removal (Priority: P2)
+
+As a game client developer, I want the fight result to include a dedicated step when a status effect is removed by an event so that I can display the removal animation and inform the player.
+
+**Why this priority**: Observability of the removal in the fight log is important for client rendering but secondary to the core mechanic working correctly.
+
+**Independent Test**: Can be tested by running a fight where an event-bound effect is terminated, then inspecting the fight result for a step of the appropriate kind with correct metadata (card identity, effect type, event name).
+
+**Acceptance Scenarios**:
+
+1. **Given** a card's burn effect is removed by event `"fire-shield-end"`, **When** the fight result is inspected, **Then** a step with kind `"effect_removed"` is present, containing the card identity, effect type (`"burn"`), and the event name.
+2. **Given** multiple cards have effects bound to the same event, **When** that event fires, **Then** one `"effect_removed"` step is emitted per card whose effect was removed.
+
+---
+
+### Edge Cases
+
+- What happens when a card has an event-bound effect but the termination event never fires during the fight? The effect expires naturally via its `remainingTurns` duration as it does today.
+- What happens when the termination event fires but the card's effect has already expired naturally? No removal step is emitted for that card (nothing to remove).
+- What happens when the termination event fires but the card is already dead? Dead cards are not processed — no removal step emitted.
+- What happens when a card has multiple different effects (e.g., burn + poison) and both are bound to the same termination event? Both effects are removed and a removal step is emitted for each.
+- What happens when the same effect type is re-applied after event-bound removal? The new effect applies normally with its own configuration (may or may not have a termination event).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support an optional `terminationEvent` field on status effects (poison, burn, freeze) that names the event which will remove the effect.
+- **FR-002**: When an event matching a status effect's `terminationEvent` is fired, the system MUST remove that effect from all affected living cards.
+- **FR-003**: Removal of an event-bound effect MUST produce a dedicated step in the fight log with the card identity, effect type, and the event name that triggered removal.
+- **FR-004**: Status effects without a `terminationEvent` MUST continue to behave exactly as they do today (duration-based expiration only).
+- **FR-005**: The API MUST accept an optional `terminationEvent` string field on effect definitions in the fight request payload.
+- **FR-006**: The event-bound effect removal MUST be processed by the same mechanism that handles event-bound buff removal, extended to also scan for matching effects.
+- **FR-007**: If a card is dead or the effect has already expired when the termination event fires, the system MUST NOT emit a removal step for that card/effect.
+
+### Key Entities
+
+- **Status Effect (CardState)**: Gains an optional `terminationEvent` string field alongside its existing `type`, `level`, and `remainingTurns`.
+- **Effect Removal Step**: New fight log step kind (`effect_removed`) containing card identity, effect type, and event name.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of event-bound effects are correctly removed when their termination event fires during battle simulation.
+- **SC-002**: Zero breaking changes — all existing fight configurations without `terminationEvent` produce identical results.
+- **SC-003**: Fight logs contain one `effect_removed` step per card per effect removed by an event, with complete metadata.
+- **SC-004**: The API accepts and validates the new optional `terminationEvent` field on effects without rejecting existing payloads.
+
+## Assumptions
+
+- The termination event name follows the same string convention as existing buff `terminationEvent` values (free-form string, matched exactly).
+- The `EndEventProcessor` (which already handles buff removal) is the natural place to extend for effect removal, ensuring a single pass when an event fires.
+- Effect removal by event happens at the same processing point as buff removal by event — when a skill emits its `endEvent`.

--- a/specs/004-event-bound-effect-termination/tasks.md
+++ b/specs/004-event-bound-effect-termination/tasks.md
@@ -1,0 +1,185 @@
+# Tasks: Event-Bound Effect Termination
+
+**Input**: Design documents from `/specs/004-event-bound-effect-termination/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Included — constitution mandates test-first development (Red-Green-Refactor).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new project setup needed — existing project. Skip.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add `terminationEvent` to the CardState interface and concrete implementations — all user stories depend on this.
+
+- [x] T001 Add optional `terminationEvent` field to the `CardState` interface in `src/fight/core/cards/@types/state/card-state.ts`
+- [x] T002 [P] Add optional `terminationEvent` parameter to `CardStatePoisoned` constructor and store it in `src/fight/core/cards/@types/state/card-state-poisoned.ts`
+- [x] T003 [P] Add optional `terminationEvent` parameter to `CardStateBurned` constructor and store it in `src/fight/core/cards/@types/state/card-state-burned.ts`
+- [x] T004 [P] Add optional `terminationEvent` parameter to `CardStateFrozen` constructor and store it in `src/fight/core/cards/@types/state/card-state-frozen.ts`
+- [x] T005 [P] Add optional `terminationEvent` parameter to `AttackPoisonedEffect` and pass it to `CardStatePoisoned` in `src/fight/core/cards/@types/attack/attack-poisoned-effect.ts`
+- [x] T006 [P] Add optional `terminationEvent` parameter to `AttackBurnedEffect` and pass it to `CardStateBurned` in `src/fight/core/cards/@types/attack/attack-burned-effect.ts`
+- [x] T007 [P] Add optional `terminationEvent` parameter to `AttackFrozenEffect` and pass it to `CardStateFrozen` in `src/fight/core/cards/@types/attack/attack-frozen-effect.ts`
+- [x] T008 Update `createEffect()` test helper to support optional `terminationEvent` in `test/helpers/effect.ts`
+
+**Checkpoint**: CardState types now carry terminationEvent. All existing tests must still pass (no behavior change).
+
+---
+
+## Phase 3: User Story 1 — Remove a status effect when a named event fires (Priority: P1) MVP
+
+**Goal**: When an end event fires during fight processing, event-bound status effects are removed from all living cards.
+
+**Independent Test**: Configure a card with a burn effect bound to an event, trigger that event via a skill lifecycle, verify the burn is removed.
+
+### Tests for User Story 1
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T009 [P] [US1] Write unit test: `removeEventBoundEffects` removes a poisoned effect matching the event name in `src/fight/core/cards/__tests__/fighting-card-remove-effects.spec.ts`
+- [x] T010 [P] [US1] Write unit test: `removeEventBoundEffects` removes a burned effect matching the event name in `src/fight/core/cards/__tests__/fighting-card-remove-effects.spec.ts`
+- [x] T011 [P] [US1] Write unit test: `removeEventBoundEffects` removes a frozen effect matching the event name in `src/fight/core/cards/__tests__/fighting-card-remove-effects.spec.ts`
+- [x] T012 [P] [US1] Write unit test: `removeEventBoundEffects` ignores effects without terminationEvent in `src/fight/core/cards/__tests__/fighting-card-remove-effects.spec.ts`
+- [x] T013 [P] [US1] Write unit test: `removeEventBoundEffects` removes multiple effects bound to the same event in `src/fight/core/cards/__tests__/fighting-card-remove-effects.spec.ts`
+- [x] T014 [US1] Write unit test: `EndEventProcessor.processEndEvent` emits `EffectRemoved` steps alongside `BuffRemoved` steps in `src/fight/core/fight-simulator/__tests__/end-event-processor-effects.spec.ts`
+
+### Implementation for User Story 1
+
+- [x] T015 [US1] Create `EffectRemovedReport` type and add `EffectRemoved` to `StepKind` enum in `src/fight/core/fight-simulator/@types/effect-removed-report.ts` and `src/fight/core/fight-simulator/@types/step.ts`
+- [x] T016 [US1] Implement `removeEventBoundEffects(eventName)` method on `FightingCard` in `src/fight/core/cards/fighting-card.ts`
+- [x] T017 [US1] Extend `EndEventProcessor.processEndEvent()` to call `removeEventBoundEffects()` on each living card and emit `EffectRemoved` steps in `src/fight/core/fight-simulator/end-event-processor.ts`
+
+**Checkpoint**: Core mechanic works — event-bound effects are removed when end events fire. All US1 tests pass.
+
+---
+
+## Phase 4: User Story 2 — Attach termination event to effects via the API (Priority: P1)
+
+**Goal**: The API accepts an optional `terminationEvent` field on `EffectDto` and passes it through to domain objects.
+
+**Independent Test**: Send a POST /fight with an effect containing `terminationEvent`, verify request accepted and effect is stored with the event name.
+
+### Tests for User Story 2
+
+- [x] T018 [US2] Write controller test: EffectDto with `terminationEvent` is correctly mapped to domain AttackEffect in `src/fight/http-api/__test__/fight.controller.spec.ts`
+
+### Implementation for User Story 2
+
+- [x] T019 [US2] Add optional `terminationEvent` string field with `@IsOptional()` and `@IsString()` to `EffectDto` in `src/fight/http-api/dto/fight-data.dto.ts`
+- [x] T020 [US2] Pass `terminationEvent` from EffectDto through to AttackEffect constructors in `src/fight/http-api/fight.controller.ts`
+
+**Checkpoint**: API accepts terminationEvent on effects and propagates it to the domain layer. US2 tests pass.
+
+---
+
+## Phase 5: User Story 3 — Fight log reports effect removal (Priority: P2)
+
+**Goal**: The fight result contains `effect_removed` steps with complete metadata when event-bound effects are terminated.
+
+**Independent Test**: Run a full fight simulation where an event-bound effect is terminated, inspect the fight result for `effect_removed` steps.
+
+### Tests for User Story 3
+
+- [x] T021 [US3] Write e2e test: fight simulation with event-bound burn effect produces `effect_removed` step in fight result in `test/fight/event-bound-effect-termination.e2e-spec.ts`
+
+### Implementation for User Story 3
+
+- [x] T022 [US3] Verify `EffectRemovedReport` is included in fight result serialization — no additional implementation expected (step is already pushed by EndEventProcessor from T017)
+
+**Checkpoint**: Full end-to-end flow works. Fight log contains correct `effect_removed` steps.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [x] T023 Update API documentation in `docs/memory-bank/backend/API_DOCS.md` with new `terminationEvent` field on EffectDto and `effect_removed` step kind
+- [x] T024 Update architecture documentation in `docs/memory-bank/backend/ARCHITECTURE.md` and `docs/memory-bank/CODEBASE_STRUCTURE.md` to reflect event-bound effect termination
+- [x] T025 Run quality gates: `npm run format` → `npm run lint` → `npm run test:cov` → `npm run build`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 2)**: No dependencies — can start immediately
+- **User Story 1 (Phase 3)**: Depends on Phase 2 completion
+- **User Story 2 (Phase 4)**: Depends on Phase 2 completion (parallel with US1)
+- **User Story 3 (Phase 5)**: Depends on US1 (Phase 3) AND US2 (Phase 4) — needs both domain and API layers
+- **Polish (Phase 6)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational — no dependencies on other stories
+- **User Story 2 (P1)**: Can start after Foundational — no dependencies on other stories
+- **User Story 3 (P2)**: Depends on US1 + US2 (needs full pipeline for e2e test)
+
+### Within Each User Story
+
+- Tests written and confirmed FAILING before implementation
+- Type definitions before method implementations
+- Domain layer before API layer
+
+### Parallel Opportunities
+
+- T002, T003, T004 can run in parallel (three CardState implementations)
+- T005, T006, T007 can run in parallel (three AttackEffect implementations)
+- T009–T013 can run in parallel (unit tests for removeEventBoundEffects)
+- US1 and US2 can proceed in parallel after Phase 2
+
+---
+
+## Parallel Example: Phase 2
+
+```bash
+# After T001 (interface change), launch all CardState updates together:
+Task: T002 "Add terminationEvent to CardStatePoisoned"
+Task: T003 "Add terminationEvent to CardStateBurned"
+Task: T004 "Add terminationEvent to CardStateFrozen"
+
+# Then launch all AttackEffect updates together:
+Task: T005 "Add terminationEvent to AttackPoisonedEffect"
+Task: T006 "Add terminationEvent to AttackBurnedEffect"
+Task: T007 "Add terminationEvent to AttackFrozenEffect"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Foundational (terminationEvent on types)
+2. Complete Phase 3: User Story 1 (core removal mechanic)
+3. **STOP and VALIDATE**: Run unit tests, verify effects are removed
+4. Core value delivered
+
+### Incremental Delivery
+
+1. Phase 2 → Foundation ready
+2. Add US1 → Test independently → Core mechanic works (MVP!)
+3. Add US2 → Test independently → API supports the feature
+4. Add US3 → Test independently → Fight log is complete
+5. Phase 6 → Documentation and quality gates
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Constitution mandates TDD: tests MUST fail before implementation
+- Commit after each task or logical group
+- All existing tests must remain green throughout

--- a/src/fight/core/cards/@types/attack/attack-burned-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-burned-effect.ts
@@ -10,15 +10,18 @@ export class BurnedAttackEffect implements AttackEffect {
   public readonly level: EffectLevel;
   public readonly type = 'burned';
   public readonly triggeredDebuff?: EffectTriggeredDebuff;
+  public readonly terminationEvent?: string;
 
   constructor(
     rate: number,
     level: EffectLevel,
     triggeredDebuff?: EffectTriggeredDebuff,
+    terminationEvent?: string,
   ) {
     this.rate = rate;
     this.level = level;
     this.triggeredDebuff = triggeredDebuff;
+    this.terminationEvent = terminationEvent;
   }
 
   public applyEffect(
@@ -44,6 +47,7 @@ export class BurnedAttackEffect implements AttackEffect {
       effectLevel,
       this.computeBurnedTurns(effectLevel),
       card.actualAttack * this.rate,
+      this.terminationEvent,
     );
     defender.setState(burnedState);
 

--- a/src/fight/core/cards/@types/attack/attack-frozen-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-frozen-effect.ts
@@ -10,15 +10,18 @@ export class FrozenAttackEffect implements AttackEffect {
   public readonly level: EffectLevel;
   public readonly type = 'frozen';
   public readonly triggeredDebuff?: EffectTriggeredDebuff;
+  public readonly terminationEvent?: string;
 
   constructor(
     rate: number,
     level: EffectLevel,
     triggeredDebuff?: EffectTriggeredDebuff,
+    terminationEvent?: string,
   ) {
     this.rate = rate;
     this.level = level;
     this.triggeredDebuff = triggeredDebuff;
+    this.terminationEvent = terminationEvent;
   }
 
   public applyEffect(
@@ -44,6 +47,7 @@ export class FrozenAttackEffect implements AttackEffect {
       effectLevel,
       this.computeFrozenTurns(effectLevel),
       this.rate,
+      this.terminationEvent,
     );
     defender.setState(frozenState);
 

--- a/src/fight/core/cards/@types/attack/attack-poisoned-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-poisoned-effect.ts
@@ -10,15 +10,18 @@ export class PoisonedAttackEffect implements AttackEffect {
   public readonly level: EffectLevel;
   public readonly type = 'poisoned';
   public readonly triggeredDebuff?: EffectTriggeredDebuff;
+  public readonly terminationEvent?: string;
 
   constructor(
     rate: number,
     level: EffectLevel,
     triggeredDebuff?: EffectTriggeredDebuff,
+    terminationEvent?: string,
   ) {
     this.rate = rate;
     this.level = level;
     this.triggeredDebuff = triggeredDebuff;
+    this.terminationEvent = terminationEvent;
   }
 
   public applyEffect(
@@ -33,6 +36,7 @@ export class PoisonedAttackEffect implements AttackEffect {
       this.level,
       this.computePoisonedTurns(),
       card.actualAttack * this.rate,
+      this.terminationEvent,
     );
     defender.setState(poisonedState);
 

--- a/src/fight/core/cards/@types/state/card-state-burned.ts
+++ b/src/fight/core/cards/@types/state/card-state-burned.ts
@@ -8,11 +8,18 @@ export class CardStateBurned implements CardState {
   public readonly level: EffectLevel;
   public remainingTurns: number;
   public damageValue: number;
+  public readonly terminationEvent?: string;
 
-  constructor(level: EffectLevel, remainingTurns: number, damageValue: number) {
+  constructor(
+    level: EffectLevel,
+    remainingTurns: number,
+    damageValue: number,
+    terminationEvent?: string,
+  ) {
     this.level = level;
     this.remainingTurns = remainingTurns;
     this.damageValue = damageValue;
+    this.terminationEvent = terminationEvent;
   }
 
   public applyState(card: FightingCard): StateResult {

--- a/src/fight/core/cards/@types/state/card-state-frozen.ts
+++ b/src/fight/core/cards/@types/state/card-state-frozen.ts
@@ -8,11 +8,18 @@ export class CardStateFrozen implements CardState {
   public readonly level: EffectLevel;
   public remainingTurns: number;
   private damageRate: number;
+  public readonly terminationEvent?: string;
 
-  constructor(level: EffectLevel, remainingTurns: number, damageRate: number) {
+  constructor(
+    level: EffectLevel,
+    remainingTurns: number,
+    damageRate: number,
+    terminationEvent?: string,
+  ) {
     this.level = level;
     this.remainingTurns = remainingTurns;
     this.damageRate = damageRate;
+    this.terminationEvent = terminationEvent;
   }
 
   public applyState(card: FightingCard): StateResult {

--- a/src/fight/core/cards/@types/state/card-state-poisoned.ts
+++ b/src/fight/core/cards/@types/state/card-state-poisoned.ts
@@ -8,11 +8,18 @@ export class CardStatePoisoned implements CardState {
   public readonly level: EffectLevel;
   public remainingTurns: number;
   public damageValue: number;
+  public readonly terminationEvent?: string;
 
-  constructor(level: EffectLevel, remainingTurns: number, damageValue: number) {
+  constructor(
+    level: EffectLevel,
+    remainingTurns: number,
+    damageValue: number,
+    terminationEvent?: string,
+  ) {
     this.level = level;
     this.remainingTurns = remainingTurns;
     this.damageValue = damageValue;
+    this.terminationEvent = terminationEvent;
   }
 
   public applyState(card: FightingCard): StateResult {

--- a/src/fight/core/cards/@types/state/card-state.ts
+++ b/src/fight/core/cards/@types/state/card-state.ts
@@ -6,6 +6,7 @@ export interface CardState {
   type: string;
   level: EffectLevel;
   remainingTurns: number;
+  terminationEvent?: string;
 
   applyState(card: FightingCard): StateResult;
 }

--- a/src/fight/core/cards/__tests__/fighting-card-remove-effects.spec.ts
+++ b/src/fight/core/cards/__tests__/fighting-card-remove-effects.spec.ts
@@ -1,0 +1,109 @@
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+import { CardStatePoisoned } from '../@types/state/card-state-poisoned';
+import { CardStateBurned } from '../@types/state/card-state-burned';
+import { CardStateFrozen } from '../@types/state/card-state-frozen';
+
+describe('FightingCard.removeEventBoundEffects()', () => {
+  describe('when card has a poisoned effect with matching terminationEvent', () => {
+    it('removes the poison effect', () => {
+      const card = createFightingCard({});
+      card.setState(new CardStatePoisoned(1, 3, 50, 'cleanse'));
+
+      card.removeEventBoundEffects('cleanse');
+
+      expect(card.poisonLevel).toBe(0);
+    });
+
+    it('returns removed effect info', () => {
+      const card = createFightingCard({});
+      card.setState(new CardStatePoisoned(1, 3, 50, 'cleanse'));
+
+      const removed = card.removeEventBoundEffects('cleanse');
+
+      expect(removed).toEqual([{ type: 'poison', card: card.identityInfo }]);
+    });
+  });
+
+  describe('when card has a burned effect with matching terminationEvent', () => {
+    it('removes the burn effect', () => {
+      const card = createFightingCard({});
+      card.setState(new CardStateBurned(2, 3, 80, 'fire-end'));
+
+      card.removeEventBoundEffects('fire-end');
+
+      expect(card.burnLevel).toBe(0);
+    });
+
+    it('returns removed effect info', () => {
+      const card = createFightingCard({});
+      card.setState(new CardStateBurned(2, 3, 80, 'fire-end'));
+
+      const removed = card.removeEventBoundEffects('fire-end');
+
+      expect(removed).toEqual([{ type: 'burn', card: card.identityInfo }]);
+    });
+  });
+
+  describe('when card has a frozen effect with matching terminationEvent', () => {
+    it('removes the freeze effect', () => {
+      const card = createFightingCard({});
+      card.setState(new CardStateFrozen(1, 3, 0.5, 'thaw'));
+
+      card.removeEventBoundEffects('thaw');
+
+      expect(card.frozenLevel).toBe(0);
+    });
+
+    it('returns removed effect info', () => {
+      const card = createFightingCard({});
+      card.setState(new CardStateFrozen(1, 3, 0.5, 'thaw'));
+
+      const removed = card.removeEventBoundEffects('thaw');
+
+      expect(removed).toEqual([{ type: 'freeze', card: card.identityInfo }]);
+    });
+  });
+
+  describe('when card has effects without terminationEvent', () => {
+    it('does not remove effects', () => {
+      const card = createFightingCard({});
+      card.setState(new CardStatePoisoned(1, 3, 50));
+      card.setState(new CardStateBurned(1, 3, 80));
+
+      card.removeEventBoundEffects('cleanse');
+
+      expect(card.poisonLevel).toBe(1);
+    });
+
+    it('returns empty array', () => {
+      const card = createFightingCard({});
+      card.setState(new CardStatePoisoned(1, 3, 50));
+
+      const removed = card.removeEventBoundEffects('cleanse');
+
+      expect(removed).toHaveLength(0);
+    });
+  });
+
+  describe('when card has multiple effects bound to the same event', () => {
+    it('removes all matching effects', () => {
+      const card = createFightingCard({});
+      card.setState(new CardStatePoisoned(1, 3, 50, 'purge'));
+      card.setState(new CardStateBurned(2, 3, 80, 'purge'));
+
+      card.removeEventBoundEffects('purge');
+
+      expect(card.poisonLevel).toBe(0);
+    });
+
+    it('returns info for all removed effects', () => {
+      const card = createFightingCard({});
+      card.setState(new CardStatePoisoned(1, 3, 50, 'purge'));
+      card.setState(new CardStateBurned(2, 3, 80, 'purge'));
+
+      const removed = card.removeEventBoundEffects('purge');
+
+      expect(removed).toHaveLength(2);
+    });
+  });
+});

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -410,6 +410,29 @@ export class FightingCard {
     return buff;
   }
 
+  public removeEventBoundEffects(
+    eventName: string,
+  ): { type: string; card: CardInfo }[] {
+    const removed: { type: string; card: CardInfo }[] = [];
+
+    if (this.poisoned?.terminationEvent === eventName) {
+      removed.push({ type: this.poisoned.type, card: this.identityInfo });
+      this.poisoned = undefined;
+    }
+
+    if (this.burned?.terminationEvent === eventName) {
+      removed.push({ type: this.burned.type, card: this.identityInfo });
+      this.burned = undefined;
+    }
+
+    if (this.frozen?.terminationEvent === eventName) {
+      removed.push({ type: this.frozen.type, card: this.identityInfo });
+      this.frozen = undefined;
+    }
+
+    return removed;
+  }
+
   public removeEventBoundBuffs(
     eventName: string,
   ): { type: BuffType; value: number }[] {

--- a/src/fight/core/fight-simulator/@types/effect-removed-report.ts
+++ b/src/fight/core/fight-simulator/@types/effect-removed-report.ts
@@ -1,0 +1,9 @@
+import { CardInfo } from '../../cards/@types/card-info';
+import { StepKind } from './step';
+
+export type EffectRemovedReport = {
+  kind: StepKind.EffectRemoved;
+  source: CardInfo;
+  eventName: string;
+  removed: { target: CardInfo; effectType: string }[];
+};

--- a/src/fight/core/fight-simulator/@types/step.ts
+++ b/src/fight/core/fight-simulator/@types/step.ts
@@ -10,6 +10,7 @@ import {
   TargetingOverrideReport,
   TargetingRevertedReport,
 } from './targeting-override-report';
+import { EffectRemovedReport } from './effect-removed-report';
 
 export enum StepKind {
   FightEnd = 'fight_end',
@@ -24,6 +25,7 @@ export enum StepKind {
   BuffRemoved = 'buff_removed',
   TargetingOverride = 'targeting_override',
   TargetingReverted = 'targeting_reverted',
+  EffectRemoved = 'effect_removed',
 }
 
 export type Step = { kind: StepKind } & (
@@ -37,4 +39,5 @@ export type Step = { kind: StepKind } & (
   | BuffRemovedReport
   | TargetingOverrideReport
   | TargetingRevertedReport
+  | EffectRemovedReport
 );

--- a/src/fight/core/fight-simulator/__tests__/end-event-processor-effects.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/end-event-processor-effects.spec.ts
@@ -1,0 +1,86 @@
+import { EndEventProcessor } from '../end-event-processor';
+import { Player } from '../../player';
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+import { StepKind } from '../@types/step';
+import { CardStateBurned } from '../../cards/@types/state/card-state-burned';
+import { CardStatePoisoned } from '../../cards/@types/state/card-state-poisoned';
+
+describe('EndEventProcessor.processEndEvent() with effects', () => {
+  const source = { id: 'src', name: 'Source', deckIdentity: '' };
+
+  describe('when a card has an event-bound burn effect', () => {
+    let processor: EndEventProcessor;
+
+    beforeEach(() => {
+      const card = createFightingCard({});
+      card.setState(new CardStateBurned(2, 3, 80, 'fire-end'));
+      const player1 = new Player('P1', [card]);
+      const player2 = new Player('P2', [createFightingCard({})]);
+      processor = new EndEventProcessor(player1, player2);
+    });
+
+    it('produces an EffectRemoved step', () => {
+      const steps = processor.processEndEvent('fire-end', source);
+
+      expect(steps.some((s) => s.kind === StepKind.EffectRemoved)).toBe(true);
+    });
+
+    it('includes the eventName in the step', () => {
+      const steps = processor.processEndEvent('fire-end', source);
+      const effectStep = steps.find(
+        (s) => s.kind === StepKind.EffectRemoved,
+      ) as any;
+
+      expect(effectStep.eventName).toBe('fire-end');
+    });
+
+    it('includes removed effect info', () => {
+      const steps = processor.processEndEvent('fire-end', source);
+      const effectStep = steps.find(
+        (s) => s.kind === StepKind.EffectRemoved,
+      ) as any;
+
+      expect(effectStep.removed).toHaveLength(1);
+    });
+
+    it('includes the effect type in removed info', () => {
+      const steps = processor.processEndEvent('fire-end', source);
+      const effectStep = steps.find(
+        (s) => s.kind === StepKind.EffectRemoved,
+      ) as any;
+
+      expect(effectStep.removed[0].effectType).toBe('burn');
+    });
+  });
+
+  describe('when multiple cards have event-bound effects', () => {
+    it('aggregates all removed effects into one step', () => {
+      const card1 = createFightingCard({});
+      const card2 = createFightingCard({});
+      card1.setState(new CardStateBurned(1, 3, 50, 'purge'));
+      card2.setState(new CardStatePoisoned(1, 3, 30, 'purge'));
+      const player1 = new Player('P1', [card1]);
+      const player2 = new Player('P2', [card2]);
+      const processor = new EndEventProcessor(player1, player2);
+
+      const steps = processor.processEndEvent('purge', source);
+      const effectStep = steps.find(
+        (s) => s.kind === StepKind.EffectRemoved,
+      ) as any;
+
+      expect(effectStep.removed).toHaveLength(2);
+    });
+  });
+
+  describe('when no card has a matching event-bound effect', () => {
+    it('does not produce an EffectRemoved step', () => {
+      const player1 = new Player('P1', [createFightingCard({})]);
+      const player2 = new Player('P2', [createFightingCard({})]);
+      const processor = new EndEventProcessor(player1, player2);
+
+      const steps = processor.processEndEvent('fire-end', source);
+
+      expect(steps.every((s) => s.kind !== StepKind.EffectRemoved)).toBe(true);
+    });
+  });
+});

--- a/src/fight/core/fight-simulator/end-event-processor.ts
+++ b/src/fight/core/fight-simulator/end-event-processor.ts
@@ -38,6 +38,22 @@ export class EndEventProcessor {
       });
     }
 
+    const removedEffects = allCards.flatMap((card) => {
+      return card.removeEventBoundEffects(eventName).map((e) => ({
+        target: e.card,
+        effectType: e.type,
+      }));
+    });
+
+    if (removedEffects.length > 0) {
+      steps.push({
+        kind: StepKind.EffectRemoved,
+        source,
+        eventName,
+        removed: removedEffects,
+      });
+    }
+
     for (const card of allCards) {
       const removedOverrides = card.restoreAttackTargeting(eventName);
       for (const override of removedOverrides) {

--- a/src/fight/http-api/__test__/fight.controller.spec.ts
+++ b/src/fight/http-api/__test__/fight.controller.spec.ts
@@ -520,6 +520,72 @@ describe('FightController', () => {
         fightSimulatorStub.validatePlayer1FirstCard(validation);
       });
     });
+
+    describe('and the simple attack effect has a terminationEvent', () => {
+      beforeEach(() => {
+        const effect = {
+          type: Effect.BURN,
+          rate: 0.3,
+          level: 1,
+          terminationEvent: 'fire-shield-end',
+        };
+
+        fightData = {
+          cardSelectorStrategy: CardSelectorStrategy.PLAYER_BY_PLAYER,
+          player1: {
+            name: 'Player 1',
+            deck: [
+              {
+                id: 'axe-01',
+                name: 'Axe',
+                attack: 10,
+                defense: 6,
+                health: 100,
+                speed: 3,
+                agility: 25,
+                accuracy: 15,
+                criticalChance: 0.05,
+                skills: {
+                  special: {
+                    name: 'No Special Attack',
+                    kind: SpecialKind.ATTACK,
+                    rate: 0,
+                    energy: 0,
+                    targetingStrategy: TargetingStrategy.POSITION_BASED,
+                  },
+                  simpleAttack: {
+                    ...simpleAttack,
+                    effect,
+                  },
+                  others: [],
+                },
+                behaviors: {
+                  dodge: DodgeStrategy.SIMPLE_DODGE,
+                },
+              },
+            ],
+          },
+          player2: {
+            name: 'Player 2',
+            deck: [],
+          },
+        };
+
+        fightController.startFight(fightData);
+      });
+
+      it('maps terminationEvent to the attack effect', () => {
+        const validation = (card: FightingCard) => {
+          const jsonCard = JSON.parse(JSON.stringify(card));
+
+          expect(jsonCard.simpleAttack.effect.terminationEvent).toBe(
+            'fire-shield-end',
+          );
+        };
+
+        fightSimulatorStub.validatePlayer1FirstCard(validation);
+      });
+    });
   });
 
   describe('when a player use a card with a simple dodge strategy', () => {

--- a/src/fight/http-api/dto/fight-data.dto.ts
+++ b/src/fight/http-api/dto/fight-data.dto.ts
@@ -127,6 +127,11 @@ class EffectDto {
   @ValidateNested()
   @Type(/* istanbul ignore next */ () => EffectTriggeredDebuffDto)
   triggeredDebuff?: EffectTriggeredDebuffDto;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  terminationEvent?: string;
 }
 
 class BuffApplicationDto {

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -209,6 +209,7 @@ export class FightController {
       duration: number;
       probability: number;
     };
+    terminationEvent?: string;
   }): AttackEffect {
     const triggeredDebuff = effectDto.triggeredDebuff
       ? new EffectTriggeredDebuff(
@@ -226,18 +227,21 @@ export class FightController {
           effectDto.rate,
           effectDto.level as EffectLevel,
           triggeredDebuff,
+          effectDto.terminationEvent,
         );
       case Effect.BURN:
         return new BurnedAttackEffect(
           effectDto.rate,
           effectDto.level as EffectLevel,
           triggeredDebuff,
+          effectDto.terminationEvent,
         );
       case Effect.FREEZE:
         return new FrozenAttackEffect(
           effectDto.rate,
           effectDto.level as EffectLevel,
           triggeredDebuff,
+          effectDto.terminationEvent,
         );
     }
   }

--- a/test/fight/event-bound-effect-termination.e2e-spec.ts
+++ b/test/fight/event-bound-effect-termination.e2e-spec.ts
@@ -1,0 +1,137 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+
+describe('Event-bound effect termination', () => {
+  let app: INestApplication;
+  let steps: any[];
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useLogger(false);
+    await app.init();
+
+    const response = await request(app.getHttpServer())
+      .post('/fight')
+      .send(buildPayload())
+      .expect(200);
+
+    steps = Object.values(response.body) as any[];
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('produces an effect_removed step', () => {
+    const effectRemovedStep = steps.find((s) => s.kind === 'effect_removed');
+
+    expect(effectRemovedStep).toBeDefined();
+  });
+
+  it('effect_removed step contains the event name', () => {
+    const effectRemovedStep = steps.find((s) => s.kind === 'effect_removed');
+
+    expect(effectRemovedStep?.eventName).toBe('fire-aura-end');
+  });
+
+  it('effect_removed step contains the removed burn effect', () => {
+    const effectRemovedStep = steps.find((s) => s.kind === 'effect_removed');
+
+    expect(effectRemovedStep?.removed[0].effectType).toBe('burn');
+  });
+});
+
+function buildPayload() {
+  return {
+    cardSelectorStrategy: 'player-by-player',
+    player1: {
+      name: 'Fire Team',
+      deck: [
+        {
+          id: 'fire-mage',
+          name: 'Fire Mage',
+          attack: 500,
+          defense: 50,
+          health: 10000,
+          speed: 200,
+          agility: 0,
+          accuracy: 100,
+          criticalChance: 0,
+          skills: {
+            special: {
+              kind: 'ATTACK',
+              name: 'Fireball',
+              rate: 1.0,
+              energy: 999,
+              targetingStrategy: 'position-based',
+            },
+            simpleAttack: {
+              name: 'Fire Strike',
+              damages: [{ type: 'FIRE', rate: 1.0 }],
+              targetingStrategy: 'position-based',
+              effect: {
+                type: 'BURN',
+                rate: 1.0,
+                level: 1,
+                terminationEvent: 'fire-aura-end',
+              },
+            },
+            others: [
+              {
+                kind: 'BUFF',
+                name: 'Fire Aura',
+                rate: 0.1,
+                targetingStrategy: 'self',
+                event: 'turn-end',
+                buffType: 'attack',
+                duration: 0,
+                terminationEvent: 'fire-aura-end',
+                activationLimit: 1,
+                endEvent: 'fire-aura-end',
+              },
+            ],
+          },
+          behaviors: { dodge: 'simple-dodge' },
+        },
+      ],
+    },
+    player2: {
+      name: 'Target Team',
+      deck: [
+        {
+          id: 'target',
+          name: 'Target',
+          attack: 10,
+          defense: 0,
+          health: 10000,
+          speed: 50,
+          agility: 0,
+          accuracy: 100,
+          criticalChance: 0,
+          skills: {
+            special: {
+              kind: 'ATTACK',
+              name: 'Weak Hit',
+              rate: 0.01,
+              energy: 999,
+              targetingStrategy: 'position-based',
+            },
+            simpleAttack: {
+              name: 'Poke',
+              damages: [{ type: 'PHYSICAL', rate: 0.01 }],
+              targetingStrategy: 'position-based',
+            },
+            others: [],
+          },
+          behaviors: { dodge: 'simple-dodge' },
+        },
+      ],
+    },
+  };
+}

--- a/test/helpers/effect.ts
+++ b/test/helpers/effect.ts
@@ -10,6 +10,7 @@ export function createEffect(params: {
   rate: number;
   level: EffectLevel;
   type: string;
+  terminationEvent?: string;
 }): AttackEffect {
   const effectRate = params.rate ?? faker.number.float({ min: 0.1, max: 0.5 });
   const effectLevel =
@@ -17,11 +18,26 @@ export function createEffect(params: {
 
   switch (params.type) {
     case 'poison':
-      return new PoisonedAttackEffect(effectRate, effectLevel);
+      return new PoisonedAttackEffect(
+        effectRate,
+        effectLevel,
+        undefined,
+        params.terminationEvent,
+      );
     case 'burn':
-      return new BurnedAttackEffect(effectRate, effectLevel);
+      return new BurnedAttackEffect(
+        effectRate,
+        effectLevel,
+        undefined,
+        params.terminationEvent,
+      );
     case 'freeze':
-      return new FrozenAttackEffect(effectRate, effectLevel);
+      return new FrozenAttackEffect(
+        effectRate,
+        effectLevel,
+        undefined,
+        params.terminationEvent,
+      );
     default:
       throw new Error(`Unknown effect type: ${params.type}`);
   }


### PR DESCRIPTION
- Add `terminationEvent` field to status effects (burn, poison, freeze) and related state classes.
- Implement `removeEventBoundEffects` method in `FightingCard` to handle removal of effects based on emitted events.
- Update `EndEventProcessor` to emit `EffectRemoved` steps when event-bound effects are terminated.
- Enhance API to accept `terminationEvent` in effect definitions and ensure it propagates through to domain objects.
- Create tests for unit, integration, and end-to-end scenarios to validate the new functionality.
- Update documentation to reflect changes in API and architecture regarding event-bound effect termination.

closes: #43 