### PR TITLE
Move validatePowerIdConsistency to domain layer

### DIFF
--- a/src/fight/core/cards/skills/__tests__/power-id-consistency.spec.ts
+++ b/src/fight/core/cards/skills/__tests__/power-id-consistency.spec.ts
@@ -1,0 +1,56 @@
+import { validatePowerIdConsistency } from '../power-id-consistency';
+
+describe('validatePowerIdConsistency', () => {
+  it('accepts skills without powerId', () => {
+    expect(() =>
+      validatePowerIdConsistency([
+        { event: 'turn-end' },
+        { event: 'next-action' },
+      ]),
+    ).not.toThrow();
+  });
+
+  it('accepts skills with distinct powerIds', () => {
+    expect(() =>
+      validatePowerIdConsistency([
+        { powerId: 'power-a', event: 'turn-end', terminationEvent: 'end-a' },
+        { powerId: 'power-b', event: 'next-action', terminationEvent: 'end-b' },
+      ]),
+    ).not.toThrow();
+  });
+
+  it('accepts skills sharing the same powerId with matching event and terminationEvent', () => {
+    expect(() =>
+      validatePowerIdConsistency([
+        { powerId: 'power-a', event: 'turn-end', terminationEvent: 'end-a' },
+        { powerId: 'power-a', event: 'turn-end', terminationEvent: 'end-a' },
+      ]),
+    ).not.toThrow();
+  });
+
+  it('rejects skills with same powerId but different events', () => {
+    expect(() =>
+      validatePowerIdConsistency([
+        { powerId: 'my-power', event: 'turn-end' },
+        { powerId: 'my-power', event: 'next-action' },
+      ]),
+    ).toThrow(/same event/);
+  });
+
+  it('rejects skills with same powerId but different terminationEvents', () => {
+    expect(() =>
+      validatePowerIdConsistency([
+        {
+          powerId: 'my-power',
+          event: 'turn-end',
+          terminationEvent: 'end-a',
+        },
+        {
+          powerId: 'my-power',
+          event: 'turn-end',
+          terminationEvent: 'end-b',
+        },
+      ]),
+    ).toThrow(/same terminationEvent/);
+  });
+});

--- a/src/fight/core/cards/skills/power-id-consistency.ts
+++ b/src/fight/core/cards/skills/power-id-consistency.ts
@@ -1,0 +1,33 @@
+export function validatePowerIdConsistency(
+  skills: { powerId?: string; event: string; terminationEvent?: string }[],
+): void {
+  const groups = new Map<
+    string,
+    { event: string; terminationEvent?: string }
+  >();
+
+  for (const skill of skills) {
+    if (!skill.powerId) continue;
+
+    const existing = groups.get(skill.powerId);
+    if (!existing) {
+      groups.set(skill.powerId, {
+        event: skill.event,
+        terminationEvent: skill.terminationEvent,
+      });
+      continue;
+    }
+
+    if (existing.event !== skill.event) {
+      throw new Error(
+        `Skills with powerId '${skill.powerId}' must share the same event. Found '${existing.event}' and '${skill.event}'.`,
+      );
+    }
+
+    if (existing.terminationEvent !== skill.terminationEvent) {
+      throw new Error(
+        `Skills with powerId '${skill.powerId}' must share the same terminationEvent. Found '${existing.terminationEvent}' and '${skill.terminationEvent}'.`,
+      );
+    }
+  }
+}

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -53,6 +53,7 @@ import { EveryNTurnsCondition } from '../core/cards/@types/attack/conditions/eve
 import { MultipleAttack } from '../core/cards/skills/multiple-attack';
 import { AttackSkill } from '../core/cards/skills/attack-skill';
 import { TargetedCard } from '../core/targeting-card-strategies/targeted-card';
+import { validatePowerIdConsistency } from '../core/cards/skills/power-id-consistency';
 
 @Controller()
 @UsePipes(
@@ -180,7 +181,17 @@ export class FightController {
       );
     }
 
-    this.validatePowerIdConsistency(cardData.skills.others);
+    try {
+      validatePowerIdConsistency(
+        cardData.skills.others.map((s) => ({
+          powerId: s.powerId,
+          event: s.event,
+          terminationEvent: s.terminationEvent,
+        })),
+      );
+    } catch (e) {
+      throw new BadRequestException((e as Error).message);
+    }
 
     const otherSkills: Skill[] = cardData.skills.others.map((skill) =>
       this.createOtherSkill(skill),
@@ -374,38 +385,6 @@ export class FightController {
     const result = BUFF_TYPE_MAP[buffType];
     if (!result) throw new Error(`Unknown buff type: ${buffType}`);
     return result;
-  }
-
-  private validatePowerIdConsistency(skills: OtherSkillDto[]): void {
-    const groups = new Map<
-      string,
-      { event: TriggerEvent; terminationEvent?: string }
-    >();
-
-    for (const skill of skills) {
-      if (!skill.powerId) continue;
-
-      const existing = groups.get(skill.powerId);
-      if (!existing) {
-        groups.set(skill.powerId, {
-          event: skill.event,
-          terminationEvent: skill.terminationEvent,
-        });
-        continue;
-      }
-
-      if (existing.event !== skill.event) {
-        throw new BadRequestException(
-          `Skills with powerId '${skill.powerId}' must share the same event. Found '${existing.event}' and '${skill.event}'.`,
-        );
-      }
-
-      if (existing.terminationEvent !== skill.terminationEvent) {
-        throw new BadRequestException(
-          `Skills with powerId '${skill.powerId}' must share the same terminationEvent. Found '${existing.terminationEvent}' and '${skill.terminationEvent}'.`,
-        );
-      }
-    }
   }
 
   private getSelectorStrategy(


### PR DESCRIPTION
Extracts composite-power consistency validation from FightController
into a standalone domain function (core/cards/skills/power-id-consistency.ts)
that throws a plain Error. The HTTP adapter catches and re-throws as
BadRequestException, keeping HTTP concerns out of the domain.

Closes #56

https://claude.ai/code/session_01LrisYAfmAtdzWuHb3T6y8V