### PR TITLE
docs: add activation semantics comment to DynamicTrigger (#147)

### DIFF
--- a/src/fight/core/trigger/dynamic-trigger.ts
+++ b/src/fight/core/trigger/dynamic-trigger.ts
@@ -28,6 +28,7 @@ export class DynamicTrigger implements ActivatableTrigger {
       // Cannot build a replacement trigger keyed on the killer; stay dormant.
       return;
     }
+    // Activation consumes this event; replacement only matches subsequent events.
     this.state = {
       kind: 'active',
       replacement: this.buildReplacementTrigger(killerCardId),


### PR DESCRIPTION
## Summary

- Adds a single-line comment to `DynamicTrigger.activate()` clarifying that the activation event is consumed and the replacement trigger only matches subsequent events.

## Test plan

- [ ] Verify the comment appears at line 31 of `src/fight/core/trigger/dynamic-trigger.ts`, directly before the state mutation.
- [ ] Confirm no logic was changed — diff should be exactly one line added.

https://claude.ai/code/session_01WMvry67nk8hiR8EVFWQFRh

Closes: #147