### PR TITLE
fix(tests): enforce one expectation per it block (issue #61)

### DIFF
--- a/src/fight/core/cards/__tests__/fighting-card-composite-power.spec.ts
+++ b/src/fight/core/cards/__tests__/fighting-card-composite-power.spec.ts
@@ -73,7 +73,9 @@ describe('FightingCard composite power', () => {
   });
 
   describe('skills with different powerIds activate independently', () => {
-    it('returns results with their respective powerIds', () => {
+    let results;
+
+    beforeEach(() => {
       const card = createFightingCard({
         id: 'card-1',
         attack: 100,
@@ -103,9 +105,14 @@ describe('FightingCard composite power', () => {
       const player2 = new Player('p2', [createFightingCard()]);
       const ctx = { sourcePlayer: player1, opponentPlayer: player2 };
 
-      const results = card.launchSkills('turn-end', ctx);
+      results = card.launchSkills('turn-end', ctx);
+    });
 
+    it('carries power-a id on first result', () => {
       expect(results[0].powerId).toBe('power-a');
+    });
+
+    it('carries power-b id on second result', () => {
       expect(results[1].powerId).toBe('power-b');
     });
   });

--- a/src/fight/http-api/__test__/fight.controller.spec.ts
+++ b/src/fight/http-api/__test__/fight.controller.spec.ts
@@ -91,18 +91,34 @@ describe('FightController', () => {
         fightController.startFight(fightData);
       });
 
-      it('creates a fighting card with a poisoned special attack effect', () => {
-        const validation = (card: FightingCard) => {
-          const jsonCard = JSON.parse(JSON.stringify(card));
+      it('creates a fighting card with a special defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special).toBeDefined();
+        });
+      });
 
-          expect(jsonCard.special).toBeDefined();
-          expect(jsonCard.special.effect).toBeDefined();
-          expect(jsonCard.special.effect.type).toBe('poisoned');
-          expect(jsonCard.special.effect.rate).toBe(0.5);
-          expect(jsonCard.special.effect.level).toBe(2);
-        };
+      it('creates a fighting card with a special effect defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect).toBeDefined();
+        });
+      });
 
-        fightSimulatorStub.validatePlayer1FirstCard(validation);
+      it('creates a fighting card with a poisoned special attack effect type', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe('poisoned');
+        });
+      });
+
+      it('creates a fighting card with a poisoned special attack effect rate', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect.rate).toBe(0.5);
+        });
+      });
+
+      it('creates a fighting card with a poisoned special attack effect level', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect.level).toBe(2);
+        });
       });
     });
 
@@ -158,18 +174,34 @@ describe('FightController', () => {
         fightController.startFight(fightData);
       });
 
-      it('creates a fighting card with a burned special attack effect', () => {
-        const validation = (card: FightingCard) => {
-          const jsonCard = JSON.parse(JSON.stringify(card));
+      it('creates a fighting card with a special defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special).toBeDefined();
+        });
+      });
 
-          expect(jsonCard.special).toBeDefined();
-          expect(jsonCard.special.effect).toBeDefined();
-          expect(jsonCard.special.effect.type).toBe('burned');
-          expect(jsonCard.special.effect.rate).toBe(0.2);
-          expect(jsonCard.special.effect.level).toBe(3);
-        };
+      it('creates a fighting card with a special effect defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect).toBeDefined();
+        });
+      });
 
-        fightSimulatorStub.validatePlayer1FirstCard(validation);
+      it('creates a fighting card with a burned special attack effect type', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe('burned');
+        });
+      });
+
+      it('creates a fighting card with a burned special attack effect rate', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect.rate).toBe(0.2);
+        });
+      });
+
+      it('creates a fighting card with a burned special attack effect level', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect.level).toBe(3);
+        });
       });
     });
 
@@ -225,18 +257,34 @@ describe('FightController', () => {
         fightController.startFight(fightData);
       });
 
-      it('creates a fighting card with a freeze special attack effect', () => {
-        const validation = (card: FightingCard) => {
-          const jsonCard = JSON.parse(JSON.stringify(card));
+      it('creates a fighting card with a special defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special).toBeDefined();
+        });
+      });
 
-          expect(jsonCard.special).toBeDefined();
-          expect(jsonCard.special.effect).toBeDefined();
-          expect(jsonCard.special.effect.type).toBe('frozen');
-          expect(jsonCard.special.effect.rate).toBe(0.2);
-          expect(jsonCard.special.effect.level).toBe(2);
-        };
+      it('creates a fighting card with a special effect defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect).toBeDefined();
+        });
+      });
 
