### PR TITLE
Improve type safety with discriminated union types for SkillResults

### DIFF
--- a/src/fight/core/card-action/action_stage.ts
+++ b/src/fight/core/card-action/action_stage.ts
@@ -9,7 +9,7 @@ import { HealingReport } from '../fight-simulator/@types/healing-report';
 import { HealingResult } from '../cards/@types/action-result/healing-result';
 import { FightingContext } from '../cards/@types/fighting-context';
 import { BuffReport } from '../fight-simulator/@types/buff-report';
-import { SkillKind } from '../cards/skills/skill';
+import { AttackSkillResults, SkillKind } from '../cards/skills/skill';
 
 type SplittedSteps = {
   actionSteps: Step[];
@@ -84,7 +84,7 @@ export class ActionStage {
     const context = this.getFightingContext(card);
     const skillResults = card.launchSkills('next-action', context);
     const attackSkill = skillResults.find(
-      (r) => r.skillKind === SkillKind.Attack,
+      (r): r is AttackSkillResults => r.skillKind === SkillKind.Attack,
     );
     if (!attackSkill) return null;
 
@@ -98,11 +98,7 @@ export class ActionStage {
       statusChanges: [],
     };
 
-    this.handleAttackResult(
-      attackSkill.results as AttackResult[],
-      result,
-      card,
-    );
+    this.handleAttackResult(attackSkill.results, result, card);
 
     return result;
   }

--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -68,11 +68,9 @@ export class AlterationSkill implements Skill {
       this.activationCondition &&
       !this.activationCondition.evaluate(source, context)
     ) {
-      return {
-        skillKind: this.resolveSkillKind(),
-        results: [],
-        powerId: this.powerId,
-      };
+      return this.polarity === 'buff'
+        ? { skillKind: SkillKind.Buff, results: [], powerId: this.powerId }
+        : { skillKind: SkillKind.Debuff, results: [], powerId: this.powerId };
     }
 
     const targetedCards = this.targetingStrategy.targetedCards(
@@ -81,40 +79,37 @@ export class AlterationSkill implements Skill {
       context.opponentPlayer,
     );
 
-    const results =
-      this.polarity === 'buff'
-        ? targetedCards.map((targetedCard) => ({
-            target: targetedCard.identityInfo,
-            buff: targetedCard.applyBuff(
-              this.attributeType,
-              this.rate,
-              this.duration,
-              this.terminationEvent,
-              this.powerId,
-            ),
-          }))
-        : targetedCards.map((targetedCard) => ({
-            target: targetedCard.identityInfo,
-            debuff: targetedCard.applyDebuff(
-              this.attributeType,
-              this.rate,
-              this.duration,
-              this.powerId,
-            ),
-          }));
-
     this.activationCount++;
 
     const isExhausted =
       this.activationLimit !== undefined &&
       this.activationCount >= this.activationLimit;
+    const endEvent = isExhausted ? this.endEvent : undefined;
 
-    return {
-      skillKind: this.resolveSkillKind(),
-      results,
-      endEvent: isExhausted ? this.endEvent : undefined,
-      powerId: this.powerId,
-    };
+    if (this.polarity === 'buff') {
+      const results = targetedCards.map((targetedCard) => ({
+        target: targetedCard.identityInfo,
+        buff: targetedCard.applyBuff(
+          this.attributeType,
+          this.rate,
+          this.duration,
+          this.terminationEvent,
+          this.powerId,
+        ),
+      }));
+      return { skillKind: SkillKind.Buff, results, endEvent, powerId: this.powerId };
+    }
+
+    const results = targetedCards.map((targetedCard) => ({
+      target: targetedCard.identityInfo,
+      debuff: targetedCard.applyDebuff(
+        this.attributeType,
+        this.rate,
+        this.duration,
+        this.powerId,
+      ),
+    }));
+    return { skillKind: SkillKind.Debuff, results, endEvent, powerId: this.powerId };
   }
 
   isTriggered(triggerName: string, context?: FightingContext): boolean {
@@ -125,10 +120,6 @@ export class AlterationSkill implements Skill {
   lifecycleEndEvent(): string | undefined {
     if (this.isExhausted()) return undefined;
     return this.endEvent;
-  }
-
-  private resolveSkillKind(): SkillKind {
-    return this.polarity === 'buff' ? SkillKind.Buff : SkillKind.Debuff;
   }
 
   private isExhausted(): boolean {

--- a/src/fight/core/cards/skills/skill.ts
+++ b/src/fight/core/cards/skills/skill.ts
@@ -14,17 +14,42 @@ export enum SkillKind {
   TargetingOverride = 'targeting_override',
 }
 
-export type SkillResults = {
-  skillKind: SkillKind;
-  results:
-    | HealingResults
-    | BuffResults
-    | DebuffResults
-    | AttackResult[]
-    | TargetingOverrideReport[];
+type BaseSkillResults = {
   endEvent?: string;
   powerId?: string;
 };
+
+export type HealingSkillResults = BaseSkillResults & {
+  skillKind: SkillKind.Healing;
+  results: HealingResults;
+};
+
+export type BuffSkillResults = BaseSkillResults & {
+  skillKind: SkillKind.Buff;
+  results: BuffResults;
+};
+
+export type DebuffSkillResults = BaseSkillResults & {
+  skillKind: SkillKind.Debuff;
+  results: DebuffResults;
+};
+
+export type AttackSkillResults = BaseSkillResults & {
+  skillKind: SkillKind.Attack;
+  results: AttackResult[];
+};
+
+export type TargetingOverrideSkillResults = BaseSkillResults & {
+  skillKind: SkillKind.TargetingOverride;
+  results: TargetingOverrideReport[];
+};
+
+export type SkillResults =
+  | HealingSkillResults
+  | BuffSkillResults
+  | DebuffSkillResults
+  | AttackSkillResults
+  | TargetingOverrideSkillResults;
 
 export interface Skill {
   id: string;

--- a/src/fight/core/fight-simulator/skill-results-to-steps.ts
+++ b/src/fight/core/fight-simulator/skill-results-to-steps.ts
@@ -1,15 +1,6 @@
-import {
-  BuffResult,
-  BuffResults,
-} from '../cards/@types/action-result/buff-results';
-import {
-  DebuffResult,
-  DebuffResults,
-} from '../cards/@types/action-result/debuff-results';
 import { FightingCard } from '../cards/fighting-card';
 import { SkillKind, SkillResults } from '../cards/skills/skill';
 import { Step, StepKind } from './@types/step';
-import { TargetingOverrideReport } from './@types/targeting-override-report';
 import { EndEventProcessor } from './end-event-processor';
 
 export function skillResultsToSteps(
@@ -35,12 +26,11 @@ export function skillResultsToSteps(
     }
 
     if (skillResult.skillKind === SkillKind.Buff) {
-      const buffResults = skillResult.results as BuffResults;
-      if (buffResults.length > 0) {
+      if (skillResult.results.length > 0) {
         steps.push({
           kind: StepKind.Buff,
           source: card.identityInfo,
-          buffs: buffResults.map((result: BuffResult) => ({
+          buffs: skillResult.results.map((result) => ({
             target: result.target,
             kind: result.buff.type,
             value: result.buff.value,
@@ -63,12 +53,11 @@ export function skillResultsToSteps(
     }
 
     if (skillResult.skillKind === SkillKind.Debuff) {
-      const debuffResults = skillResult.results as DebuffResults;
-      if (debuffResults.length > 0) {
+      if (skillResult.results.length > 0) {
         steps.push({
           kind: StepKind.Debuff,
           source: card.identityInfo,
-          debuffs: debuffResults.map((result: DebuffResult) => ({
+          debuffs: skillResult.results.map((result) => ({
             target: result.target,
             kind: result.debuff.type,
             value: result.debuff.value,
@@ -81,9 +70,7 @@ export function skillResultsToSteps(
     }
 
     if (skillResult.skillKind === SkillKind.TargetingOverride) {
-      const reports =
-        skillResult.results as unknown as TargetingOverrideReport[];
-      reports.forEach((report) => steps.push(report));
+      skillResult.results.forEach((report) => steps.push(report));
     }
   }
 


### PR DESCRIPTION
## Summary
This PR refactors the `SkillResults` type system to use discriminated unions, improving type safety and eliminating the need for runtime type casting throughout the codebase.

## Key Changes

- **Refactored SkillResults type hierarchy**: Converted the generic `SkillResults` type into a discriminated union with specific types for each skill kind (`HealingSkillResults`, `BuffSkillResults`, `DebuffSkillResults`, `AttackSkillResults`, `TargetingOverrideSkillResults`). Each type now correctly associates `skillKind` with its corresponding `results` type.

- **Removed manual type casting**: Eliminated unnecessary `as` type assertions in `skill-results-to-steps.ts` by leveraging TypeScript's type narrowing with discriminated unions. The compiler now automatically infers the correct result type based on the `skillKind` check.

- **Simplified AlterationSkill implementation**: 
  - Removed the `resolveSkillKind()` helper method and inlined the polarity check
  - Refactored the early return condition to directly return typed results
  - Split the main return logic into separate buff/debuff branches for better clarity

- **Improved type guard in ActionStage**: Added a type predicate to the `find()` call to properly narrow `AttackSkillResults`, eliminating the need for a subsequent type cast.

## Benefits
- **Type safety**: The compiler now prevents mismatches between `skillKind` and `results` types
- **Reduced boilerplate**: Eliminates repetitive type casting throughout the codebase
- **Better maintainability**: Changes to skill result types are now enforced at compile time
- **Clearer intent**: The code structure better reflects the relationship between skill kinds and their result types

https://claude.ai/code/session_01LKc77dupxWbY313LZX2goo