### PR TITLE
Fix endEvent processing scope in skill results handler

### DIFF
--- a/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-end-event.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-end-event.spec.ts
@@ -1,0 +1,59 @@
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+import { Player } from '../../player';
+import { TurnManager } from '../turn-manager';
+import { DeathSkillHandler } from '../death-skill-handler';
+import { EndEventProcessor } from '../end-event-processor';
+import { StepKind } from '../@types/step';
+import { AlterationSkill } from '../../cards/skills/alteration-skill';
+import { TurnEnd } from '../../trigger/turn-end';
+import { Launcher } from '../../targeting-card-strategies/launcher';
+
+describe('skillResultsToSteps: endEvent on non-Buff skills', () => {
+  describe('when a debuff skill exhausts and emits endEvent', () => {
+    let buffedCard: ReturnType<typeof createFightingCard>;
+    let debuffingCard: ReturnType<typeof createFightingCard>;
+    let turnManager: TurnManager;
+
+    beforeEach(() => {
+      debuffingCard = createFightingCard({ id: 'debuffer', health: 5000 });
+      buffedCard = createFightingCard({ id: 'ally', health: 5000 });
+
+      const debuffSkill = new AlterationSkill({
+        polarity: 'debuff',
+        attributeType: 'attack',
+        rate: 0.2,
+        duration: 1,
+        trigger: new TurnEnd(),
+        targetingStrategy: new Launcher(),
+        activationLimit: 1,
+        endEvent: 'debuff-lifecycle-end',
+      });
+      (debuffingCard as any).skills = [debuffSkill];
+
+      // Give buffedCard an event-bound buff that should be removed on 'debuff-lifecycle-end'
+      buffedCard.applyBuff('attack', 0.5, Infinity, 'debuff-lifecycle-end');
+
+      const player1 = new Player('p1', [debuffingCard, buffedCard]);
+      const player2 = new Player('p2', [createFightingCard()]);
+      const endEventProcessor = new EndEventProcessor(player1, player2);
+      const deathSkillHandler = new DeathSkillHandler(
+        player1,
+        player2,
+        endEventProcessor,
+      );
+      turnManager = new TurnManager(
+        player1,
+        player2,
+        { onCardDeath: [deathSkillHandler] },
+        deathSkillHandler,
+        endEventProcessor,
+      );
+    });
+
+    it('emits a BuffRemoved step when the debuff skill lifecycle ends', () => {
+      const steps = turnManager.endTurn([debuffingCard]);
+
+      expect(steps.some((s) => s.kind === StepKind.BuffRemoved)).toBe(true);
+    });
+  });
+});

--- a/src/fight/core/fight-simulator/skill-results-to-steps.ts
+++ b/src/fight/core/fight-simulator/skill-results-to-steps.ts
@@ -50,16 +50,16 @@ export function skillResultsToSteps(
           powerId: skillResult.powerId,
         });
       }
+    }
 
-      if (skillResult.endEvent && endEventProcessor) {
-        steps.push(
-          ...endEventProcessor.processEndEvent(
-            skillResult.endEvent,
-            card.identityInfo,
-            skillResult.powerId,
-          ),
-        );
-      }
+    if (skillResult.endEvent && endEventProcessor) {
+      steps.push(
+        ...endEventProcessor.processEndEvent(
+          skillResult.endEvent,
+          card.identityInfo,
+          skillResult.powerId,
+        ),
+      );
     }
 
     if (skillResult.skillKind === SkillKind.Debuff) {


### PR DESCRIPTION
## Summary
Fixed a scoping issue in the skill results to steps converter where `endEvent` processing was incorrectly nested inside the buff skill condition block, preventing non-buff skills from emitting end events.

## Key Changes
- Moved `endEvent` processing outside of the buff skill conditional block in `skillResultsToSteps()` function
- This allows debuff and other non-buff skills to properly emit and process their end events
- Added comprehensive test coverage for debuff skill lifecycle end events

## Implementation Details
The `endEvent` processing logic was previously indented as part of the buff skill handling block (inside the `if (skillResult.skillKind === SkillKind.Buff)` condition). By moving it to the same indentation level as the buff block, end events are now processed for all skill types, not just buffs. This enables skills like debuffs to trigger lifecycle end events that can remove associated buffs or trigger other cleanup logic.

The test case demonstrates the fix by verifying that when a debuff skill with an `endEvent` exhausts, it properly emits a `BuffRemoved` step for any buffs bound to that event.

https://claude.ai/code/session_01UQtTHqWEu22AoPesbvg26r

closes: #60 