### PR TITLE
refactor(trigger): fix ISP violation in Trigger.isTriggered

### DIFF
--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -276,8 +276,9 @@ export class FightingCard {
     trigger: string,
     context: FightingContext,
   ): SkillResults[] {
+    this.skills.forEach((s) => s.activate?.(trigger, context));
     return this.skills
-      .filter((s) => s.isTriggered(trigger, context))
+      .filter((s) => s.isTriggered(trigger))
       .map((skill) => skill.launch(this, context));
   }
 

--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -1,6 +1,7 @@
 import { TargetingCardStrategy } from '../../targeting-card-strategies/targeting-card-strategy';
 import { FightingCard } from '../fighting-card';
 import { Trigger } from '../../trigger/trigger';
+import { ActivatableTrigger } from '../../trigger/activatable-trigger';
 import { FightingContext } from '../@types/fighting-context';
 import { BuffType } from '../@types/buff/type';
 import { Skill, SkillKind, SkillResults } from './skill';
@@ -122,9 +123,15 @@ export class AlterationSkill implements Skill {
     };
   }
 
-  isTriggered(triggerName: string, context?: FightingContext): boolean {
+  isTriggered(triggerName: string): boolean {
     if (this.isExhausted()) return false;
-    return this.trigger.isTriggered(triggerName, context);
+    return this.trigger.isTriggered(triggerName);
+  }
+
+  activate(triggerId: string, context: FightingContext): void {
+    if ('activate' in this.trigger) {
+      (this.trigger as ActivatableTrigger).activate(triggerId, context);
+    }
   }
 
   lifecycleEndEvent(): string | undefined {

--- a/src/fight/core/cards/skills/healing.ts
+++ b/src/fight/core/cards/skills/healing.ts
@@ -2,6 +2,7 @@ import { TargetingCardStrategy } from '../../targeting-card-strategies/targeting
 import { FightingCard } from '../fighting-card';
 import { Skill, SkillKind, SkillResults } from './skill';
 import { Trigger } from '../../trigger/trigger';
+import { ActivatableTrigger } from '../../trigger/activatable-trigger';
 import { FightingContext } from '../@types/fighting-context';
 
 export class Healing implements Skill {
@@ -46,7 +47,13 @@ export class Healing implements Skill {
     };
   }
 
-  isTriggered(triggerName: string, context?: FightingContext): boolean {
-    return this.trigger.isTriggered(triggerName, context);
+  isTriggered(triggerName: string): boolean {
+    return this.trigger.isTriggered(triggerName);
+  }
+
+  activate(triggerId: string, context: FightingContext): void {
+    if ('activate' in this.trigger) {
+      (this.trigger as ActivatableTrigger).activate(triggerId, context);
+    }
   }
 }

--- a/src/fight/core/cards/skills/skill.ts
+++ b/src/fight/core/cards/skills/skill.ts
@@ -67,10 +67,19 @@ export interface Skill {
    * Checks if the skill is triggered.
    *
    * @param triggerName - The name of the trigger to check.
-   * @param context - Optional fighting context (used by DynamicTrigger for activation).
    * @returns True if the skill is triggered, false otherwise
    */
-  isTriggered(triggerName: string, context?: FightingContext): boolean;
+  isTriggered(triggerName: string): boolean;
+
+  /**
+   * Activates dynamic triggers by observing events with context.
+   * Called before isTriggered to allow stateful triggers to transition.
+   * Optional — only skills wrapping ActivatableTrigger implement this.
+   *
+   * @param triggerId - The name of the trigger event observed.
+   * @param context - The fighting context providing killer card info.
+   */
+  activate?(triggerId: string, context: FightingContext): void;
 
   /**
    * Advances internal state (e.g., turn counter). Called each action turn.

--- a/src/fight/core/cards/skills/targeting-override.ts
+++ b/src/fight/core/cards/skills/targeting-override.ts
@@ -1,6 +1,7 @@
 import { TargetingCardStrategy } from '../../targeting-card-strategies/targeting-card-strategy';
 import { FightingCard } from '../fighting-card';
 import { Trigger } from '../../trigger/trigger';
+import { ActivatableTrigger } from '../../trigger/activatable-trigger';
 import { FightingContext } from '../@types/fighting-context';
 import { Skill, SkillKind, SkillResults } from './skill';
 import { TargetingOverrideReport } from '../../fight-simulator/@types/targeting-override-report';
@@ -47,7 +48,13 @@ export class TargetingOverrideSkill implements Skill {
     };
   }
 
-  isTriggered(triggerName: string, context?: FightingContext): boolean {
-    return this.trigger.isTriggered(triggerName, context);
+  isTriggered(triggerName: string): boolean {
+    return this.trigger.isTriggered(triggerName);
+  }
+
+  activate(triggerId: string, context: FightingContext): void {
+    if ('activate' in this.trigger) {
+      (this.trigger as ActivatableTrigger).activate(triggerId, context);
+    }
   }
 }

--- a/src/fight/core/trigger/__tests__/dynamic-trigger.spec.ts
+++ b/src/fight/core/trigger/__tests__/dynamic-trigger.spec.ts
@@ -39,15 +39,16 @@ describe('DynamicTrigger', () => {
 
     it('does not fire on activation event', () => {
       const context = createMinimalContext('goblin-03');
+      trigger.activate('ally-death:warrior-01', context);
 
-      expect(trigger.isTriggered('ally-death:warrior-01', context)).toBe(false);
+      expect(trigger.isTriggered('ally-death:warrior-01')).toBe(false);
     });
   });
 
   describe('after activation event is observed', () => {
     beforeEach(() => {
       const context = createMinimalContext('goblin-03');
-      trigger.isTriggered('ally-death:warrior-01', context);
+      trigger.activate('ally-death:warrior-01', context);
     });
 
     it('matches the replacement trigger built from killer card id', () => {
@@ -70,8 +71,8 @@ describe('DynamicTrigger', () => {
   describe('activation is idempotent', () => {
     it('calling activation event multiple times still delegates to replacement', () => {
       const context = createMinimalContext('goblin-03');
-      trigger.isTriggered('ally-death:warrior-01', context);
-      trigger.isTriggered('ally-death:warrior-01', context);
+      trigger.activate('ally-death:warrior-01', context);
+      trigger.activate('ally-death:warrior-01', context);
 
       expect(trigger.isTriggered('enemy-death:goblin-03')).toBe(true);
     });
@@ -79,11 +80,15 @@ describe('DynamicTrigger', () => {
 
   describe('activation without killerCard context', () => {
     it('stays dormant on activation event', () => {
+      const context = { killerCard: undefined } as any;
+      trigger.activate('ally-death:warrior-01', context);
+
       expect(trigger.isTriggered('ally-death:warrior-01')).toBe(false);
     });
 
     it('does not delegate to a replacement trigger afterwards', () => {
-      trigger.isTriggered('ally-death:warrior-01');
+      const context = { killerCard: undefined } as any;
+      trigger.activate('ally-death:warrior-01', context);
 
       expect(trigger.isTriggered('enemy-death:goblin-03')).toBe(false);
     });
@@ -97,7 +102,7 @@ describe('DynamicTrigger', () => {
       );
       const context = createMinimalContext('any-card');
 
-      dynamicWithTurnEnd.isTriggered('ally-death:warrior-01', context);
+      dynamicWithTurnEnd.activate('ally-death:warrior-01', context);
 
       expect(dynamicWithTurnEnd.isTriggered('turn-end')).toBe(true);
     });

--- a/src/fight/core/trigger/activatable-trigger.ts
+++ b/src/fight/core/trigger/activatable-trigger.ts
@@ -1,0 +1,6 @@
+import { FightingContext } from '../cards/@types/fighting-context';
+import { Trigger } from './trigger';
+
+export interface ActivatableTrigger extends Trigger {
+  activate(triggerId: string, context: FightingContext): void;
+}

--- a/src/fight/core/trigger/dynamic-trigger.ts
+++ b/src/fight/core/trigger/dynamic-trigger.ts
@@ -1,7 +1,8 @@
 import { FightingContext } from '../cards/@types/fighting-context';
+import { ActivatableTrigger } from './activatable-trigger';
 import { Trigger } from './trigger';
 
-export class DynamicTrigger implements Trigger {
+export class DynamicTrigger implements ActivatableTrigger {
   public id = 'dormant';
   private activated = false;
   private activationTrigger: Trigger;
@@ -16,20 +17,21 @@ export class DynamicTrigger implements Trigger {
     this.buildReplacementTrigger = buildReplacementTrigger;
   }
 
-  isTriggered(triggerId: string, context?: FightingContext): boolean {
-    if (!this.activated) {
-      if (this.activationTrigger.isTriggered(triggerId)) {
-        const killerCardId = context?.killerCard?.id;
-        if (!killerCardId) {
-          // Activation event observed without a killer (e.g. status-effect death).
-          // Cannot build a replacement trigger keyed on the killer; stay dormant.
-          return false;
-        }
-        this.replacementTrigger = this.buildReplacementTrigger(killerCardId);
-        this.activated = true;
-      }
-      return false;
+  activate(triggerId: string, context: FightingContext): void {
+    if (this.activated) return;
+    if (!this.activationTrigger.isTriggered(triggerId)) return;
+    const killerCardId = context?.killerCard?.id;
+    if (!killerCardId) {
+      // Activation event observed without a killer (e.g. status-effect death).
+      // Cannot build a replacement trigger keyed on the killer; stay dormant.
+      return;
     }
+    this.replacementTrigger = this.buildReplacementTrigger(killerCardId);
+    this.activated = true;
+  }
+
+  isTriggered(triggerId: string): boolean {
+    if (!this.activated) return false;
     return this.replacementTrigger!.isTriggered(triggerId);
   }
 }

--- a/src/fight/core/trigger/trigger.ts
+++ b/src/fight/core/trigger/trigger.ts
@@ -1,7 +1,5 @@
-import { FightingContext } from '../cards/@types/fighting-context';
-
 export interface Trigger {
   id: string;
 
-  isTriggered(triggerId: string, context?: FightingContext): boolean;
+  isTriggered(triggerId: string): boolean;
 }

--- a/src/fight/http-api/__test__/trigger-factory.spec.ts
+++ b/src/fight/http-api/__test__/trigger-factory.spec.ts
@@ -89,8 +89,8 @@ describe('buildTriggerStrategy', () => {
         activationEvent: TriggerEvent.ALLY_DEATH,
         activationTargetCardId: 'card-1',
         replacementEvent: TriggerEvent.ENEMY_DEATH,
-      });
-      trigger.isTriggered('ally-death:card-1', {
+      }) as DynamicTrigger;
+      trigger.activate('ally-death:card-1', {
         killerCard: { id: 'killer-1' },
       } as any);
 
@@ -102,8 +102,8 @@ describe('buildTriggerStrategy', () => {
         activationEvent: TriggerEvent.ALLY_DEATH,
         activationTargetCardId: 'card-1',
         replacementEvent: TriggerEvent.TURN_END,
-      });
-      trigger.isTriggered('ally-death:card-1', {
+      }) as DynamicTrigger;
+      trigger.activate('ally-death:card-1', {
         killerCard: { id: 'killer-1' },
       } as any);
 


### PR DESCRIPTION
Removes the optional context? parameter from Trigger.isTriggered that
was only used by DynamicTrigger, violating the Interface Segregation
Principle.

Introduces ActivatableTrigger sub-interface with an explicit activate()
method for state-transitioning triggers. DynamicTrigger now implements
ActivatableTrigger: activate() captures killerCard context and
transitions dormant→active, while isTriggered() is a pure predicate.

Skills (Healing, AlterationSkill, TargetingOverrideSkill) implement the
optional Skill.activate?() method, delegating to their trigger when it
is activatable. FightingCard.launchSkills() calls activate() on all
skills before filtering with isTriggered().

Closes #131

https://claude.ai/code/session_01F4gw7x38o4Um3KoyvinmEW