### PR TITLE
refactor: delegate launch() to launchWithTargeting() in SimpleAttack and MultipleAttack

### DIFF
--- a/src/fight/core/cards/skills/multiple-attack.ts
+++ b/src/fight/core/cards/skills/multiple-attack.ts
@@ -30,7 +30,7 @@ export class MultipleAttack implements AttackSkill {
   }
 
   public launch(card: FightingCard, context: FightingContext): AttackResult[] {
-    return this.executeAttack(card, context, this.targetingStrategy);
+    return this.launchWithTargeting(card, context, this.targetingStrategy);
   }
 
   private executeAttack(

--- a/src/fight/core/cards/skills/simple-attack.ts
+++ b/src/fight/core/cards/skills/simple-attack.ts
@@ -19,7 +19,7 @@ export class SimpleAttack implements AttackSkill {
   }
 
   public launch(card: FightingCard, context: FightingContext): AttackResult[] {
-    return this.executeAttack(card, context, this.targetingStrategy);
+    return this.launchWithTargeting(card, context, this.targetingStrategy);
   }
 
   public launchWithTargeting(


### PR DESCRIPTION
## Summary

- `SimpleAttack.launch()` now delegates to `launchWithTargeting()` instead of calling `executeAttack()` directly
- `MultipleAttack.launch()` now delegates to `launchWithTargeting()` instead of calling `executeAttack()` directly
- Eliminates the duplicate code path so there is a single entry point for attack execution logic

Closes #67

## Test plan

- [ ] All 415 existing tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)

https://claude.ai/code/session_01E977APa5fvmRSSvdTEUuPc