### PR TITLE
test: add unit tests for skillResultsToSteps TargetingOverride path

### DIFF
--- a/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-targeting-override.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-targeting-override.spec.ts
@@ -1,0 +1,48 @@
+import { skillResultsToSteps } from '../skill-results-to-steps';
+import {
+  SkillKind,
+  TargetingOverrideSkillResults,
+} from '../../cards/skills/skill';
+import { StepKind } from '../@types/step';
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+
+describe('skillResultsToSteps: TargetingOverride', () => {
+  const card = createFightingCard({ id: 'card-1' });
+
+  const overrideResult: TargetingOverrideSkillResults = {
+    skillKind: SkillKind.TargetingOverride,
+    results: [
+      {
+        kind: StepKind.TargetingOverride,
+        source: card.identityInfo,
+        previousStrategy: 'position-based',
+        newStrategy: 'all',
+        powerId: 'rage',
+      },
+    ],
+  };
+
+  it('emits a targeting_override step', () => {
+    const steps = skillResultsToSteps(card, [overrideResult]);
+
+    expect(steps[0].kind).toBe(StepKind.TargetingOverride);
+  });
+
+  it('preserves the newStrategy field', () => {
+    const steps = skillResultsToSteps(card, [overrideResult]);
+
+    expect((steps[0] as any).newStrategy).toBe('all');
+  });
+
+  it('preserves the powerId field', () => {
+    const steps = skillResultsToSteps(card, [overrideResult]);
+
+    expect((steps[0] as any).powerId).toBe('rage');
+  });
+
+  it('preserves the source card identity', () => {
+    const steps = skillResultsToSteps(card, [overrideResult]);
+
+    expect((steps[0] as any).source.id).toBe('card-1');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #139

The unsafe double-cast `as unknown as TargetingOverrideReport[]` reported in `death-skill-handler.ts:160` was removed when `SkillResults` was converted to a proper discriminated union (via `TargetingOverrideSkillResults`) and the conversion logic was extracted into `skillResultsToSteps`. TypeScript can now narrow the type safely via the `skillKind` discriminant.

This PR adds a direct unit test for `skillResultsToSteps` covering the `TargetingOverride` case, explicitly verifying:
- The step kind is `targeting_override`
- The `newStrategy`, `powerId`, and `source` fields are preserved correctly

## Test plan

- [ ] `npm run test:cov` — all 419 tests pass, coverage unchanged
- [ ] `npm run lint` — no lint errors