### PR TITLE
fix: add terminationEvent to AttackEffect interface for contract completeness

### DIFF
--- a/src/fight/core/cards/@types/attack/attack-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-effect.ts
@@ -16,6 +16,7 @@ export interface AttackEffect {
   level: EffectLevel;
   type: string;
   triggeredDebuff?: EffectTriggeredDebuff;
+  terminationEvent?: string;
 
   applyEffect(
     defender: FightingCard,


### PR DESCRIPTION
All three concrete implementations (BurnedAttackEffect, FrozenAttackEffect,
PoisonedAttackEffect) already declared terminationEvent as a readonly optional
string, but the AttackEffect interface was missing it, forcing consumers to
cast when accessing this property.

Closes #75

https://claude.ai/code/session_01DA195ym9jek2kUEUEZxYQR