### PR TITLE
feat: add powerId to Debuff type for parity with Buff

### DIFF
--- a/src/fight/core/cards/@types/buff/debuff.ts
+++ b/src/fight/core/cards/@types/buff/debuff.ts
@@ -4,4 +4,5 @@ export type Debuff = {
   type: DebuffType;
   value: number;
   duration: number;
+  powerId?: string;
 };

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -465,11 +465,13 @@ export class FightingCard {
     debuffType: DebuffType,
     debuffRate: number,
     duration: number,
+    powerId?: string,
   ): Debuff {
     const debuff: Debuff = {
       type: debuffType,
       value: this.computeAttributeModifierValue(debuffType, debuffRate),
       duration: duration,
+      powerId,
     };
 
     this.debuffs.push(debuff);

--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -99,6 +99,7 @@ export class AlterationSkill implements Skill {
               this.attributeType,
               this.rate,
               this.duration,
+              this.powerId,
             ),
           }));
 


### PR DESCRIPTION
Closes #59 — Buff had optional powerId but Debuff did not.
Added powerId to the Debuff type, applyDebuff() signature, and
AlterationSkill so composite power identity flows through debuffs.

https://claude.ai/code/session_019DJnRu6vg8c3U58Ujugp1p