### PR TITLE
Extract skill results conversion logic into reusable function

### DIFF
--- a/src/fight/core/fight-simulator/death-skill-handler.ts
+++ b/src/fight/core/fight-simulator/death-skill-handler.ts
@@ -1,19 +1,11 @@
 import { FightingCard } from '../cards/fighting-card';
 import { Player } from '../player';
 import { CardDeathSubscriber } from './card-death-subscriber';
-import { Step, StepKind } from './@types/step';
-import {
-  BuffResult,
-  BuffResults,
-} from '../cards/@types/action-result/buff-results';
-import {
-  DebuffResult,
-  DebuffResults,
-} from '../cards/@types/action-result/debuff-results';
-import { SkillKind, SkillResults } from '../cards/skills/skill';
+import { Step } from './@types/step';
+import { SkillResults } from '../cards/skills/skill';
 import { EndEventProcessor } from './end-event-processor';
-import { TargetingOverrideReport } from './@types/targeting-override-report';
 import { FightingContext } from '../cards/@types/fighting-context';
+import { skillResultsToSteps } from './skill-results-to-steps';
 
 export class DeathSkillHandler implements CardDeathSubscriber {
   private steps: Step[] = [];
@@ -102,72 +94,8 @@ export class DeathSkillHandler implements CardDeathSubscriber {
     card: FightingCard,
     skillResults: SkillResults[],
   ): void {
-    for (const skillResult of skillResults) {
-      if (skillResult.skillKind === SkillKind.Healing) {
-        this.steps.push({
-          kind: StepKind.Healing,
-          source: card.identityInfo,
-          heal: skillResult.results.map((heal) => ({
-            target: heal.target,
-            healed: heal.healAmount,
-            remainingHealth: heal.remainingHealth,
-          })),
-          energy: card.actualEnergy,
-          powerId: skillResult.powerId,
-        });
-      }
-
-      if (skillResult.skillKind === SkillKind.Buff) {
-        const buffResults = skillResult.results as BuffResults;
-        if (buffResults.length > 0) {
-          this.steps.push({
-            kind: StepKind.Buff,
-            source: card.identityInfo,
-            buffs: buffResults.map((result: BuffResult) => ({
-              target: result.target,
-              kind: result.buff.type,
-              value: result.buff.value,
-              remainingTurns: result.buff.duration,
-            })),
-            energy: card.actualEnergy,
-            powerId: skillResult.powerId,
-          });
-        }
-
-        if (skillResult.endEvent && this.endEventProcessor) {
-          this.steps.push(
-            ...this.endEventProcessor.processEndEvent(
-              skillResult.endEvent,
-              card.identityInfo,
-              skillResult.powerId,
-            ),
-          );
-        }
-      }
-
-      if (skillResult.skillKind === SkillKind.Debuff) {
-        const debuffResults = skillResult.results as DebuffResults;
-        if (debuffResults.length > 0) {
-          this.steps.push({
-            kind: StepKind.Debuff,
-            source: card.identityInfo,
-            debuffs: debuffResults.map((result: DebuffResult) => ({
-              target: result.target,
-              kind: result.debuff.type,
-              value: result.debuff.value,
-              remainingTurns: result.debuff.duration,
-            })),
-            energy: card.actualEnergy,
-            powerId: skillResult.powerId,
-          });
-        }
-      }
-
-      if (skillResult.skillKind === SkillKind.TargetingOverride) {
-        const reports =
-          skillResult.results as unknown as TargetingOverrideReport[];
-        reports.forEach((report) => this.steps.push(report));
-      }
-    }
+    this.steps.push(
+      ...skillResultsToSteps(card, skillResults, this.endEventProcessor),
+    );
   }
 }

