### PR TITLE
docs(alteration-skill): document duration=0→Infinity translation in JSDoc

### DIFF
--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -11,7 +11,9 @@ import { BuffCondition } from '../@types/buff/buff-condition';
  *
  * @param polarity - 'buff' for positive alterations, 'debuff' for negative
  * @param duration - Number of turns the alteration lasts. Use Infinity for alterations that
- *   persist until an event fires (event-bound) or indefinitely (permanent).
+ *   persist until an event fires (event-bound) or indefinitely (permanent). Infinity bypasses
+ *   the turn-decrement filter. The HTTP layer translates DTO duration=0 to Infinity before
+ *   constructing this skill.
  * @param terminationEvent - Event name that removes this buff when fired by
  *   EndEventProcessor. Pair with duration=Infinity for event-bound buffs.
  * @param endEvent - Event emitted when activationLimit is reached. Must match


### PR DESCRIPTION
The HTTP layer translates DTO duration=0 to Infinity before constructing
AlterationSkill. Add this context to the @param duration JSDoc so the
domain class documents why Infinity is used and how the DTO convention maps
to it, mirroring the existing comment in fight.controller.ts.

Closes #73

https://claude.ai/code/session_01S4ZEW5pn7xvgJCvrURw1dx