### PR TITLE
refactor: replace AlterationSkill positional params with options object

### DIFF
--- a/src/fight/core/cards/__tests__/fighting-card.spec.ts
+++ b/src/fight/core/cards/__tests__/fighting-card.spec.ts
@@ -113,17 +113,16 @@ describe('FightingCard.lifecycleEndEvents()', () => {
     let card;
 
     beforeEach(() => {
-      const skill = new AlterationSkill(
-        'buff',
-        'attack',
-        0.4,
-        Infinity,
-        new TurnEnd(),
-        new Launcher(),
-        undefined,
-        3,
-        'lions-end',
-      );
+      const skill = new AlterationSkill({
+        polarity: 'buff',
+        attributeType: 'attack',
+        rate: 0.4,
+        duration: Infinity,
+        trigger: new TurnEnd(),
+        targetingStrategy: new Launcher(),
+        activationLimit: 3,
+        endEvent: 'lions-end',
+      });
       card = createFightingCard({});
       (card as any).skills = [skill];
     });
@@ -140,17 +139,16 @@ describe('FightingCard.lifecycleEndEvents()', () => {
     let skill;
 
     beforeEach(() => {
-      skill = new AlterationSkill(
-        'buff',
-        'attack',
-        0.4,
-        Infinity,
-        new TurnEnd(),
-        new Launcher(),
-        undefined,
-        1,
-        'lions-end',
-      );
+      skill = new AlterationSkill({
+        polarity: 'buff',
+        attributeType: 'attack',
+        rate: 0.4,
+        duration: Infinity,
+        trigger: new TurnEnd(),
+        targetingStrategy: new Launcher(),
+        activationLimit: 1,
+        endEvent: 'lions-end',
+      });
       card = createFightingCard({});
       (card as any).skills = [skill];
       // exhaust by launching once

--- a/src/fight/core/cards/skills/__tests__/alteration-skill.spec.ts
+++ b/src/fight/core/cards/skills/__tests__/alteration-skill.spec.ts
@@ -18,27 +18,27 @@ describe('AlterationSkill lifecycle', () => {
 
   describe('when activationLimit is not set', () => {
     it('is always triggered', () => {
-      const skill = new AlterationSkill(
-        'buff',
-        'attack',
-        0.1,
-        2,
+      const skill = new AlterationSkill({
+        polarity: 'buff',
+        attributeType: 'attack',
+        rate: 0.1,
+        duration: 2,
         trigger,
-        targeting,
-      );
+        targetingStrategy: targeting,
+      });
       expect(skill.isTriggered('turn-end')).toBe(true);
     });
 
     it('never returns endEvent', () => {
       const source = createFightingCard({ health: 100 });
-      const skill = new AlterationSkill(
-        'buff',
-        'attack',
-        0.1,
-        2,
+      const skill = new AlterationSkill({
+        polarity: 'buff',
+        attributeType: 'attack',
+        rate: 0.1,
+        duration: 2,
         trigger,
-        targeting,
-      );
+        targetingStrategy: targeting,
+      });
       const result = skill.launch(source, makeContext(source));
 
       expect(result.endEvent).toBeUndefined();
@@ -49,17 +49,16 @@ describe('AlterationSkill lifecycle', () => {
     let skill;
 
     beforeEach(() => {
-      skill = new AlterationSkill(
-        'buff',
-        'attack',
-        0.1,
-        2,
+      skill = new AlterationSkill({
+        polarity: 'buff',
+        attributeType: 'attack',
+        rate: 0.1,
+        duration: 2,
         trigger,
-        targeting,
-        undefined,
-        3,
-        'test-end',
-      );
+        targetingStrategy: targeting,
+        activationLimit: 3,
+        endEvent: 'test-end',
+      });
     });
 
     it('increments activationCount on each launch', () => {
@@ -126,14 +125,14 @@ describe('AlterationSkill lifecycle', () => {
   describe('debuff polarity', () => {
     it('returns skillKind Debuff', () => {
       const source = createFightingCard({ health: 100 });
-      const skill = new AlterationSkill(
-        'debuff',
-        'attack',
-        0.1,
-        2,
+      const skill = new AlterationSkill({
+        polarity: 'debuff',
+        attributeType: 'attack',
+        rate: 0.1,
+        duration: 2,
         trigger,
-        targeting,
-      );
+        targetingStrategy: targeting,
+      });
       const result = skill.launch(source, makeContext(source));
 
       expect(result.skillKind).toBe(SkillKind.Debuff);
@@ -142,14 +141,14 @@ describe('AlterationSkill lifecycle', () => {
     it('applies debuff to target', () => {
       const source = createFightingCard({ attack: 100, health: 100 });
       const initialAttack = source.actualAttack;
-      const skill = new AlterationSkill(
-        'debuff',
-        'attack',
-        0.1,
-        2,
+      const skill = new AlterationSkill({
+        polarity: 'debuff',
+        attributeType: 'attack',
+        rate: 0.1,
+        duration: 2,
         trigger,
-        targeting,
-      );
+        targetingStrategy: targeting,
+      });
       skill.launch(source, makeContext(source));
 
       expect(source.actualAttack).toBe(initialAttack - 10);

--- a/src/fight/core/cards/skills/__tests__/conditional-buff-skill.spec.ts
+++ b/src/fight/core/cards/skills/__tests__/conditional-buff-skill.spec.ts
@@ -22,15 +22,15 @@ describe('AlterationSkill with activationCondition', () => {
 
     beforeEach(() => {
       const condition = new HealthThresholdCondition(0.5, 'above');
-      const skill = new AlterationSkill(
-        'buff',
-        'attack',
-        0.1,
-        2,
+      const skill = new AlterationSkill({
+        polarity: 'buff',
+        attributeType: 'attack',
+        rate: 0.1,
+        duration: 2,
         trigger,
         targetingStrategy,
-        condition,
-      );
+        activationCondition: condition,
+      });
       const source = createFightingCard({ health: 100 });
       results = skill.launch(source, makeContext(source));
     });
@@ -45,15 +45,15 @@ describe('AlterationSkill with activationCondition', () => {
 
     beforeEach(() => {
       const condition = new HealthThresholdCondition(0.5, 'above');
-      const skill = new AlterationSkill(
-        'buff',
-        'attack',
-        0.1,
-        2,
+      const skill = new AlterationSkill({
+        polarity: 'buff',
+        attributeType: 'attack',
+        rate: 0.1,
+        duration: 2,
         trigger,
         targetingStrategy,
-        condition,
-      );
+        activationCondition: condition,
+      });
       const source = createFightingCard({ health: 100 });
       source.addRealDamage(60);
       results = skill.launch(source, makeContext(source));
@@ -72,14 +72,14 @@ describe('AlterationSkill with activationCondition', () => {
     let results;
 
     beforeEach(() => {
-      const skill = new AlterationSkill(
-        'buff',
-        'attack',
-        0.1,
-        2,
+      const skill = new AlterationSkill({
+        polarity: 'buff',
+        attributeType: 'attack',
+        rate: 0.1,
+        duration: 2,
         trigger,
         targetingStrategy,
-      );
+      });
       const source = createFightingCard({ health: 100 });
       source.addRealDamage(99);
       results = skill.launch(source, makeContext(source));

--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -6,21 +6,21 @@ import { BuffType } from '../@types/buff/type';
 import { Skill, SkillKind, SkillResults } from './skill';
 import { BuffCondition } from '../@types/buff/buff-condition';
 
-/**
- * Unified skill that applies a positive (buff) or negative (debuff) stat alteration.
- *
- * @param polarity - 'buff' for positive alterations, 'debuff' for negative
- * @param duration - Number of turns the alteration lasts. Use Infinity for alterations that
- *   persist until an event fires (event-bound) or indefinitely (permanent). Infinity bypasses
- *   the turn-decrement filter. The HTTP layer translates DTO duration=0 to Infinity before
- *   constructing this skill.
- * @param terminationEvent - Event name that removes this buff when fired by
- *   EndEventProcessor. Pair with duration=Infinity for event-bound buffs.
- * @param endEvent - Event emitted when activationLimit is reached. Must match
- *   the terminationEvent of the buffs to remove via EndEventProcessor.
- * @param activationLimit - Max number of times this skill fires before its
- *   lifecycle ends and endEvent is emitted.
- */
+export interface AlterationSkillOptions {
+  polarity: 'buff' | 'debuff';
+  attributeType: BuffType;
+  rate: number;
+  /** Number of turns the alteration lasts. Use Infinity for event-bound or permanent buffs. */
+  duration: number;
+  trigger: Trigger;
+  targetingStrategy: TargetingCardStrategy;
+  activationCondition?: BuffCondition;
+  activationLimit?: number;
+  endEvent?: string;
+  terminationEvent?: string;
+  powerId?: string;
+}
+
 export class AlterationSkill implements Skill {
   public id = 'alteration-skill';
 
@@ -37,19 +37,19 @@ export class AlterationSkill implements Skill {
   private readonly powerId?: string;
   private activationCount = 0;
 
-  constructor(
-    polarity: 'buff' | 'debuff',
-    attributeType: BuffType,
-    rate: number,
-    duration: number,
-    trigger: Trigger,
-    targetingStrategy: TargetingCardStrategy,
-    activationCondition?: BuffCondition,
-    activationLimit?: number,
-    endEvent?: string,
-    terminationEvent?: string,
-    powerId?: string,
-  ) {
+  constructor({
+    polarity,
+    attributeType,
+    rate,
+    duration,
+    trigger,
+    targetingStrategy,
+    activationCondition,
+    activationLimit,
+    endEvent,
+    terminationEvent,
+    powerId,
+  }: AlterationSkillOptions) {
     this.polarity = polarity;
     this.attributeType = attributeType;
     this.rate = rate;

--- a/src/fight/core/fight-simulator/__tests__/death-skill-handler.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/death-skill-handler.spec.ts
@@ -156,18 +156,17 @@ describe('DeathSkillHandler', () => {
       });
 
       // Attach lifecycle skill to deadCard after creation
-      const lifecycleSkill = new AlterationSkill(
-        'buff',
-        'attack',
-        0.4,
-        Infinity,
-        new TurnEnd(),
-        new Launcher(),
-        undefined,
-        3,
-        'lions-end',
-        'lions-end',
-      );
+      const lifecycleSkill = new AlterationSkill({
+        polarity: 'buff',
+        attributeType: 'attack',
+        rate: 0.4,
+        duration: Infinity,
+        trigger: new TurnEnd(),
+        targetingStrategy: new Launcher(),
+        activationLimit: 3,
+        endEvent: 'lions-end',
+        terminationEvent: 'lions-end',
+      });
       (deadCard as any).skills = [lifecycleSkill];
 
       allyCard = createFightingCard({

--- a/src/fight/http-api/__test__/fight.controller.spec.ts
+++ b/src/fight/http-api/__test__/fight.controller.spec.ts
@@ -105,13 +105,17 @@ describe('FightController', () => {
 
       it('creates a fighting card with a poisoned special attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe('poisoned');
+          expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe(
+            'poisoned',
+          );
         });
       });
 
       it('creates a fighting card with a poisoned special attack effect rate', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).special.effect.rate).toBe(0.5);
+          expect(JSON.parse(JSON.stringify(card)).special.effect.rate).toBe(
+            0.5,
+          );
         });
       });
 
@@ -188,13 +192,17 @@ describe('FightController', () => {
 
       it('creates a fighting card with a burned special attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe('burned');
+          expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe(
+            'burned',
+          );
         });
       });
 
       it('creates a fighting card with a burned special attack effect rate', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).special.effect.rate).toBe(0.2);
+          expect(JSON.parse(JSON.stringify(card)).special.effect.rate).toBe(
+            0.2,
+          );
         });
       });
 
@@ -271,13 +279,17 @@ describe('FightController', () => {
 
       it('creates a fighting card with a freeze special attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe('frozen');
+          expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe(
+            'frozen',
+          );
         });
       });
 
       it('creates a fighting card with a freeze special attack effect rate', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).special.effect.rate).toBe(0.2);
+          expect(JSON.parse(JSON.stringify(card)).special.effect.rate).toBe(
+            0.2,
+          );
         });
       });
 
@@ -424,25 +436,33 @@ describe('FightController', () => {
 
       it('creates a fighting card with a simple attack effect defined', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect).toBeDefined();
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect,
+          ).toBeDefined();
         });
       });
 
       it('creates a fighting card with a poisoned simple attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.type).toBe('poisoned');
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect.type,
+          ).toBe('poisoned');
         });
       });
 
       it('creates a fighting card with a poisoned simple attack effect rate', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate).toBe(0.5);
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate,
+          ).toBe(0.5);
         });
       });
 
       it('creates a fighting card with a poisoned simple attack effect level', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.level).toBe(2);
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect.level,
+          ).toBe(2);
         });
       });
     });
@@ -509,25 +529,33 @@ describe('FightController', () => {
 
       it('creates a fighting card with a simple attack effect defined', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect).toBeDefined();
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect,
+          ).toBeDefined();
         });
       });
 
       it('creates a fighting card with a burned simple attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.type).toBe('burned');
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect.type,
+          ).toBe('burned');
         });
       });
 
       it('creates a fighting card with a burned simple attack effect rate', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate).toBe(0.2);
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate,
+          ).toBe(0.2);
         });
       });
 
       it('creates a fighting card with a burned simple attack effect level', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.level).toBe(3);
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect.level,
+          ).toBe(3);
         });
       });
     });
