### PR TITLE
Add JSDoc documentation and improve code formatting

### DIFF
--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -97,7 +97,12 @@ export class AlterationSkill implements Skill {
           this.powerId,
         ),
       }));
-      return { skillKind: SkillKind.Buff, results, endEvent, powerId: this.powerId };
+      return {
+        skillKind: SkillKind.Buff,
+        results,
+        endEvent,
+        powerId: this.powerId,
+      };
     }
 
     const results = targetedCards.map((targetedCard) => ({
@@ -109,7 +114,12 @@ export class AlterationSkill implements Skill {
         this.powerId,
       ),
     }));
-    return { skillKind: SkillKind.Debuff, results, endEvent, powerId: this.powerId };
+    return {
+      skillKind: SkillKind.Debuff,
+      results,
+      endEvent,
+      powerId: this.powerId,
+    };
   }
 
   isTriggered(triggerName: string, context?: FightingContext): boolean {

--- a/src/fight/core/cards/skills/attack-skill.ts
+++ b/src/fight/core/cards/skills/attack-skill.ts
@@ -5,7 +5,28 @@ import { TargetingCardStrategy } from '../../targeting-card-strategies/targeting
 
 export interface AttackSkill {
   targetingId: string;
+
+  /**
+   * Executes the attack using the skill's own internally-configured targeting strategy.
+   * This is the default attack path, used when no targeting override is active on the card.
+   *
+   * @param card - The attacking card
+   * @param context - The current fighting context (source and opponent players)
+   * @returns Array of attack results, one per targeted defender
+   */
   launch(card: FightingCard, context: FightingContext): AttackResult[];
+
+  /**
+   * Executes the attack using an externally-supplied targeting strategy, bypassing
+   * the skill's own default strategy. Called when a targeting override is active on
+   * the card (e.g. from a `TARGETING_OVERRIDE` skill), allowing the card's attack
+   * target selection to be changed dynamically mid-battle.
+   *
+   * @param card - The attacking card
+   * @param context - The current fighting context (source and opponent players)
+   * @param targetingStrategy - The override strategy to use instead of the skill's default
+   * @returns Array of attack results, one per targeted defender
+   */
   launchWithTargeting(
     card: FightingCard,
     context: FightingContext,


### PR DESCRIPTION
## Summary
This PR adds comprehensive JSDoc documentation to the `AttackSkill` interface and improves code formatting consistency in the `AlterationSkill` class.

## Key Changes
- **AttackSkill interface documentation**: Added detailed JSDoc comments for both `launch()` and `launchWithTargeting()` methods, explaining their purposes, parameters, and return values
  - `launch()`: Documents the default attack path using the skill's internal targeting strategy
  - `launchWithTargeting()`: Documents the override path for externally-supplied targeting strategies (e.g., from `TARGETING_OVERRIDE` skills)
  
- **AlterationSkill formatting**: Improved code formatting by expanding object literals across multiple lines for better readability in two return statements (lines 100 and 117)

## Notable Details
The documentation clarifies the distinction between the two attack execution paths, particularly highlighting how `launchWithTargeting()` enables dynamic target selection changes during battle through targeting overrides.

https://claude.ai/code/session_01Gr8iTwBe6k8mngyjLP3B6Z

closes: #72 