### PR TITLE
fix: throw on unknown enum values in mapBuffType and getSelectorStrategy

### DIFF
--- a/src/fight/http-api/__test__/fight.controller.spec.ts
+++ b/src/fight/http-api/__test__/fight.controller.spec.ts
@@ -1150,4 +1150,79 @@ describe('FightController', () => {
       );
     });
   });
+
+  describe('error handling for unknown enum values', () => {
+    const baseCard = {
+      id: 'card-1',
+      name: 'Card',
+      attack: 100,
+      defense: 50,
+      health: 1000,
+      speed: 100,
+      agility: 10,
+      accuracy: 50,
+      criticalChance: 0,
+      skills: {
+        special: {
+          kind: SpecialKind.ATTACK,
+          name: 'Special',
+          rate: 2,
+          energy: 9999,
+          targetingStrategy: TargetingStrategy.POSITION_BASED,
+        },
+        simpleAttack: {
+          name: 'Attack',
+          damages: [{ type: DamageType.PHYSICAL, rate: 1.0 }],
+          targetingStrategy: TargetingStrategy.POSITION_BASED,
+        },
+        others: [],
+      },
+      behaviors: { dodge: DodgeStrategy.SIMPLE_DODGE },
+    };
+
+    it('throws when mapBuffType receives an unknown buff type', () => {
+      const data: FightDataDto = {
+        cardSelectorStrategy: CardSelectorStrategy.PLAYER_BY_PLAYER,
+        player1: {
+          name: 'P1',
+          deck: [
+            {
+              ...baseCard,
+              skills: {
+                ...baseCard.skills,
+                others: [
+                  {
+                    kind: SkillKind.BUFF,
+                    name: 'Buff',
+                    rate: 0.2,
+                    targetingStrategy: TargetingStrategy.SELF,
+                    event: TriggerEvent.TURN_END,
+                    buffType: 'unknown-buff' as any,
+                    duration: 1,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        player2: { name: 'P2', deck: [] },
+      };
+
+      expect(() => fightController.startFight(data)).toThrow(
+        /Unknown buff type/,
+      );
+    });
+
+    it('throws when getSelectorStrategy receives an unknown card selector strategy', () => {
+      const data: FightDataDto = {
+        cardSelectorStrategy: 'unknown-strategy' as any,
+        player1: { name: 'P1', deck: [baseCard] },
+        player2: { name: 'P2', deck: [] },
+      };
+
+      expect(() => fightController.startFight(data)).toThrow(
+        /Unknown card selector strategy/,
+      );
+    });
+  });
 });

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -347,7 +347,9 @@ export class FightController {
       [BuffType.ACCURACY]: 'accuracy' as const,
     };
 
-    return BUFF_TYPE_MAP[buffType];
+    const result = BUFF_TYPE_MAP[buffType];
+    if (!result) throw new Error(`Unknown buff type: ${buffType}`);
+    return result;
   }
 
   private validatePowerIdConsistency(skills: OtherSkillDto[]): void {
@@ -398,6 +400,11 @@ export class FightController {
       ),
     };
 
-    return STRATEGY_MAP[cardSelectorStrategy];
+    const result = STRATEGY_MAP[cardSelectorStrategy];
+    if (!result)
+      throw new Error(
+        `Unknown card selector strategy: ${cardSelectorStrategy}`,
+      );
+    return result;
   }
 }


### PR DESCRIPTION
Fixes #53 — both functions were silently returning undefined for unknown
enum values. Now they throw an explicit error to prevent silent failures.

https://claude.ai/code/session_01TJUchPscWAbFJR2wCqhj3z