### PR TITLE
[tests] Split it blocks with multiple expects into individual it blocks

### DIFF
--- a/src/fight/core/__tests__/buffing-skill.spec.ts
+++ b/src/fight/core/__tests__/buffing-skill.spec.ts
@@ -143,20 +143,22 @@ describe('Buffing-skill', () => {
     });
   });
 
-  it('remove expired buffs and restore original stats', () => {
+  it('increases attack after fight with buff skill', () => {
     const initialAttack = card1.actualAttack;
 
     fight.start();
 
-    // Attack be buffed
     expect(card1.actualAttack).toBe(initialAttack + 2 * 50);
+  });
 
-    // Expire the buff
+  it('restores attack after buff expires', () => {
+    const initialAttack = card1.actualAttack;
+
+    fight.start();
     card1.decreaseBuffAndDebuffDuration();
     card1.decreaseBuffAndDebuffDuration();
     card1.decreaseBuffAndDebuffDuration();
 
-    // Attack return to original value
     expect(card1.actualAttack).toBe(initialAttack);
   });
 });

--- a/src/fight/core/__tests__/debuff-basic.spec.ts
+++ b/src/fight/core/__tests__/debuff-basic.spec.ts
@@ -17,14 +17,19 @@ describe('Debuff System - Basic Tests', () => {
   });
 
   describe('Multiple debuffs', () => {
-    it('apply multiple debuffs of different types', () => {
+    it('reduces attack when attack debuff is applied', () => {
       const initialAttack = card.actualAttack;
-      const initialDefense = card.actualDefense;
 
       card.applyDebuff('attack', 0.1, 3);
-      card.applyDebuff('defense', 0.2, 2);
 
       expect(card.actualAttack).toBe(initialAttack - 10);
+    });
+
+    it('reduces defense when defense debuff is applied', () => {
+      const initialDefense = card.actualDefense;
+
+      card.applyDebuff('defense', 0.2, 2);
+
       expect(card.actualDefense).toBe(Math.max(0, initialDefense - 10));
     });
 
@@ -39,13 +44,20 @@ describe('Debuff System - Basic Tests', () => {
   });
 
   describe('Debuff duration management', () => {
-    it('restore original stats when debuffs expire', () => {
+    it('reduces stat when debuff is applied', () => {
       const initialAttack = card.actualAttack;
 
       card.applyDebuff('attack', 0.2, 1);
-      expect(card.actualAttack).toBe(initialAttack - 20);
 
+      expect(card.actualAttack).toBe(initialAttack - 20);
+    });
+
+    it('restores stat after debuff expires', () => {
+      const initialAttack = card.actualAttack;
+
+      card.applyDebuff('attack', 0.2, 1);
       card.decreaseBuffAndDebuffDuration();
+
       expect(card.actualAttack).toBe(initialAttack);
     });
   });
@@ -61,12 +73,27 @@ describe('Debuff System - Basic Tests', () => {
       expect(card.actualAttack).toBe(expectedAttack);
     });
 
-    it('never go below 0 even with strong debuffs', () => {
-      card.applyDebuff('attack', 2.0, 3); // 200% debuff (more than the stat)
+    it('clamps attack to 0 with excessive debuff', () => {
+      card.applyDebuff('attack', 2.0, 3);
 
       expect(card.actualAttack).toBe(0);
+    });
+
+    it('does not affect defense when attack is over-debuffed', () => {
+      card.applyDebuff('attack', 2.0, 3);
+
       expect(card.actualDefense).toBeGreaterThanOrEqual(0);
+    });
+
+    it('does not affect agility when attack is over-debuffed', () => {
+      card.applyDebuff('attack', 2.0, 3);
+
       expect(card.actualAgility).toBeGreaterThanOrEqual(0);
+    });
+
+    it('does not affect accuracy when attack is over-debuffed', () => {
+      card.applyDebuff('attack', 2.0, 3);
+
       expect(card.actualAccuracy).toBeGreaterThanOrEqual(0);
     });
   });

--- a/src/fight/core/__tests__/debuffing-skill.spec.ts
+++ b/src/fight/core/__tests__/debuffing-skill.spec.ts
@@ -68,9 +68,7 @@ describe('Debuffing-skill', () => {
       );
     });
 
-    it('applies attack debuff to opponent when triggered at turn end', () => {
-      const initialAttack = card2.actualAttack;
-
+    it('records attack and debuff steps in fight result', () => {
       const fightResult = fight.start();
 
       expect(fightResult).toMatchObject({
@@ -91,6 +89,12 @@ describe('Debuffing-skill', () => {
           ],
         }),
       });
+    });
+
+    it('reduces opponent attack stat after debuff is applied', () => {
+      const initialAttack = card2.actualAttack;
+
+      fight.start();
 
       expect(card2.actualAttack).toBe(initialAttack - 36 * 2);
     });

--- a/src/fight/core/__tests__/special-attack.spec.ts
+++ b/src/fight/core/__tests__/special-attack.spec.ts
@@ -278,65 +278,62 @@ describe('Trigger card special attack with poison effect', () => {
 });
 
 describe('Trigger card special attack with buff', () => {
-  const defender = createFightingCard({
-    attack: 100,
-    defense: 0,
-    health: 50,
-    speed: 1,
-    criticalChance: 0,
-    agility: 25,
-  });
-
-  const attacker = createFightingCard({
-    attack: 50,
-    defense: 0,
-    health: 100,
-    speed: 100,
-    criticalChance: 0,
-    accuracy: 25,
-    agility: 25,
-    skills: {
-      special: {
-        kind: 'specialAttack',
-        damageRate: 1.0,
-        energy: 100,
-        targetingStrategy: 'target-all',
-        buffs: [
-          {
-            buffType: 'attack',
-            buffRate: 0.2,
-            buffDuration: 3,
-            buffTargetingStrategy: 'all-owner-cards',
-          },
-        ],
-      },
-    },
-  });
-
-  const player1 = new Player('Player 1', [attacker]);
-  const player2 = new Player('Player 2', [defender]);
-  const fight = new Fight(
-    player1,
-    player2,
-    new PlayerByPlayerCardSelector(player1, player2),
-  );
+  let attacker: ReturnType<typeof createFightingCard>;
+  let defender: ReturnType<typeof createFightingCard>;
+  let result: ReturnType<Fight['start']>;
 
   beforeEach(() => {
-    attacker.increaseSpecialEnergy();
-    attacker.increaseSpecialEnergy();
-    attacker.increaseSpecialEnergy();
-    attacker.increaseSpecialEnergy();
-    attacker.increaseSpecialEnergy();
-    attacker.increaseSpecialEnergy();
-    attacker.increaseSpecialEnergy();
-    attacker.increaseSpecialEnergy();
-    attacker.increaseSpecialEnergy();
-    attacker.increaseSpecialEnergy();
+    defender = createFightingCard({
+      attack: 100,
+      defense: 0,
+      health: 50,
+      speed: 1,
+      criticalChance: 0,
+      agility: 25,
+    });
+
+    attacker = createFightingCard({
+      attack: 50,
+      defense: 0,
+      health: 100,
+      speed: 100,
+      criticalChance: 0,
+      accuracy: 25,
+      agility: 25,
+      skills: {
+        special: {
+          kind: 'specialAttack',
+          damageRate: 1.0,
+          energy: 100,
+          targetingStrategy: 'target-all',
+          buffs: [
+            {
+              buffType: 'attack',
+              buffRate: 0.2,
+              buffDuration: 3,
+              buffTargetingStrategy: 'all-owner-cards',
+            },
+          ],
+        },
+      },
+    });
+
+    for (let i = 0; i < 10; i++) {
+      attacker.increaseSpecialEnergy();
+    }
+
+    const player1 = new Player('Player 1', [attacker]);
+    const player2 = new Player('Player 2', [defender]);
+    const fight = new Fight(
+      player1,
+      player2,
+      new PlayerByPlayerCardSelector(player1, player2),
+    );
+
+    result = fight.start();
   });
 
-  it('apply buffs to targeted cards after special attack', () => {
-    const result = fight.start();
-
+  it('applies special_attack as first action', () => {
     expect(result[1]).toEqual({
       attacker: attacker.identityInfo,
       damages: [
@@ -351,7 +348,9 @@ describe('Trigger card special attack with buff', () => {
       energy: 0,
       kind: 'special_attack',
     });
+  });
 
+  it('applies buff as second step', () => {
     expect(result[2]).toEqual({
       kind: 'buff',
       source: attacker.identityInfo,
@@ -365,13 +364,17 @@ describe('Trigger card special attack with buff', () => {
       ],
       energy: 0,
     });
+  });
 
+  it('marks defender as dead', () => {
     expect(result[3]).toEqual({
       card: defender.identityInfo,
       kind: 'status_change',
       status: 'dead',
     });
+  });
 
+  it('ends fight with Player 1 winning', () => {
     expect(result[4]).toEqual({
       kind: 'fight_end',
       winner: 'Player 1',

--- a/src/fight/core/cards/skills/__tests__/conditional-attack.spec.ts
+++ b/src/fight/core/cards/skills/__tests__/conditional-attack.spec.ts
@@ -236,12 +236,16 @@ describe('ConditionalAttack integration via Fight (interval=3)', () => {
     );
   });
 
-  it('fires simple attack on attacker turns 1 and 2 (steps 1 and 3)', () => {
+  it('fires simple attack on attacker turn 1 (step 1)', () => {
     const result = fight.start();
     expect(result[1]).toMatchObject({
       kind: 'attack',
       damages: [{ damage: 100 }],
     });
+  });
+
+  it('fires simple attack on attacker turn 2 (step 3)', () => {
+    const result = fight.start();
     expect(result[3]).toMatchObject({
       kind: 'attack',
       damages: [{ damage: 100 }],

--- a/src/fight/tools/__tests__/math-randomizer.spec.ts
+++ b/src/fight/tools/__tests__/math-randomizer.spec.ts
@@ -8,10 +8,15 @@ describe('math randomizer', () => {
     describe('when max is strictly higher than min', () => {
       const min = faker.number.int(10);
       const max = faker.number.int({ min, max: 100 });
-      it('returns the int value', () => {
+      it('returns a value greater than or equal to min', () => {
         const randomValue = randomizer.random_int_between(min, max);
 
         expect(randomValue).toBeGreaterThanOrEqual(min);
+      });
+
+      it('returns a value less than or equal to max', () => {
+        const randomValue = randomizer.random_int_between(min, max);
+
         expect(randomValue).toBeLessThanOrEqual(max);
       });
     });

--- a/test/fight/composite-power.e2e-spec.ts
+++ b/test/fight/composite-power.e2e-spec.ts
@@ -164,16 +164,36 @@ describe('Composite Power — targeting override and revert', () => {
     expect(revertStep[1].eventName).toBe('fury-end');
   });
 
-  it('all composite power step types carry powerId', () => {
+  it('buff step carries powerId', () => {
     const powerStepKinds = stepEntries
       .filter(([, s]) => s.powerId === 'fury-power')
       .map(([, s]) => s.kind);
-    const uniqueKinds = [...new Set(powerStepKinds)];
 
-    expect(uniqueKinds).toContain('buff');
-    expect(uniqueKinds).toContain('targeting_override');
-    expect(uniqueKinds).toContain('buff_removed');
-    expect(uniqueKinds).toContain('targeting_reverted');
+    expect(powerStepKinds).toContain('buff');
+  });
+
+  it('targeting_override step carries powerId', () => {
+    const powerStepKinds = stepEntries
+      .filter(([, s]) => s.powerId === 'fury-power')
+      .map(([, s]) => s.kind);
+
+    expect(powerStepKinds).toContain('targeting_override');
+  });
+
+  it('buff_removed step carries powerId', () => {
+    const powerStepKinds = stepEntries
+      .filter(([, s]) => s.powerId === 'fury-power')
+      .map(([, s]) => s.kind);
+
+    expect(powerStepKinds).toContain('buff_removed');
+  });
+
+  it('targeting_reverted step carries powerId', () => {
+    const powerStepKinds = stepEntries
+      .filter(([, s]) => s.powerId === 'fury-power')
+      .map(([, s]) => s.kind);
+
+    expect(powerStepKinds).toContain('targeting_reverted');
   });
 });
 


### PR DESCRIPTION
Fixes #61 — enforces one expectation per it block across all test files:
- math-randomizer.spec.ts: split bounds check into two tests
- debuff-basic.spec.ts: split 3 multi-expect blocks (6 new tests)
- special-attack.spec.ts: restructure describe to use beforeEach, split 4-expect block
- buffing-skill.spec.ts: split sequential state test into two tests
- debuffing-skill.spec.ts: split result + stat assertion into two tests
- conditional-attack.spec.ts: split two-step assertion into two tests
- composite-power.e2e-spec.ts: split 4-expect powerId check into four tests

https://claude.ai/code/session_014CMgqshyP5kYmJ4yt88vGz