### PR TITLE
Remove stale comment in fighting-card.ts

### DIFF
--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -304,7 +304,6 @@ export class FightingCard {
     this.poisoned = this.poisoned?.remainingTurns ? this.poisoned : undefined;
     this.burned = this.burned?.remainingTurns ? this.burned : undefined;
 
-    // remove undefined states results
     return stateResults.filter((result) => result !== undefined);
   }
 


### PR DESCRIPTION
The comment '// remove undefined states results' at line 307 was
misleading and the code is self-explanatory without it.

Closes #84

https://claude.ai/code/session_01SGh2vRi14vYjM6mky7wSBZ