### PR TITLE
fix(types): type buildTriggerForSkill parameter as OtherSkillDto instead of any

### DIFF
--- a/src/fight/core/fight-simulator/@types/damage-report.ts
+++ b/src/fight/core/fight-simulator/@types/damage-report.ts
@@ -16,4 +16,6 @@ export type DamageReport = {
 };
 
 export type AttackStepReport = { kind: StepKind.Attack } & DamageReport;
-export type SpecialAttackStepReport = { kind: StepKind.SpecialAttack } & DamageReport;
+export type SpecialAttackStepReport = {
+  kind: StepKind.SpecialAttack;
+} & DamageReport;

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -248,7 +248,7 @@ export class FightController {
     }
   }
 
-  private buildTriggerForSkill(skillData: any) {
+  private buildTriggerForSkill(skillData: OtherSkillDto) {
     const dormantConfig =
       skillData.event === TriggerEvent.DORMANT
         ? {


### PR DESCRIPTION
Replaces the `any` type on `buildTriggerForSkill(skillData: any)` with
`OtherSkillDto` so that missing dormant fields (activationEvent,
activationTargetCardId, replacementEvent) surface at compile time
rather than silently at runtime.

Closes #133

https://claude.ai/code/session_01X6aibgg4jUZZrV4wDQuC5C