### PR TITLE
fix: guard against empty debuff steps in TurnManager and DeathSkillHandler

### DIFF
--- a/src/fight/core/fight-simulator/__tests__/death-skill-handler.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/death-skill-handler.spec.ts
@@ -6,6 +6,7 @@ import { DamageComposition } from '../../cards/@types/damage/damage-composition'
 import { DamageType } from '../../cards/@types/damage/damage-type';
 import { AlterationSkill } from '../../cards/skills/alteration-skill';
 import { TurnEnd } from '../../trigger/turn-end';
+import { AllyDeath } from '../../trigger/ally-death';
 import { Launcher } from '../../targeting-card-strategies/launcher';
 import { StepKind } from '../@types/step';
 
@@ -203,6 +204,53 @@ describe('DeathSkillHandler', () => {
       );
 
       expect((buffRemovedStep as any).eventName).toBe('lions-end');
+    });
+  });
+
+  describe('when an ally-death-triggered debuff skill produces empty results', () => {
+    const deadCardId = 'warrior-02';
+    let handler: DeathSkillHandler;
+    let player1: Player;
+    let deadCard;
+
+    beforeEach(() => {
+      deadCard = createFightingCard({
+        id: deadCardId,
+        name: 'Warrior',
+        health: 10,
+        criticalChance: 0,
+      });
+
+      const survivingCard = createFightingCard({
+        id: 'debuffer-01',
+        name: 'Debuffer',
+        health: 5000,
+        criticalChance: 0,
+      });
+
+      const debuffSkill = new AlterationSkill({
+        polarity: 'debuff',
+        attributeType: 'attack',
+        rate: 0.2,
+        duration: 2,
+        trigger: new AllyDeath(deadCardId),
+        targetingStrategy: new Launcher(),
+        activationCondition: { id: 'never', evaluate: () => false },
+      });
+      (survivingCard as any).skills = [debuffSkill];
+
+      player1 = new Player('Player 1', [deadCard, survivingCard]);
+      const player2 = new Player('Player 2', [createFightingCard({})]);
+      handler = new DeathSkillHandler(player1, player2);
+
+      deadCard.addRealDamage(10);
+    });
+
+    it('does not emit a debuff step', () => {
+      handler.notifyDeath(player1, deadCard);
+      const steps = handler.drainSteps();
+
+      expect(steps.find((s) => s.kind === StepKind.Debuff)).toBeUndefined();
     });
   });
 });

--- a/src/fight/core/fight-simulator/__tests__/turn-manager-debuff-guard.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/turn-manager-debuff-guard.spec.ts
@@ -1,0 +1,53 @@
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+import { Player } from '../../player';
+import { TurnManager } from '../turn-manager';
+import { DeathSkillHandler } from '../death-skill-handler';
+import { EndEventProcessor } from '../end-event-processor';
+import { StepKind } from '../@types/step';
+import { AlterationSkill } from '../../cards/skills/alteration-skill';
+import { TurnEnd } from '../../trigger/turn-end';
+import { Launcher } from '../../targeting-card-strategies/launcher';
+
+describe('TurnManager debuff guard', () => {
+  describe('when a debuff skill produces empty results', () => {
+    let card: ReturnType<typeof createFightingCard>;
+    let turnManager: TurnManager;
+
+    beforeEach(() => {
+      card = createFightingCard({ id: 'card-1', attack: 100, health: 5000 });
+
+      const debuffSkill = new AlterationSkill({
+        polarity: 'debuff',
+        attributeType: 'attack',
+        rate: 0.2,
+        duration: 2,
+        trigger: new TurnEnd(),
+        targetingStrategy: new Launcher(),
+        activationCondition: { id: 'never', evaluate: () => false },
+      });
+      (card as any).skills = [debuffSkill];
+
+      const player1 = new Player('p1', [card]);
+      const player2 = new Player('p2', [createFightingCard()]);
+      const endEventProcessor = new EndEventProcessor(player1, player2);
+      const deathSkillHandler = new DeathSkillHandler(
+        player1,
+        player2,
+        endEventProcessor,
+      );
+      turnManager = new TurnManager(
+        player1,
+        player2,
+        { onCardDeath: [deathSkillHandler] },
+        deathSkillHandler,
+        endEventProcessor,
+      );
+    });
+
+    it('does not emit a debuff step', () => {
+      const steps = turnManager.endTurn([card]);
+
+      expect(steps.find((s) => s.kind === StepKind.Debuff)).toBeUndefined();
+    });
+  });
+});

--- a/src/fight/core/fight-simulator/death-skill-handler.ts
+++ b/src/fight/core/fight-simulator/death-skill-handler.ts
@@ -147,18 +147,20 @@ export class DeathSkillHandler implements CardDeathSubscriber {
 
       if (skillResult.skillKind === SkillKind.Debuff) {
         const debuffResults = skillResult.results as DebuffResults;
-        this.steps.push({
-          kind: StepKind.Debuff,
-          source: card.identityInfo,
-          debuffs: debuffResults.map((result: DebuffResult) => ({
-            target: result.target,
-            kind: result.debuff.type,
-            value: result.debuff.value,
-            remainingTurns: result.debuff.duration,
-          })),
-          energy: card.actualEnergy,
-          powerId: skillResult.powerId,
-        });
+        if (debuffResults.length > 0) {
+          this.steps.push({
+            kind: StepKind.Debuff,
+            source: card.identityInfo,
+            debuffs: debuffResults.map((result: DebuffResult) => ({
+              target: result.target,
+              kind: result.debuff.type,
+              value: result.debuff.value,
+              remainingTurns: result.debuff.duration,
+            })),
+            energy: card.actualEnergy,
+            powerId: skillResult.powerId,
+          });
+        }
       }
 
       if (skillResult.skillKind === SkillKind.TargetingOverride) {

--- a/src/fight/core/fight-simulator/turn-manager.ts
+++ b/src/fight/core/fight-simulator/turn-manager.ts
@@ -106,18 +106,20 @@ export class TurnManager {
 
       if (appliedSkill.skillKind === SkillKind.Debuff) {
         const debuffResults = appliedSkill.results as DebuffResults;
-        steps.push({
-          kind: StepKind.Debuff,
-          source: card.identityInfo,
-          debuffs: debuffResults.map((result: DebuffResult) => ({
-            target: result.target,
-            kind: result.debuff.type,
-            value: result.debuff.value,
-            remainingTurns: result.debuff.duration,
-          })),
-          energy: card.actualEnergy,
-          powerId: appliedSkill.powerId,
-        });
+        if (debuffResults.length > 0) {
+          steps.push({
+            kind: StepKind.Debuff,
+            source: card.identityInfo,
+            debuffs: debuffResults.map((result: DebuffResult) => ({
+              target: result.target,
+              kind: result.debuff.type,
+              value: result.debuff.value,
+              remainingTurns: result.debuff.duration,
+            })),
+            energy: card.actualEnergy,
+            powerId: appliedSkill.powerId,
+          });
+        }
       }
 
       if (appliedSkill.skillKind === SkillKind.TargetingOverride) {


### PR DESCRIPTION
Add missing `debuffResults.length > 0` guard before pushing debuff steps,
mirroring the existing guard already present for buff results. Without this
guard, an empty debuff step (with `debuffs: []`) was emitted whenever a
debuff skill returned no targets.

Closes #57