### PR TITLE
Add validation for unknown special card kinds

### DIFF
--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -56,7 +56,7 @@ function makeCard(special: Special): FightingCard {
 
 describe('ActionStage', () => {
   describe('launchSpecial', () => {
-    it('throws when special kind is unknown', () => {
+    describe('when launching an unknown special kind', () => {
       const attacker = makeCard(new UnknownSpecial());
       const defender = makeCard(new SpecialAttack(1, 999, POSITION_BASED));
       const player1 = new Player('Player 1', [attacker]);
@@ -65,9 +65,11 @@ describe('ActionStage', () => {
         onCardDeath: [],
       });
 
-      expect(() => actionStage.computeNextAction([attacker])).toThrow(
-        'Unknown special kind: unknownKind',
-      );
+      it('throws', () => {
+        expect(() => actionStage.computeNextAction([attacker])).toThrow(
+          'Unknown special kind: unknownKind',
+        );
+      });
     });
   });
 });

--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -1,0 +1,73 @@
+import { faker } from '@faker-js/faker';
+
+import { ActionStage } from '../action_stage';
+import { Player } from '../../player';
+import { FightingCard } from '../../cards/fighting-card';
+import { Special } from '../../cards/skills/special';
+import { SpecialAttack } from '../../cards/skills/special-attack';
+import { SimpleAttack } from '../../cards/skills/simple-attack';
+import { SimpleDodge } from '../../cards/behaviors/simple-dodge';
+import { TargetedFromPosition } from '../../targeting-card-strategies/targeted-from-position';
+import { Element } from '../../cards/@types/damage/element';
+import { DamageComposition } from '../../cards/@types/damage/damage-composition';
+import { DamageType } from '../../cards/@types/damage/damage-type';
+import { FightingContext } from '../../cards/@types/fighting-context';
+import { SpecialResult } from '../../cards/@types/action-result/special-result';
+
+class UnknownSpecial implements Special {
+  ready(): boolean {
+    return true;
+  }
+  launch(_source: FightingCard, _context: FightingContext): SpecialResult {
+    return { actionResults: [], buffResults: [] };
+  }
+  increaseEnergy(actualEnergy: number): number {
+    return actualEnergy;
+  }
+  getSpecialKind(): string {
+    return 'unknownKind';
+  }
+}
+
+const POSITION_BASED = new TargetedFromPosition();
+const SIMPLE_ATTACK = new SimpleAttack(
+  [new DamageComposition(DamageType.PHYSICAL, 1)],
+  POSITION_BASED,
+);
+
+function makeCard(special: Special): FightingCard {
+  return new FightingCard(
+    faker.string.uuid(),
+    'Card',
+    {
+      attack: 100,
+      defense: 0,
+      health: 1000,
+      speed: 100,
+      agility: 0,
+      accuracy: 9999,
+      criticalChance: 0,
+    },
+    { simpleAttack: SIMPLE_ATTACK, special, others: [] },
+    { dodge: new SimpleDodge() },
+    Element.PHYSICAL,
+  );
+}
+
+describe('ActionStage', () => {
+  describe('launchSpecial', () => {
+    it('throws when special kind is unknown', () => {
+      const attacker = makeCard(new UnknownSpecial());
+      const defender = makeCard(new SpecialAttack(1, 999, POSITION_BASED));
+      const player1 = new Player('Player 1', [attacker]);
+      const player2 = new Player('Player 2', [defender]);
+      const actionStage = new ActionStage(player1, player2, {
+        onCardDeath: [],
+      });
+
+      expect(() => actionStage.computeNextAction([attacker])).toThrow(
+        'Unknown special kind: unknownKind',
+      );
+    });
+  });
+});

--- a/src/fight/core/card-action/action_stage.ts
+++ b/src/fight/core/card-action/action_stage.ts
@@ -112,7 +112,11 @@ export class ActionStage {
       return this.computeSpecialAttackResult(card);
     }
 
-    return this.computeSpecialHealingResult(card);
+    if (card.specialKind() === 'specialHealing') {
+      return this.computeSpecialHealingResult(card);
+    }
+
+    throw new Error(`Unknown special kind: ${card.specialKind()}`);
   }
 
   private computeSpecialAttackResult(card: FightingCard): AttackReport {


### PR DESCRIPTION
## Summary
Added explicit error handling in the `ActionStage.launchSpecial()` method to throw an error when an unknown special card kind is encountered, along with comprehensive test coverage.

## Key Changes
- Modified `ActionStage.launchSpecial()` to explicitly check for 'specialHealing' kind before falling back to error handling
- Added error throwing for unknown special kinds with a descriptive error message
- Added test suite for `ActionStage` with a test case verifying that unknown special kinds throw the expected error

## Implementation Details
The change improves robustness by replacing an implicit fallback behavior with explicit validation. Previously, any unknown special kind would silently fall through to `computeSpecialHealingResult()`. Now, only explicitly recognized special kinds ('specialAttack' and 'specialHealing') are handled, and any other kind will throw an error with the format: `Unknown special kind: {kind}`.

This makes it easier to catch configuration errors or missing special kind implementations during development and testing.

https://claude.ai/code/session_01SJo8zFffEXijrjtCyZr54g

resolves: #58 