### PR TITLE
test: achieve 100% coverage on trigger-factory.ts

### DIFF
--- a/src/fight/http-api/__test__/trigger-factory.spec.ts
+++ b/src/fight/http-api/__test__/trigger-factory.spec.ts
@@ -6,6 +6,7 @@ import { TurnEnd } from '../../core/trigger/turn-end';
 import { NextAction } from '../../core/trigger/next-action';
 import { AllyDeath } from '../../core/trigger/ally-death';
 import { EnemyDeath } from '../../core/trigger/enemy-death';
+import { DynamicTrigger } from '../../core/trigger/dynamic-trigger';
 
 describe('buildTriggerStrategy', () => {
   describe('known simple events', () => {
@@ -34,11 +35,79 @@ describe('buildTriggerStrategy', () => {
     });
   });
 
+  describe('death events without targetCardId', () => {
+    it('throws for ally-death event without targetCardId', () => {
+      expect(() => buildTriggerStrategy(TriggerEvent.ALLY_DEATH)).toThrow(
+        'ally-death trigger requires targetCardId',
+      );
+    });
+
+    it('throws for enemy-death event without targetCardId', () => {
+      expect(() => buildTriggerStrategy(TriggerEvent.ENEMY_DEATH)).toThrow(
+        'enemy-death trigger requires targetCardId',
+      );
+    });
+  });
+
   describe('unknown events', () => {
     it('throws for an unknown event not in STRATEGY_MAP', () => {
       expect(() =>
         buildTriggerStrategy('unknown-event' as TriggerEvent),
       ).toThrow('Unknown trigger event: unknown-event');
+    });
+  });
+
+  describe('dormant trigger', () => {
+    it('throws when dormant config is missing', () => {
+      expect(() => buildTriggerStrategy(TriggerEvent.DORMANT)).toThrow(
+        'Dormant trigger requires activationEvent, activationTargetCardId, and replacementEvent',
+      );
+    });
+
+    it('returns DynamicTrigger with ally-death activation and enemy-death replacement', () => {
+      const trigger = buildTriggerStrategy(TriggerEvent.DORMANT, undefined, {
+        activationEvent: TriggerEvent.ALLY_DEATH,
+        activationTargetCardId: 'card-1',
+        replacementEvent: TriggerEvent.ENEMY_DEATH,
+      });
+
+      expect(trigger).toBeInstanceOf(DynamicTrigger);
+    });
+
+    it('returns DynamicTrigger with ally-death activation and turn-end replacement', () => {
+      const trigger = buildTriggerStrategy(TriggerEvent.DORMANT, undefined, {
+        activationEvent: TriggerEvent.ALLY_DEATH,
+        activationTargetCardId: 'card-1',
+        replacementEvent: TriggerEvent.TURN_END,
+      });
+
+      expect(trigger).toBeInstanceOf(DynamicTrigger);
+    });
+
+    it('activates and matches enemy-death replacement trigger keyed on killer card', () => {
+      const trigger = buildTriggerStrategy(TriggerEvent.DORMANT, undefined, {
+        activationEvent: TriggerEvent.ALLY_DEATH,
+        activationTargetCardId: 'card-1',
+        replacementEvent: TriggerEvent.ENEMY_DEATH,
+      });
+      trigger.isTriggered('ally-death:card-1', {
+        killerCard: { id: 'killer-1' },
+      } as any);
+
+      expect(trigger.isTriggered('enemy-death:killer-1')).toBe(true);
+    });
+
+    it('activates and matches turn-end replacement trigger', () => {
+      const trigger = buildTriggerStrategy(TriggerEvent.DORMANT, undefined, {
+        activationEvent: TriggerEvent.ALLY_DEATH,
+        activationTargetCardId: 'card-1',
+        replacementEvent: TriggerEvent.TURN_END,
+      });
+      trigger.isTriggered('ally-death:card-1', {
+        killerCard: { id: 'killer-1' },
+      } as any);
+
+      expect(trigger.isTriggered('turn-end')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add missing tests for the entirely untested dormant trigger wiring in `trigger-factory.ts`
- Coverage goes from 42.85% → 100% (statements, branches, functions, lines)

## What was missing

The following paths in `trigger-factory.ts` had zero test coverage:

- `buildDeathTrigger` error path — throws when `targetCardId` is absent for `ally-death` / `enemy-death`
- `buildReplacementTriggerFactory` — both branches: death-event replacement (returns factory keyed on killer card id) and simple-event replacement
- Dormant path in `buildTriggerStrategy` — missing config error, `DynamicTrigger` construction, and post-activation behavior of the replacement trigger

## Test plan

- [x] `throws for ally-death event without targetCardId`
- [x] `throws for enemy-death event without targetCardId`
- [x] `throws when dormant config is missing`
- [x] `returns DynamicTrigger with ally-death activation and enemy-death replacement`
- [x] `returns DynamicTrigger with ally-death activation and turn-end replacement`
- [x] `activates and matches enemy-death replacement trigger keyed on killer card`
- [x] `activates and matches turn-end replacement trigger`
- [x] Full test suite: 407 tests passing

Closes #130