--- a/src/fight/core/fight-simulator/skill-results-to-steps.ts
+++ b/src/fight/core/fight-simulator/skill-results-to-steps.ts
@@ -1,0 +1,91 @@
+import {
+  BuffResult,
+  BuffResults,
+} from '../cards/@types/action-result/buff-results';
+import {
+  DebuffResult,
+  DebuffResults,
+} from '../cards/@types/action-result/debuff-results';
+import { FightingCard } from '../cards/fighting-card';
+import { SkillKind, SkillResults } from '../cards/skills/skill';
+import { Step, StepKind } from './@types/step';
+import { TargetingOverrideReport } from './@types/targeting-override-report';
+import { EndEventProcessor } from './end-event-processor';
+
+export function skillResultsToSteps(
+  card: FightingCard,
+  skillResults: SkillResults[],
+  endEventProcessor?: EndEventProcessor,
+): Step[] {
+  const steps: Step[] = [];
+
+  for (const skillResult of skillResults) {
+    if (skillResult.skillKind === SkillKind.Healing) {
+      steps.push({
+        kind: StepKind.Healing,
+        source: card.identityInfo,
+        heal: skillResult.results.map((heal) => ({
+          target: heal.target,
+          healed: heal.healAmount,
+          remainingHealth: heal.remainingHealth,
+        })),
+        energy: card.actualEnergy,
+        powerId: skillResult.powerId,
+      });
+    }
+
+    if (skillResult.skillKind === SkillKind.Buff) {
+      const buffResults = skillResult.results as BuffResults;
+      if (buffResults.length > 0) {
+        steps.push({
+          kind: StepKind.Buff,
+          source: card.identityInfo,
+          buffs: buffResults.map((result: BuffResult) => ({
+            target: result.target,
+            kind: result.buff.type,
+            value: result.buff.value,
+            remainingTurns: result.buff.duration,
+          })),
+          energy: card.actualEnergy,
+          powerId: skillResult.powerId,
+        });
+      }
+
+      if (skillResult.endEvent && endEventProcessor) {
+        steps.push(
+          ...endEventProcessor.processEndEvent(
+            skillResult.endEvent,
+            card.identityInfo,
+            skillResult.powerId,
+          ),
+        );
+      }
+    }
+
+    if (skillResult.skillKind === SkillKind.Debuff) {
+      const debuffResults = skillResult.results as DebuffResults;
+      if (debuffResults.length > 0) {
+        steps.push({
+          kind: StepKind.Debuff,
+          source: card.identityInfo,
+          debuffs: debuffResults.map((result: DebuffResult) => ({
+            target: result.target,
+            kind: result.debuff.type,
+            value: result.debuff.value,
+            remainingTurns: result.debuff.duration,
+          })),
+          energy: card.actualEnergy,
+          powerId: skillResult.powerId,
+        });
+      }
+    }
+
+    if (skillResult.skillKind === SkillKind.TargetingOverride) {
+      const reports =
+        skillResult.results as unknown as TargetingOverrideReport[];
+      reports.forEach((report) => steps.push(report));
+    }
+  }
+
+  return steps;
+}

--- a/src/fight/core/fight-simulator/turn-manager.ts
+++ b/src/fight/core/fight-simulator/turn-manager.ts
@@ -1,20 +1,11 @@
-import {
-  BuffResult,
-  BuffResults,
-} from '../cards/@types/action-result/buff-results';
-import {
-  DebuffResult,
-  DebuffResults,
-} from '../cards/@types/action-result/debuff-results';
 import { FightingContext } from '../cards/@types/fighting-context';
 import { FightingCard } from '../cards/fighting-card';
-import { SkillKind } from '../cards/skills/skill';
 import { Player } from '../player';
 import { Step, StepKind } from './@types/step';
-import { TargetingOverrideReport } from './@types/targeting-override-report';
 import { CardDeathSubscriber } from './card-death-subscriber';
 import { DeathSkillHandler } from './death-skill-handler';
 import { EndEventProcessor } from './end-event-processor';
