### PR TITLE
refactor: remove redundant dormant trigger comment in OtherSkillDto (#148)

### DIFF
--- a/src/fight/http-api/dto/fight-data.dto.ts
+++ b/src/fight/http-api/dto/fight-data.dto.ts
@@ -394,7 +394,6 @@ export class OtherSkillDto {
   @IsNotEmpty()
   powerId?: string;
 
-  // Required when event=dormant
   @ValidateIf((o) => o.event === TriggerEvent.DORMANT)
   @IsDefined()
   @IsEnum(TriggerEvent)


### PR DESCRIPTION
## Summary

- Removes the `// Required when event=dormant` comment from `OtherSkillDto` in `fight-data.dto.ts`
- The comment was redundant: the `@ValidateIf((o) => o.event === TriggerEvent.DORMANT)` decorator immediately below already expresses the same constraint in a self-documenting way
- Follows project convention: "Avoid comments on obvious code, make code self-explanatory instead"

## Test plan

- [ ] No logic changes — only a comment removal
- [ ] Lint passes (pre-existing ESLint config issue unrelated to this change)
- [ ] All tests continue to pass (`npm run test`)

https://claude.ai/code/session_01WMvry67nk8hiR8EVFWQF

Closes: #148