### PR TITLE
Add comprehensive JSDoc documentation to EndEventProcessor

### DIFF
--- a/src/fight/core/fight-simulator/end-event-processor.ts
+++ b/src/fight/core/fight-simulator/end-event-processor.ts
@@ -8,6 +8,20 @@ export class EndEventProcessor {
     private readonly player2: Player,
   ) {}
 
+  /**
+   * Processes an end event across all living cards in three sweeps:
+   * 1. **Buff removal** – removes all buffs whose `terminationEvent` matches `eventName`
+   *    and emits a single `buff_removed` step listing every removed buff.
+   * 2. **Effect removal** – removes all status effects (poison, burn, freeze) whose
+   *    `terminationEvent` matches `eventName` and emits a single `effect_removed` step.
+   * 3. **Targeting revert** – restores any targeting overrides whose `terminationEvent`
+   *    matches `eventName` and emits one `targeting_reverted` step per reverted override.
+   *
+   * @param eventName - The end-event name to match against bound buffs, effects, and targeting overrides.
+   * @param source - Identity of the card whose skill emitted the end event.
+   * @param powerId - Optional composite-power identifier forwarded to each emitted step.
+   * @returns Ordered list of steps produced by the three sweeps (may be empty).
+   */
   public processEndEvent(
     eventName: string,
     source: CardInfo,


### PR DESCRIPTION
## Summary
Added detailed JSDoc documentation to the `processEndEvent` method in `EndEventProcessor` to clarify its behavior and parameters.

## Key Changes
- Added comprehensive JSDoc block documenting the three-sweep processing algorithm:
  - **Buff removal** – removes buffs matching the termination event and emits a single `buff_removed` step
  - **Effect removal** – removes status effects (poison, burn, freeze) matching the termination event and emits a single `effect_removed` step
  - **Targeting revert** – restores targeting overrides matching the termination event and emits one `targeting_reverted` step per override
- Documented all method parameters (`eventName`, `source`, `powerId`) with clear descriptions
- Documented the return value as an ordered list of steps produced by the three sweeps

## Implementation Details
The documentation clarifies that the method processes end events across all living cards in a specific three-phase sequence, with each phase producing distinct step types. This helps developers understand the execution order and expected output structure when using this method.

https://claude.ai/code/session_01JDubkXqUeS23sqRRsRyHir

closes: #71 