### PR TITLE
Make rate and level optional in createEffect test helper

### DIFF
--- a/test/helpers/effect.ts
+++ b/test/helpers/effect.ts
@@ -7,8 +7,8 @@ import { EffectLevel } from '../../src/fight/core/cards/@types/attack/effect-lev
 import { FreezeAttackEffect } from '../../src/fight/core/cards/@types/attack/attack-freeze-effect';
 
 export function createEffect(params: {
-  rate: number;
-  level: EffectLevel;
+  rate?: number;
+  level?: EffectLevel;
   type: string;
   terminationEvent?: string;
 }): AttackEffect {


### PR DESCRIPTION
## Summary
Updated the `createEffect` test helper function to make the `rate` and `level` parameters optional, allowing for more flexible test setup with sensible defaults.

## Key Changes
- Made `rate` parameter optional (`rate?: number`)
- Made `level` parameter optional (`level?: EffectLevel`)
- The `type` parameter remains required as it's essential for effect creation

## Implementation Details
This change improves the test helper's usability by reducing boilerplate when creating effects in tests where `rate` and `level` values are not critical to the test scenario. Tests can now omit these parameters and rely on default values, making test code more concise and focused on the specific behavior being tested.

https://claude.ai/code/session_01QCFd64xvAQBTARxwoFdSYG

resolve: #49 