### PR TITLE
fix: add return type annotation to buildTriggerForSkill

### DIFF
--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -32,6 +32,7 @@ import { SpecialHealing } from '../core/cards/skills/special-healing';
 import { Healing } from '../core/cards/skills/healing';
 import { AlterationSkill } from '../core/cards/skills/alteration-skill';
 import { buildTriggerStrategy } from './trigger-factory';
+import { Trigger } from '../core/trigger/trigger';
 import { PoisonAttackEffect } from '../core/cards/@types/attack/attack-poison-effect';
 import { EffectLevel } from '../core/cards/@types/attack/effect-level';
 import { AttackEffect } from '../core/cards/@types/attack/attack-effect';
@@ -248,7 +249,7 @@ export class FightController {
     }
   }
 
-  private buildTriggerForSkill(skillData: OtherSkillDto) {
+  private buildTriggerForSkill(skillData: OtherSkillDto): Trigger {
     const dormantConfig =
       skillData.event === TriggerEvent.DORMANT
         ? {


### PR DESCRIPTION
## Summary

- Added explicit `Trigger` return type annotation to the `buildTriggerForSkill` private method in `FightController`
- Added the missing `import { Trigger } from '../core/trigger/trigger'` import to support the annotation
- Fixes issue #150: the method was previously missing its return type, which is inconsistent with the project's typing conventions

## Test plan

- [x] Verify TypeScript compilation succeeds with `npm run build`
- [x] Verify existing tests pass with `npm run test`
- [x] Confirm no lint errors with `npm run lint`

https://claude.ai/code/session_01WMvry67nk8hiR8EVFWQFRh