### PR TITLE
fix: throw explicit error for unknown trigger events in buildSimpleTrigger

### DIFF
--- a/src/fight/http-api/__test__/trigger-factory.spec.ts
+++ b/src/fight/http-api/__test__/trigger-factory.spec.ts
@@ -1,0 +1,44 @@
+import 'reflect-metadata';
+
+import { TriggerEvent } from '../dto/fight-data.dto';
+import { buildTriggerStrategy } from '../trigger-factory';
+import { TurnEnd } from '../../core/trigger/turn-end';
+import { NextAction } from '../../core/trigger/next-action';
+import { AllyDeath } from '../../core/trigger/ally-death';
+import { EnemyDeath } from '../../core/trigger/enemy-death';
+
+describe('buildTriggerStrategy', () => {
+  describe('known simple events', () => {
+    it('returns TurnEnd for turn-end event', () => {
+      expect(buildTriggerStrategy(TriggerEvent.TURN_END)).toBeInstanceOf(
+        TurnEnd,
+      );
+    });
+
+    it('returns NextAction for next-action event', () => {
+      expect(buildTriggerStrategy(TriggerEvent.NEXT_ACTION)).toBeInstanceOf(
+        NextAction,
+      );
+    });
+
+    it('returns AllyDeath for ally-death event with targetCardId', () => {
+      expect(
+        buildTriggerStrategy(TriggerEvent.ALLY_DEATH, 'card-1'),
+      ).toBeInstanceOf(AllyDeath);
+    });
+
+    it('returns EnemyDeath for enemy-death event with targetCardId', () => {
+      expect(
+        buildTriggerStrategy(TriggerEvent.ENEMY_DEATH, 'card-1'),
+      ).toBeInstanceOf(EnemyDeath);
+    });
+  });
+
+  describe('unknown events', () => {
+    it('throws for an unknown event not in STRATEGY_MAP', () => {
+      expect(() =>
+        buildTriggerStrategy('unknown-event' as TriggerEvent),
+      ).toThrow('Unknown trigger event: unknown-event');
+    });
+  });
+});

--- a/src/fight/http-api/trigger-factory.ts
+++ b/src/fight/http-api/trigger-factory.ts
@@ -31,7 +31,11 @@ function buildSimpleTrigger(
   if (event === TriggerEvent.ALLY_DEATH || event === TriggerEvent.ENEMY_DEATH) {
     return buildDeathTrigger(event, targetCardId);
   }
-  return STRATEGY_MAP[event];
+  const trigger = STRATEGY_MAP[event];
+  if (!trigger) {
+    throw new Error(`Unknown trigger event: ${event}`);
+  }
+  return trigger;
 }
 
 function buildReplacementTriggerFactory(


### PR DESCRIPTION
## Summary

- `buildSimpleTrigger` was silently returning `undefined` when `STRATEGY_MAP[event]` had no entry for the given event, causing a late `TypeError` deep in simulation instead of a clear failure at the source
- Added an explicit guard that throws `Error: Unknown trigger event: <event>` immediately when the lookup returns nothing
- Added `trigger-factory.spec.ts` with tests covering known events (`turn-end`, `next-action`, `ally-death`, `enemy-death`) and the new unknown-event guard

## Test plan

- [x] `trigger-factory.spec.ts` — 5 tests, all passing
- [x] Full test suite — 400 tests, all passing
- [x] Build passes

Closes #129

https://claude.ai/code/session_01Dj3TVo7H8PSvzTXqk15YwM