+import { skillResultsToSteps } from './skill-results-to-steps';
 
 export class TurnManager {
   private player1: Player;
@@ -60,73 +51,9 @@ export class TurnManager {
       'turn-end',
       this.getFightingContext(card),
     );
-
-    for (const appliedSkill of appliedSkills) {
-      if (appliedSkill.skillKind === SkillKind.Healing) {
-        steps.push({
-          kind: StepKind.Healing,
-          source: card.identityInfo,
-          heal: appliedSkill.results.map((heal) => ({
-            target: heal.target,
-            healed: heal.healAmount,
-            remainingHealth: heal.remainingHealth,
-          })),
-          energy: card.actualEnergy,
-          powerId: appliedSkill.powerId,
-        });
-      }
-
-      if (appliedSkill.skillKind === SkillKind.Buff) {
-        const buffResults = appliedSkill.results as BuffResults;
-        if (buffResults.length > 0) {
-          steps.push({
-            kind: StepKind.Buff,
-            source: card.identityInfo,
-            buffs: buffResults.map((result: BuffResult) => ({
-              target: result.target,
-              kind: result.buff.type,
-              value: result.buff.value,
-              remainingTurns: result.buff.duration,
-            })),
-            energy: card.actualEnergy,
-            powerId: appliedSkill.powerId,
-          });
-        }
-
-        if (appliedSkill.endEvent) {
-          steps.push(
-            ...this.endEventProcessor.processEndEvent(
-              appliedSkill.endEvent,
-              card.identityInfo,
-              appliedSkill.powerId,
-            ),
-          );
-        }
-      }
-
-      if (appliedSkill.skillKind === SkillKind.Debuff) {
-        const debuffResults = appliedSkill.results as DebuffResults;
-        if (debuffResults.length > 0) {
-          steps.push({
-            kind: StepKind.Debuff,
-            source: card.identityInfo,
-            debuffs: debuffResults.map((result: DebuffResult) => ({
-              target: result.target,
-              kind: result.debuff.type,
-              value: result.debuff.value,
-              remainingTurns: result.debuff.duration,
-            })),
-            energy: card.actualEnergy,
-            powerId: appliedSkill.powerId,
-          });
-        }
-      }
-
-      if (appliedSkill.skillKind === SkillKind.TargetingOverride) {
-        const reports = appliedSkill.results as TargetingOverrideReport[];
-        reports.forEach((report) => steps.push(report));
-      }
-    }
+    steps.push(
+      ...skillResultsToSteps(card, appliedSkills, this.endEventProcessor),
+    );
   }
 
   private processCardEffectStates(card: FightingCard, steps: Step[]) {


### PR DESCRIPTION
## Summary
Refactored duplicated skill results-to-steps conversion logic into a standalone utility function to improve code maintainability and reduce duplication across the fight simulator.

## Key Changes
- **New file**: Created `skill-results-to-steps.ts` with a reusable `skillResultsToSteps()` function that converts `SkillResults` arrays into `Step` arrays
- **DeathSkillHandler**: Replaced 70+ lines of skill result processing logic with a single call to `skillResultsToSteps()`
- **TurnManager**: Replaced 70+ lines of skill result processing logic with a single call to `skillResultsToSteps()`
- Removed duplicate imports from both modified files that are now only needed in the new utility function

## Implementation Details
The extracted function handles conversion of all skill kinds:
- **Healing**: Maps heal results to healing steps with target, amount, and remaining health
- **Buff**: Converts buff results to buff steps with type, value, and duration
- **Debuff**: Converts debuff results to debuff steps with type, value, and duration
- **TargetingOverride**: Passes through targeting override reports as steps
- Supports optional `EndEventProcessor` for processing buff end events

This refactoring eliminates ~140 lines of duplicated code while maintaining identical behavior across both call sites.

https://claude.ai/code/session_01K8crQMBiC7F7ZMWqFLidRz

resolves: #54 