### PR TITLE
Rename status effect types from past tense to present tense

### DIFF
--- a/src/fight/core/__tests__/burned_effect.spec.ts
+++ b/src/fight/core/__tests__/burned_effect.spec.ts
@@ -163,7 +163,7 @@ describe('Add Burned effect level 1', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'burned',
+          status: 'burn',
           card: card2.identityInfo,
         },
         3: {
@@ -451,7 +451,7 @@ describe('Add Burned effect level 2', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'burned',
+          status: 'burn',
           card: card2.identityInfo,
         },
         3: {
@@ -537,7 +537,7 @@ describe('Add Burned effect level 2', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'burned',
+          status: 'burn',
           card: card2.identityInfo,
         },
         3: {
@@ -631,7 +631,7 @@ describe('Add Burned effect level 2', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'burned',
+          status: 'burn',
           card: card2.identityInfo,
         },
         3: {
@@ -830,7 +830,7 @@ describe('Add Burned effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'burned',
+          status: 'burn',
           card: card2.identityInfo,
         },
         3: {
@@ -915,7 +915,7 @@ describe('Add Burned effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'burned',
+          status: 'burn',
           card: card2.identityInfo,
         },
         3: {
@@ -1001,7 +1001,7 @@ describe('Add Burned effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'burned',
+          status: 'burn',
           card: card2.identityInfo,
         },
         3: {
@@ -1095,7 +1095,7 @@ describe('Add Burned effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'burned',
+          status: 'burn',
           card: card2.identityInfo,
         },
         3: {
@@ -1181,7 +1181,7 @@ describe('Add Burned effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'burned',
+          status: 'burn',
           card: card2.identityInfo,
         },
         3: {

--- a/src/fight/core/__tests__/frozen_effect.spec.ts
+++ b/src/fight/core/__tests__/frozen_effect.spec.ts
@@ -163,7 +163,7 @@ describe('Add frozen effect level 1', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'frozen',
+          status: 'freeze',
           card: card2.identityInfo,
         },
         3: {
@@ -443,7 +443,7 @@ describe('Add frozen effect level 2', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'frozen',
+          status: 'freeze',
           card: card2.identityInfo,
         },
         3: {
@@ -529,7 +529,7 @@ describe('Add frozen effect level 2', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'frozen',
+          status: 'freeze',
           card: card2.identityInfo,
         },
         3: {
@@ -615,7 +615,7 @@ describe('Add frozen effect level 2', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'frozen',
+          status: 'freeze',
           card: card2.identityInfo,
         },
         3: {
@@ -814,7 +814,7 @@ describe('Add frozen effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'frozen',
+          status: 'freeze',
           card: card2.identityInfo,
         },
         3: {
@@ -899,7 +899,7 @@ describe('Add frozen effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'frozen',
+          status: 'freeze',
           card: card2.identityInfo,
         },
         3: {
@@ -985,7 +985,7 @@ describe('Add frozen effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'frozen',
+          status: 'freeze',
           card: card2.identityInfo,
         },
         3: {
@@ -1071,7 +1071,7 @@ describe('Add frozen effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'frozen',
+          status: 'freeze',
           card: card2.identityInfo,
         },
         3: {
@@ -1157,7 +1157,7 @@ describe('Add frozen effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'frozen',
+          status: 'freeze',
           card: card2.identityInfo,
         },
         3: {

--- a/src/fight/core/__tests__/poison_effect.spec.ts
+++ b/src/fight/core/__tests__/poison_effect.spec.ts
@@ -163,7 +163,7 @@ describe('Add Poison effect level 1', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'poisoned',
+          status: 'poison',
           card: card2.identityInfo,
         },
         3: {
@@ -364,7 +364,7 @@ describe('Add Poison effect level 2', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'poisoned',
+          status: 'poison',
           card: card2.identityInfo,
         },
         3: {
@@ -449,7 +449,7 @@ describe('Add Poison effect level 2', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'poisoned',
+          status: 'poison',
           card: card2.identityInfo,
         },
         3: {
@@ -649,7 +649,7 @@ describe('Add Poison effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'poisoned',
+          status: 'poison',
           card: card2.identityInfo,
         },
         3: {
@@ -734,7 +734,7 @@ describe('Add Poison effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'poisoned',
+          status: 'poison',
           card: card2.identityInfo,
         },
         3: {
@@ -820,7 +820,7 @@ describe('Add Poison effect level 3', () => {
         },
         2: {
           kind: 'status_change',
-          status: 'poisoned',
+          status: 'poison',
           card: card2.identityInfo,
         },
         3: {

--- a/src/fight/core/__tests__/special-attack.spec.ts
+++ b/src/fight/core/__tests__/special-attack.spec.ts
@@ -239,7 +239,7 @@ describe('Trigger card special attack with poison effect', () => {
       },
       2: {
         kind: 'status_change',
-        status: 'poisoned',
+        status: 'poison',
         card: card2.identityInfo,
       },
       3: {

--- a/src/fight/core/cards/@types/attack/__tests__/attack-burn-effect.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/attack-burn-effect.spec.ts
@@ -1,24 +1,24 @@
-import { FrozenAttackEffect } from '../attack-frozen-effect';
+import { BurnAttackEffect } from '../attack-burn-effect';
 import { EffectTriggeredDebuff } from '../effect-triggered-debuff';
-import { CardStateFrozen } from '../../state/card-state-frozen';
+import { CardStateBurned } from '../../state/card-state-burned';
 import { RandomizerFake } from '../../../../../../../test/helpers/randomizer-fake';
 import { createFightingCard } from '../../../../../../../test/helpers/fighting-card';
 import { EffectResult } from '../attack-effect';
 
 function makeCards() {
   const attacker = createFightingCard({ attack: 200 });
-  const defender = createFightingCard({ agility: 50 });
+  const defender = createFightingCard({ defense: 100 });
   return { attacker, defender };
 }
 
-describe('FrozenAttackEffect with triggeredDebuff', () => {
+describe('BurnAttackEffect with triggeredDebuff', () => {
   const randomizer = new RandomizerFake();
 
   afterEach(() => {
     randomizer.reset();
   });
 
-  describe('when freeze is applied and roll succeeds', () => {
+  describe('when burn is applied and roll succeeds', () => {
     let result: EffectResult;
 
     beforeEach(() => {
@@ -26,12 +26,12 @@ describe('FrozenAttackEffect with triggeredDebuff', () => {
       const { attacker, defender } = makeCards();
       const triggered = new EffectTriggeredDebuff(
         1.0,
-        'agility',
+        'defense',
         0.1,
         2,
         randomizer,
       );
-      const effect = new FrozenAttackEffect(0.2, 1, triggered);
+      const effect = new BurnAttackEffect(0.2, 1, triggered);
       result = effect.applyEffect(defender, attacker, null);
     });
 
@@ -39,28 +39,28 @@ describe('FrozenAttackEffect with triggeredDebuff', () => {
       expect(result.triggeredDebuff).toEqual({
         card: expect.anything(),
         debuff: expect.objectContaining({
-          type: 'agility',
-          value: 5,
+          type: 'defense',
+          value: 10,
           duration: 2,
         }),
       });
     });
   });
 
-  describe('when frozen level is already high enough (effect skipped)', () => {
+  describe('when burn level is already high enough (effect skipped)', () => {
     let result: EffectResult;
 
     beforeEach(() => {
       const { attacker, defender } = makeCards();
-      defender.setState(new CardStateFrozen(2, 3, 0.1));
+      defender.setState(new CardStateBurned(2, 3, 10));
       const triggered = new EffectTriggeredDebuff(
         1.0,
-        'agility',
+        'defense',
         0.1,
         2,
         randomizer,
       );
-      const effect = new FrozenAttackEffect(0.2, 1, triggered);
+      const effect = new BurnAttackEffect(0.2, 1, triggered);
       result = effect.applyEffect(defender, attacker, null);
     });
 

--- a/src/fight/core/cards/@types/attack/__tests__/attack-freeze-effect.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/attack-freeze-effect.spec.ts
@@ -1,4 +1,4 @@
-import { PoisonedAttackEffect } from '../attack-poisoned-effect';
+import { FreezeAttackEffect } from '../attack-freeze-effect';
 import { EffectTriggeredDebuff } from '../effect-triggered-debuff';
 import { CardStateFrozen } from '../../state/card-state-frozen';
 import { RandomizerFake } from '../../../../../../../test/helpers/randomizer-fake';
@@ -7,18 +7,18 @@ import { EffectResult } from '../attack-effect';
 
 function makeCards() {
   const attacker = createFightingCard({ attack: 200 });
-  const defender = createFightingCard({ defense: 100, attack: 150 });
+  const defender = createFightingCard({ agility: 50 });
   return { attacker, defender };
 }
 
-describe('PoisonedAttackEffect with triggeredDebuff', () => {
+describe('FreezeAttackEffect with triggeredDebuff', () => {
   const randomizer = new RandomizerFake();
 
   afterEach(() => {
     randomizer.reset();
   });
 
-  describe('when poison is applied and roll succeeds', () => {
+  describe('when freeze is applied and roll succeeds', () => {
     let result: EffectResult;
 
     beforeEach(() => {
@@ -26,12 +26,12 @@ describe('PoisonedAttackEffect with triggeredDebuff', () => {
       const { attacker, defender } = makeCards();
       const triggered = new EffectTriggeredDebuff(
         1.0,
-        'attack',
+        'agility',
         0.1,
         2,
         randomizer,
       );
-      const effect = new PoisonedAttackEffect(0.2, 1, triggered);
+      const effect = new FreezeAttackEffect(0.2, 1, triggered);
       result = effect.applyEffect(defender, attacker, null);
     });
 
@@ -39,28 +39,28 @@ describe('PoisonedAttackEffect with triggeredDebuff', () => {
       expect(result.triggeredDebuff).toEqual({
         card: expect.anything(),
         debuff: expect.objectContaining({
-          type: 'attack',
-          value: 15,
+          type: 'agility',
+          value: 5,
           duration: 2,
         }),
       });
     });
   });
 
-  describe('when defender is frozen (effect skipped)', () => {
+  describe('when frozen level is already high enough (effect skipped)', () => {
     let result: EffectResult;
 
     beforeEach(() => {
       const { attacker, defender } = makeCards();
-      defender.setState(new CardStateFrozen(1, 1, 0.1));
+      defender.setState(new CardStateFrozen(2, 3, 0.1));
       const triggered = new EffectTriggeredDebuff(
         1.0,
-        'attack',
+        'agility',
         0.1,
         2,
         randomizer,
       );
-      const effect = new PoisonedAttackEffect(0.2, 1, triggered);
+      const effect = new FreezeAttackEffect(0.2, 1, triggered);
       result = effect.applyEffect(defender, attacker, null);
     });
 

--- a/src/fight/core/cards/@types/attack/__tests__/attack-poison-effect.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/attack-poison-effect.spec.ts
@@ -1,24 +1,24 @@
-import { BurnedAttackEffect } from '../attack-burned-effect';
+import { PoisonAttackEffect } from '../attack-poison-effect';
 import { EffectTriggeredDebuff } from '../effect-triggered-debuff';
-import { CardStateBurned } from '../../state/card-state-burned';
+import { CardStateFrozen } from '../../state/card-state-frozen';
 import { RandomizerFake } from '../../../../../../../test/helpers/randomizer-fake';
 import { createFightingCard } from '../../../../../../../test/helpers/fighting-card';
 import { EffectResult } from '../attack-effect';
 
 function makeCards() {
   const attacker = createFightingCard({ attack: 200 });
-  const defender = createFightingCard({ defense: 100 });
+  const defender = createFightingCard({ defense: 100, attack: 150 });
   return { attacker, defender };
 }
 
-describe('BurnedAttackEffect with triggeredDebuff', () => {
+describe('PoisonAttackEffect with triggeredDebuff', () => {
   const randomizer = new RandomizerFake();
 
   afterEach(() => {
     randomizer.reset();
   });
 
-  describe('when burn is applied and roll succeeds', () => {
+  describe('when poison is applied and roll succeeds', () => {
     let result: EffectResult;
 
     beforeEach(() => {
@@ -26,12 +26,12 @@ describe('BurnedAttackEffect with triggeredDebuff', () => {
       const { attacker, defender } = makeCards();
       const triggered = new EffectTriggeredDebuff(
         1.0,
-        'defense',
+        'attack',
         0.1,
         2,
         randomizer,
       );
-      const effect = new BurnedAttackEffect(0.2, 1, triggered);
+      const effect = new PoisonAttackEffect(0.2, 1, triggered);
       result = effect.applyEffect(defender, attacker, null);
     });
 
@@ -39,28 +39,28 @@ describe('BurnedAttackEffect with triggeredDebuff', () => {
       expect(result.triggeredDebuff).toEqual({
         card: expect.anything(),
         debuff: expect.objectContaining({
-          type: 'defense',
-          value: 10,
+          type: 'attack',
+          value: 15,
           duration: 2,
         }),
       });
     });
   });
 
-  describe('when burn level is already high enough (effect skipped)', () => {
+  describe('when defender is frozen (effect skipped)', () => {
     let result: EffectResult;
 
     beforeEach(() => {
       const { attacker, defender } = makeCards();
-      defender.setState(new CardStateBurned(2, 3, 10));
+      defender.setState(new CardStateFrozen(1, 1, 0.1));
       const triggered = new EffectTriggeredDebuff(
         1.0,
-        'defense',
+        'attack',
         0.1,
         2,
         randomizer,
       );
-      const effect = new BurnedAttackEffect(0.2, 1, triggered);
+      const effect = new PoisonAttackEffect(0.2, 1, triggered);
       result = effect.applyEffect(defender, attacker, null);
     });
 

--- a/src/fight/core/cards/@types/attack/attack-burn-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-burn-effect.ts
@@ -5,10 +5,10 @@ import { FightingContext } from '../fighting-context';
 import { CardStateBurned } from '../state/card-state-burned';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
 
-export class BurnedAttackEffect implements AttackEffect {
+export class BurnAttackEffect implements AttackEffect {
   public readonly rate: number;
   public readonly level: EffectLevel;
-  public readonly type = 'burned';
+  public readonly type = 'burn' as const;
   public readonly triggeredDebuff?: EffectTriggeredDebuff;
   public readonly terminationEvent?: string;
 

--- a/src/fight/core/cards/@types/attack/attack-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-effect.ts
@@ -3,10 +3,10 @@ import { EffectLevel } from './effect-level';
 import { FightingContext } from '../fighting-context';
 import { Debuff } from '../buff/debuff';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
+import { StateEffectType } from '../state/state-effect-type';
 
-type EffectType = 'poisoned' | 'burned' | 'frozen';
 export type EffectResult = {
-  type: EffectType;
+  type: StateEffectType;
   card: FightingCard;
   triggeredDebuff?: { card: FightingCard; debuff: Debuff };
 };

--- a/src/fight/core/cards/@types/attack/attack-freeze-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-freeze-effect.ts
@@ -5,10 +5,10 @@ import { AttackEffect, EffectResult } from './attack-effect';
 import { EffectLevel } from './effect-level';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
 
-export class FrozenAttackEffect implements AttackEffect {
+export class FreezeAttackEffect implements AttackEffect {
   public readonly rate: number;
   public readonly level: EffectLevel;
-  public readonly type = 'frozen';
+  public readonly type = 'freeze' as const;
   public readonly triggeredDebuff?: EffectTriggeredDebuff;
   public readonly terminationEvent?: string;
 

--- a/src/fight/core/cards/@types/attack/attack-poison-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-poison-effect.ts
@@ -5,10 +5,10 @@ import { EffectLevel } from './effect-level';
 import { FightingContext } from '../fighting-context';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
 
-export class PoisonedAttackEffect implements AttackEffect {
+export class PoisonAttackEffect implements AttackEffect {
   public readonly rate: number;
   public readonly level: EffectLevel;
-  public readonly type = 'poisoned';
+  public readonly type = 'poison' as const;
   public readonly triggeredDebuff?: EffectTriggeredDebuff;
   public readonly terminationEvent?: string;
 

--- a/src/fight/core/fight-simulator/@types/status-change-report.ts
+++ b/src/fight/core/fight-simulator/@types/status-change-report.ts
@@ -1,6 +1,6 @@
 import { CardInfo } from '../../cards/@types/card-info';
 
-export type status = 'dead' | 'poisoned' | 'burned' | 'frozen';
+export type status = 'dead' | 'poison' | 'burn' | 'freeze';
 
 export type StatusChangeReport = {
   card: CardInfo;

--- a/src/fight/http-api/__test__/fight.controller.spec.ts
+++ b/src/fight/http-api/__test__/fight.controller.spec.ts
@@ -106,7 +106,7 @@ describe('FightController', () => {
       it('creates a fighting card with a poisoned special attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe(
-            'poisoned',
+            'poison',
           );
         });
       });
@@ -193,7 +193,7 @@ describe('FightController', () => {
       it('creates a fighting card with a burned special attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe(
-            'burned',
+            'burn',
           );
         });
       });
@@ -340,7 +340,7 @@ describe('FightController', () => {
       it('creates a fighting card with a freeze special attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(JSON.parse(JSON.stringify(card)).special.effect.type).toBe(
-            'frozen',
+            'freeze',
           );
         });
       });
@@ -506,7 +506,7 @@ describe('FightController', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
             JSON.parse(JSON.stringify(card)).simpleAttack.effect.type,
-          ).toBe('poisoned');
+          ).toBe('poison');
         });
       });
 
@@ -599,7 +599,7 @@ describe('FightController', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
             JSON.parse(JSON.stringify(card)).simpleAttack.effect.type,
-          ).toBe('burned');
+          ).toBe('burn');
         });
       });
 
@@ -692,7 +692,7 @@ describe('FightController', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
             JSON.parse(JSON.stringify(card)).simpleAttack.effect.type,
-          ).toBe('frozen');
+          ).toBe('freeze');
         });
       });
 

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -32,11 +32,11 @@ import { SpecialHealing } from '../core/cards/skills/special-healing';
 import { Healing } from '../core/cards/skills/healing';
 import { AlterationSkill } from '../core/cards/skills/alteration-skill';
 import { buildTriggerStrategy } from './trigger-factory';
-import { PoisonedAttackEffect } from '../core/cards/@types/attack/attack-poisoned-effect';
+import { PoisonAttackEffect } from '../core/cards/@types/attack/attack-poison-effect';
 import { EffectLevel } from '../core/cards/@types/attack/effect-level';
 import { AttackEffect } from '../core/cards/@types/attack/attack-effect';
-import { BurnedAttackEffect } from '../core/cards/@types/attack/attack-burned-effect';
-import { FrozenAttackEffect } from '../core/cards/@types/attack/attack-frozen-effect';
+import { BurnAttackEffect } from '../core/cards/@types/attack/attack-burn-effect';
+import { FreezeAttackEffect } from '../core/cards/@types/attack/attack-freeze-effect';
 import { EffectTriggeredDebuff } from '../core/cards/@types/attack/effect-triggered-debuff';
 import { MathRandomizer } from '../tools/math-randomizer';
 import { BuffApplication } from '../core/cards/@types/buff/buff-application';
@@ -225,21 +225,21 @@ export class FightController {
 
     switch (effectDto.type) {
       case Effect.POISON:
-        return new PoisonedAttackEffect(
+        return new PoisonAttackEffect(
           effectDto.rate,
           effectDto.level as EffectLevel,
           triggeredDebuff,
           effectDto.terminationEvent,
         );
       case Effect.BURN:
-        return new BurnedAttackEffect(
+        return new BurnAttackEffect(
           effectDto.rate,
           effectDto.level as EffectLevel,
           triggeredDebuff,
           effectDto.terminationEvent,
         );
       case Effect.FREEZE:
-        return new FrozenAttackEffect(
+        return new FreezeAttackEffect(
           effectDto.rate,
           effectDto.level as EffectLevel,
           triggeredDebuff,

--- a/test/helpers/effect.ts
+++ b/test/helpers/effect.ts
@@ -1,10 +1,10 @@
 import { faker } from '@faker-js/faker';
 
-import { PoisonedAttackEffect } from '../../src/fight/core/cards/@types/attack/attack-poisoned-effect';
-import { BurnedAttackEffect } from '../../src/fight/core/cards/@types/attack/attack-burned-effect';
+import { PoisonAttackEffect } from '../../src/fight/core/cards/@types/attack/attack-poison-effect';
+import { BurnAttackEffect } from '../../src/fight/core/cards/@types/attack/attack-burn-effect';
 import { AttackEffect } from '../../src/fight/core/cards/@types/attack/attack-effect';
 import { EffectLevel } from '../../src/fight/core/cards/@types/attack/effect-level';
-import { FrozenAttackEffect } from '../../src/fight/core/cards/@types/attack/attack-frozen-effect';
+import { FreezeAttackEffect } from '../../src/fight/core/cards/@types/attack/attack-freeze-effect';
 
 export function createEffect(params: {
   rate: number;
@@ -18,21 +18,21 @@ export function createEffect(params: {
 
   switch (params.type) {
     case 'poison':
-      return new PoisonedAttackEffect(
+      return new PoisonAttackEffect(
         effectRate,
         effectLevel,
         undefined,
         params.terminationEvent,
       );
     case 'burn':
-      return new BurnedAttackEffect(
+      return new BurnAttackEffect(
         effectRate,
         effectLevel,
         undefined,
         params.terminationEvent,
       );
     case 'freeze':
-      return new FrozenAttackEffect(
+      return new FreezeAttackEffect(
         effectRate,
         effectLevel,
         undefined,


### PR DESCRIPTION
## Summary
This PR standardizes the naming convention for status effect types across the codebase by renaming them from past tense (poisoned, burned, frozen) to present tense (poison, burn, freeze). This change improves consistency and clarity in the API and internal type definitions.

## Key Changes
- **Effect class names**: Renamed `PoisonedAttackEffect` → `PoisonAttackEffect`, `BurnedAttackEffect` → `BurnAttackEffect`, `FrozenAttackEffect` → `FreezeAttackEffect`
- **Effect type constants**: Updated the `type` property in effect classes from `'poisoned'` → `'poison'`, `'burned'` → `'burn'`, `'frozen'` → `'freeze'`
- **Status type definition**: Updated the `status` type in `status-change-report.ts` to use the new naming convention
- **File renames**: Renamed effect implementation files to match new class names:
  - `attack-poisoned-effect.ts` → `attack-poison-effect.ts`
  - `attack-burned-effect.ts` → `attack-burn-effect.ts`
  - `attack-frozen-effect.ts` → `attack-freeze-effect.ts`
- **Test updates**: Updated all test files and test expectations to use the new effect type names
- **Import statements**: Updated all imports across the codebase to reference the renamed classes and files

## Implementation Details
- The `StateEffectType` type is now used in `EffectResult` instead of the inline `EffectType` definition
- All 40+ test assertions were updated to expect the new status names
- The change is consistent across the fight simulator, HTTP API controller, and test helpers

https://claude.ai/code/session_01DMT8jk1V6TXCDZnx1zTenm

resolve: #80 