-        fightSimulatorStub.validatePlayer1FirstCard(validation);
+      it('creates a fighting card with a freeze special attack effect type', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe('frozen');
+        });
+      });
+
+      it('creates a fighting card with a freeze special attack effect rate', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect.rate).toBe(0.2);
+        });
+      });
+
+      it('creates a fighting card with a freeze special attack effect level', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).special.effect.level).toBe(2);
+        });
       });
     });
   });
@@ -368,18 +416,34 @@ describe('FightController', () => {
         fightController.startFight(fightData);
       });
 
-      it('creates a fighting card with a poisoned simple attack effect', () => {
-        const validation = (card: FightingCard) => {
-          const jsonCard = JSON.parse(JSON.stringify(card));
+      it('creates a fighting card with a simple attack defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack).toBeDefined();
+        });
+      });
 
-          expect(jsonCard.simpleAttack).toBeDefined();
-          expect(jsonCard.simpleAttack.effect).toBeDefined();
-          expect(jsonCard.simpleAttack.effect.type).toBe('poisoned');
-          expect(jsonCard.simpleAttack.effect.rate).toBe(0.5);
-          expect(jsonCard.simpleAttack.effect.level).toBe(2);
-        };
+      it('creates a fighting card with a simple attack effect defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect).toBeDefined();
+        });
+      });
 
-        fightSimulatorStub.validatePlayer1FirstCard(validation);
+      it('creates a fighting card with a poisoned simple attack effect type', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.type).toBe('poisoned');
+        });
+      });
+
+      it('creates a fighting card with a poisoned simple attack effect rate', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate).toBe(0.5);
+        });
+      });
+
+      it('creates a fighting card with a poisoned simple attack effect level', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.level).toBe(2);
+        });
       });
     });
 
@@ -437,18 +501,34 @@ describe('FightController', () => {
         fightController.startFight(fightData);
       });
 
-      it('creates a fighting card with a burned special attack effect', () => {
-        const validation = (card: FightingCard) => {
-          const jsonCard = JSON.parse(JSON.stringify(card));
+      it('creates a fighting card with a simple attack defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack).toBeDefined();
+        });
+      });
 
-          expect(jsonCard.simpleAttack).toBeDefined();
-          expect(jsonCard.simpleAttack.effect).toBeDefined();
-          expect(jsonCard.simpleAttack.effect.type).toBe('burned');
-          expect(jsonCard.simpleAttack.effect.rate).toBe(0.2);
-          expect(jsonCard.simpleAttack.effect.level).toBe(3);
-        };
+      it('creates a fighting card with a simple attack effect defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect).toBeDefined();
+        });
+      });
 
-        fightSimulatorStub.validatePlayer1FirstCard(validation);
+      it('creates a fighting card with a burned simple attack effect type', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.type).toBe('burned');
+        });
+      });
+
+      it('creates a fighting card with a burned simple attack effect rate', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate).toBe(0.2);
+        });
+      });
+
+      it('creates a fighting card with a burned simple attack effect level', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.level).toBe(3);
+        });
       });
     });
 
@@ -506,18 +586,34 @@ describe('FightController', () => {
         fightController.startFight(fightData);
       });
 
-      it('creates a fighting card with a freeze simple attack effect', () => {
-        const validation = (card: FightingCard) => {
-          const jsonCard = JSON.parse(JSON.stringify(card));
+      it('creates a fighting card with a simple attack defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack).toBeDefined();
+        });
+      });
 
-          expect(jsonCard.simpleAttack).toBeDefined();
-          expect(jsonCard.simpleAttack.effect).toBeDefined();
-          expect(jsonCard.simpleAttack.effect.type).toBe('frozen');
-          expect(jsonCard.simpleAttack.effect.rate).toBe(0.2);
-          expect(jsonCard.simpleAttack.effect.level).toBe(2);
-        };
+      it('creates a fighting card with a simple attack effect defined', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect).toBeDefined();
+        });
+      });
 
-        fightSimulatorStub.validatePlayer1FirstCard(validation);
+      it('creates a fighting card with a freeze simple attack effect type', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.type).toBe('frozen');
+        });
+      });
+
+      it('creates a fighting card with a freeze simple attack effect rate', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate).toBe(0.2);
+        });
+      });
+
+      it('creates a fighting card with a freeze simple attack effect level', () => {
+        fightSimulatorStub.validatePlayer1FirstCard((card) => {
+          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.level).toBe(2);
+        });
       });
     });
 


### PR DESCRIPTION
Split it blocks with multiple expects into individual it blocks across:
- fighting-card-composite-power.spec.ts: extracted beforeEach for shared setup
- fight.controller.spec.ts: split 6 blocks (5 expects each) into single-expect its

https://claude.ai/code/session_01BHJdknondeY1EDLjHqKUjp