### PR TITLE
fix(types): use union type for effectType in EffectRemovedReport

### DIFF
--- a/src/fight/core/cards/@types/state/card-state.ts
+++ b/src/fight/core/cards/@types/state/card-state.ts
@@ -1,9 +1,10 @@
 import { FightingCard } from '../../fighting-card';
 import { StateResult } from '../action-result/state-result';
 import { EffectLevel } from '../attack/effect-level';
+import { StateEffectType } from './state-effect-type';
 
 export interface CardState {
-  type: string;
+  type: StateEffectType;
   level: EffectLevel;
   remainingTurns: number;
   terminationEvent?: string;

--- a/src/fight/core/cards/@types/state/state-effect-type.ts
+++ b/src/fight/core/cards/@types/state/state-effect-type.ts
@@ -1,0 +1,1 @@
+export type StateEffectType = 'burn' | 'poison' | 'freeze';

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -6,6 +6,7 @@ import { DodgeBehavior } from './behaviors/dodge-behaviors';
 import { AttackSkill } from './skills/attack-skill';
 import { Special } from './skills/special';
 import { CardState } from './@types/state/card-state';
+import { StateEffectType } from './@types/state/state-effect-type';
 import { StateResult } from './@types/action-result/state-result';
 import { CardStateFrozen } from './@types/state/card-state-frozen';
 import { EffectLevel } from './@types/attack/effect-level';
@@ -412,8 +413,8 @@ export class FightingCard {
 
   public removeEventBoundEffects(
     eventName: string,
-  ): { type: string; card: CardInfo }[] {
-    const removed: { type: string; card: CardInfo }[] = [];
+  ): { type: StateEffectType; card: CardInfo }[] {
+    const removed: { type: StateEffectType; card: CardInfo }[] = [];
 
     if (this.poisoned?.terminationEvent === eventName) {
       removed.push({ type: this.poisoned.type, card: this.identityInfo });

--- a/src/fight/core/fight-simulator/@types/effect-removed-report.ts
+++ b/src/fight/core/fight-simulator/@types/effect-removed-report.ts
@@ -1,9 +1,10 @@
 import { CardInfo } from '../../cards/@types/card-info';
+import { StateEffectType } from '../../cards/@types/state/state-effect-type';
 import { StepKind } from './step';
 
 export type EffectRemovedReport = {
   kind: StepKind.EffectRemoved;
   source: CardInfo;
   eventName: string;
-  removed: { target: CardInfo; effectType: string }[];
+  removed: { target: CardInfo; effectType: StateEffectType }[];
 };


### PR DESCRIPTION
Introduce StateEffectType = 'burn' | 'poison' | 'freeze' to replace
loose string types in CardState, FightingCard.removeEventBoundEffects,
and EffectRemovedReport.removed.effectType — closes #79.

https://claude.ai/code/session_017scAGxKjCt99AYZPPLuSRn