### PR TITLE
Add error handling for unknown attribute types in buff/debuff

### DIFF
--- a/src/fight/core/cards/__tests__/fighting-card.spec.ts
+++ b/src/fight/core/cards/__tests__/fighting-card.spec.ts
@@ -4,6 +4,36 @@ import { Launcher } from '../../targeting-card-strategies/launcher';
 import { AlterationSkill } from '../skills/alteration-skill';
 import { Player } from '../../player';
 
+describe('FightingCard.computeAttributeModifierValue()', () => {
+  describe('when an unknown buff/debuff type is provided', () => {
+    it('throws an error for unknown type in applyBuff', () => {
+      const card = createFightingCard({
+        attack: 100,
+        defense: 0,
+        accuracy: 0,
+        agility: 0,
+      });
+
+      expect(() => card.applyBuff('unknown' as any, 0.1, 2)).toThrow(
+        'Unknown attribute type: unknown',
+      );
+    });
+
+    it('throws an error for unknown type in applyDebuff', () => {
+      const card = createFightingCard({
+        attack: 100,
+        defense: 0,
+        accuracy: 0,
+        agility: 0,
+      });
+
+      expect(() => card.applyDebuff('unknown' as any, 0.1, 2)).toThrow(
+        'Unknown attribute type: unknown',
+      );
+    });
+  });
+});
+
 describe('FightingCard.applyBuff()', () => {
   describe('when applying a duration-only buff', () => {
     it('stacks on top of existing buff of same type', () => {

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -493,6 +493,8 @@ export class FightingCard {
         return rate * this.agility;
       case 'accuracy':
         return rate * this.accuracy;
+      default:
+        throw new Error(`Unknown attribute type: ${type}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
Added validation and error handling to the `computeAttributeModifierValue()` method to throw an error when an unknown attribute type is provided, preventing silent failures and making debugging easier.

## Key Changes
- Added a `default` case to the attribute type switch statement in `computeAttributeModifierValue()` that throws an error for unknown types
- Added comprehensive test coverage for both `applyBuff()` and `applyDebuff()` methods when invalid attribute types are provided
- Tests verify that the expected error message `'Unknown attribute type: {type}'` is thrown in both scenarios

## Implementation Details
The change ensures type safety by explicitly handling the error case rather than implicitly returning `undefined`. This makes it easier to catch bugs where an invalid attribute type is accidentally passed to buff/debuff operations.

https://claude.ai/code/session_01FbTkjKA1DDqiFxhEkZDJ7b

closes: #52 