### PR TITLE
Refactor: Extract identityInfo to variable in state removal

### DIFF
--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -414,19 +414,20 @@ export class FightingCard {
     eventName: string,
   ): { type: StateEffectType; card: CardInfo }[] {
     const removed: { type: StateEffectType; card: CardInfo }[] = [];
+    const card = this.identityInfo;
 
     if (this.poisoned?.terminationEvent === eventName) {
-      removed.push({ type: this.poisoned.type, card: this.identityInfo });
+      removed.push({ type: this.poisoned.type, card });
       this.poisoned = undefined;
     }
 
     if (this.burned?.terminationEvent === eventName) {
-      removed.push({ type: this.burned.type, card: this.identityInfo });
+      removed.push({ type: this.burned.type, card });
       this.burned = undefined;
     }
 
     if (this.frozen?.terminationEvent === eventName) {
-      removed.push({ type: this.frozen.type, card: this.identityInfo });
+      removed.push({ type: this.frozen.type, card });
       this.frozen = undefined;
     }
 


### PR DESCRIPTION
## Summary
This change refactors the `removeStateEffectsByEvent` method in the `FightingCard` class to improve code maintainability by extracting a repeated property access into a local variable.

## Key Changes
- Extracted `this.identityInfo` into a local `card` variable at the beginning of the method
- Updated all three state effect removal blocks (poisoned, burned, frozen) to use the `card` variable instead of repeatedly accessing `this.identityInfo`

## Implementation Details
This is a minor refactoring that reduces code duplication and improves readability. The change has no functional impact on the behavior of the method—it simply eliminates the redundant property access pattern that was repeated three times within the same method.

https://claude.ai/code/session_01LnRyBpdKAdFzgsRXh8N9oC