### PR TITLE
fix(types): remove outer { kind: StepKind } & wrapper from Step union

### DIFF
--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -186,10 +186,7 @@ export class ActionStage {
           }
 
           report.statusChanges.forEach((statusChange) => {
-            acc.statusChangeSteps.push({
-              kind: StepKind.StatusChange,
-              ...statusChange,
-            });
+            acc.statusChangeSteps.push(statusChange);
           });
         }
 
@@ -222,11 +219,13 @@ export class ActionStage {
       if (defensiveCard.isDead()) {
         this.notifyDeath(defensiveCard, attackerCard);
         report.statusChanges.push({
+          kind: StepKind.StatusChange,
           card: defensiveCard.identityInfo,
           status: 'dead',
         });
       } else if (damageDealt.effect) {
         report.statusChanges.push({
+          kind: StepKind.StatusChange,
           status: damageDealt.effect.type,
           card: damageDealt.effect.card.identityInfo,
         });

--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -179,7 +179,7 @@ export class ActionStage {
           acc.actionSteps.push({
             kind: report.kind,
             ...report.attack,
-          });
+          } as Step);
 
           if (report.buffReport) {
             acc.actionSteps.push(report.buffReport);

--- a/src/fight/core/fight-simulator/@types/damage-report.ts
+++ b/src/fight/core/fight-simulator/@types/damage-report.ts
@@ -1,4 +1,5 @@
 import { CardInfo } from '../../cards/@types/card-info';
+import { StepKind } from './step';
 
 export type Damage = {
   defender: CardInfo;
@@ -13,3 +14,6 @@ export type DamageReport = {
   damages: Damage[];
   energy: number;
 };
+
+export type AttackStepReport = { kind: StepKind.Attack } & DamageReport;
+export type SpecialAttackStepReport = { kind: StepKind.SpecialAttack } & DamageReport;

--- a/src/fight/core/fight-simulator/@types/state-effect-report.ts
+++ b/src/fight/core/fight-simulator/@types/state-effect-report.ts
@@ -1,6 +1,8 @@
 import { CardInfo } from '../../cards/@types/card-info';
+import { StepKind } from './step';
 
 export type StateEffectReport = {
+  kind: StepKind.StateEffect;
   type: string;
   card: CardInfo;
   damage: number;

--- a/src/fight/core/fight-simulator/@types/status-change-report.ts
+++ b/src/fight/core/fight-simulator/@types/status-change-report.ts
@@ -1,8 +1,10 @@
 import { CardInfo } from '../../cards/@types/card-info';
+import { StepKind } from './step';
 
 export type status = 'dead' | 'poison' | 'burn' | 'freeze';
 
 export type StatusChangeReport = {
+  kind: StepKind.StatusChange;
   card: CardInfo;
   status: status;
 };

--- a/src/fight/core/fight-simulator/@types/step.ts
+++ b/src/fight/core/fight-simulator/@types/step.ts
@@ -1,6 +1,6 @@
 import { BuffReport } from './buff-report';
 import { DebuffReport } from './debuff-report';
-import { DamageReport } from './damage-report';
+import { AttackStepReport, SpecialAttackStepReport } from './damage-report';
 import { HealingReport } from './healing-report';
 import { StateEffectReport } from './state-effect-report';
 import { StatusChangeReport } from './status-change-report';
@@ -29,12 +29,12 @@ export enum StepKind {
 }
 
 export type Step =
-  | ({ kind: StepKind.StatusChange } & StatusChangeReport)
-  | ({ kind: StepKind.Attack } & DamageReport)
-  | ({ kind: StepKind.SpecialAttack } & DamageReport)
+  | StatusChangeReport
+  | AttackStepReport
+  | SpecialAttackStepReport
   | HealingReport
-  | ({ kind: StepKind.FightEnd } & WinnerReport)
-  | ({ kind: StepKind.StateEffect } & StateEffectReport)
+  | WinnerReport
+  | StateEffectReport
   | BuffReport
   | DebuffReport
   | BuffRemovedReport

--- a/src/fight/core/fight-simulator/@types/step.ts
+++ b/src/fight/core/fight-simulator/@types/step.ts
@@ -28,16 +28,16 @@ export enum StepKind {
   EffectRemoved = 'effect_removed',
 }
 
-export type Step = { kind: StepKind } & (
-  | StatusChangeReport
-  | DamageReport
+export type Step =
+  | ({ kind: StepKind.StatusChange } & StatusChangeReport)
+  | ({ kind: StepKind.Attack } & DamageReport)
+  | ({ kind: StepKind.SpecialAttack } & DamageReport)
   | HealingReport
-  | WinnerReport
-  | StateEffectReport
+  | ({ kind: StepKind.FightEnd } & WinnerReport)
+  | ({ kind: StepKind.StateEffect } & StateEffectReport)
   | BuffReport
   | DebuffReport
   | BuffRemovedReport
   | TargetingOverrideReport
   | TargetingRevertedReport
-  | EffectRemovedReport
-);
+  | EffectRemovedReport;

--- a/src/fight/core/fight-simulator/@types/winner-report.ts
+++ b/src/fight/core/fight-simulator/@types/winner-report.ts
@@ -1,3 +1,6 @@
+import { StepKind } from './step';
+
 export type WinnerReport = {
+  kind: StepKind.FightEnd;
   winner: string | null;
 };


### PR DESCRIPTION
The outer intersection widened the discriminator for union members that
lacked their own kind literal (DamageReport, StatusChangeReport,
WinnerReport, StateEffectReport), preventing TypeScript from narrowing
on Step.kind.

Each Step union member now carries its own specific kind literal,
making the union a proper discriminated union. A narrowing cast is
added in action-stage where kind is a union type at the push site.

Closes #69

https://claude.ai/code/session_01LAGU1RwpnAJNWY6iMx25sQ