@@ -594,25 +622,33 @@ describe('FightController', () => {
 
       it('creates a fighting card with a simple attack effect defined', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect).toBeDefined();
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect,
+          ).toBeDefined();
         });
       });
 
       it('creates a fighting card with a freeze simple attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.type).toBe('frozen');
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect.type,
+          ).toBe('frozen');
         });
       });
 
       it('creates a fighting card with a freeze simple attack effect rate', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate).toBe(0.2);
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate,
+          ).toBe(0.2);
         });
       });
 
       it('creates a fighting card with a freeze simple attack effect level', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
-          expect(JSON.parse(JSON.stringify(card)).simpleAttack.effect.level).toBe(2);
+          expect(
+            JSON.parse(JSON.stringify(card)).simpleAttack.effect.level,
+          ).toBe(2);
         });
       });
     });

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -271,19 +271,24 @@ export class FightController {
         // The domain uses Infinity to bypass the turn-decrement filter.
         const alterationDuration =
           skillData.duration === 0 ? Infinity : (skillData.duration ?? 0);
-        return new AlterationSkill(
-          skillData.kind === SkillKind.BUFF ? 'buff' : 'debuff',
-          this.mapBuffType(skillData.buffType),
-          skillData.rate,
-          alterationDuration,
-          buildTriggerStrategy(skillData.event, skillData.targetCardId),
-          buildTargetingStrategy(skillData.targetingStrategy),
-          alterationCondition,
-          skillData.activationLimit,
-          skillData.endEvent,
-          skillData.terminationEvent,
-          skillData.powerId,
-        );
+        return new AlterationSkill({
+          polarity: skillData.kind === SkillKind.BUFF ? 'buff' : 'debuff',
+          attributeType: this.mapBuffType(skillData.buffType),
+          rate: skillData.rate,
+          duration: alterationDuration,
+          trigger: buildTriggerStrategy(
+            skillData.event,
+            skillData.targetCardId,
+          ),
+          targetingStrategy: buildTargetingStrategy(
+            skillData.targetingStrategy,
+          ),
+          activationCondition: alterationCondition,
+          activationLimit: skillData.activationLimit,
+          endEvent: skillData.endEvent,
+          terminationEvent: skillData.terminationEvent,
+          powerId: skillData.powerId,
+        });
       case SkillKind.CONDITIONAL_ATTACK:
         if (!skillData.damages || !skillData.interval) {
           throw new Error('Conditional attack requires damages and interval');

--- a/test/helpers/fighting-card.ts
+++ b/test/helpers/fighting-card.ts
@@ -262,33 +262,28 @@ function createsSkills(
         skill.powerId,
       );
     } else if ('buffType' in skill) {
-      return new AlterationSkill(
-        'buff',
-        skill.buffType,
-        skill.buffRate,
-        skill.duration,
-        createTrigger(skill.trigger, skill.targetCardId),
-        createTargetingStrategy(skill.targetingStrategy),
-        undefined,
-        skill.activationLimit,
-        skill.endEvent,
-        skill.terminationEvent,
-        skill.powerId,
-      );
+      return new AlterationSkill({
+        polarity: 'buff',
+        attributeType: skill.buffType,
+        rate: skill.buffRate,
+        duration: skill.duration,
+        trigger: createTrigger(skill.trigger, skill.targetCardId),
+        targetingStrategy: createTargetingStrategy(skill.targetingStrategy),
+        activationLimit: skill.activationLimit,
+        endEvent: skill.endEvent,
+        terminationEvent: skill.terminationEvent,
+        powerId: skill.powerId,
+      });
     } else {
-      return new AlterationSkill(
-        'debuff',
-        skill.debuffType,
-        skill.debuffRate,
-        skill.duration,
-        createTrigger(skill.trigger, skill.targetCardId),
-        createTargetingStrategy(skill.targetingStrategy),
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        skill.powerId,
-      );
+      return new AlterationSkill({
+        polarity: 'debuff',
+        attributeType: skill.debuffType,
+        rate: skill.debuffRate,
+        duration: skill.duration,
+        trigger: createTrigger(skill.trigger, skill.targetCardId),
+        targetingStrategy: createTargetingStrategy(skill.targetingStrategy),
+        powerId: skill.powerId,
+      });
     }
   });
 }


### PR DESCRIPTION
Replaces 11 positional constructor parameters with a single
AlterationSkillOptions object, improving readability at all call sites.

Closes #66
https://claude.ai/code/session_011B1JDXbQTZ75spcqJw2E4T