### PR TITLE
refactor(trigger-factory): remove over-layered buildReplacementTriggerFactory

### DIFF
--- a/src/fight/http-api/trigger-factory.ts
+++ b/src/fight/http-api/trigger-factory.ts
@@ -38,18 +38,6 @@ function buildSimpleTrigger(
   return trigger;
 }
 
-function buildReplacementTriggerFactory(
-  replacementEvent: TriggerEvent,
-): (cardId: string) => Trigger {
-  if (
-    replacementEvent === TriggerEvent.ALLY_DEATH ||
-    replacementEvent === TriggerEvent.ENEMY_DEATH
-  ) {
-    return (cardId: string) => buildDeathTrigger(replacementEvent, cardId);
-  }
-  return () => buildSimpleTrigger(replacementEvent);
-}
-
 export function buildTriggerStrategy(
   triggerEvent: TriggerEvent,
   targetCardId?: string,
@@ -69,10 +57,9 @@ export function buildTriggerStrategy(
       dormantConfig.activationEvent,
       dormantConfig.activationTargetCardId,
     );
-    const replacementFactory = buildReplacementTriggerFactory(
-      dormantConfig.replacementEvent,
+    return new DynamicTrigger(activationTrigger, (cardId) =>
+      buildSimpleTrigger(dormantConfig.replacementEvent, cardId),
     );
-    return new DynamicTrigger(activationTrigger, replacementFactory);
   }
 
   return buildSimpleTrigger(triggerEvent, targetCardId);


### PR DESCRIPTION
Collapses the function to an inline one-liner, relying on buildSimpleTrigger
which already handles both death and non-death event routing.

Closes #137

https://claude.ai/code/session_01NQaDwykVwzzdJbDDW7Uk95