### PR TITLE
Type createOtherSkill parameter with OtherSkillDto

### DIFF
--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -264,7 +264,7 @@ export class FightController {
     );
   }
 
-  private createOtherSkill(skillData: any): Skill {
+  private createOtherSkill(skillData: OtherSkillDto): Skill {
     switch (skillData.kind) {
       case SkillKind.HEALING:
         return new Healing(


### PR DESCRIPTION
## Summary
Improved type safety in the FightController by replacing a generic `any` type with the specific `OtherSkillDto` type for the `createOtherSkill` method parameter.

## Key Changes
- Changed `createOtherSkill(skillData: any)` parameter type to `createOtherSkill(skillData: OtherSkillDto)`
- Enables better IDE support and compile-time type checking for skill data validation
- Reduces potential runtime errors by enforcing the correct data structure at the type level

## Implementation Details
This change improves code maintainability by making the expected input structure explicit, allowing TypeScript to catch type mismatches during development rather than at runtime.

https://claude.ai/code/session_01LHhpbUznbC3ahYTVqd79C4