### PR TITLE
test: add dormant skill support to createFightingCard helper (#146)

### DIFF
--- a/src/fight/core/cards/__tests__/fighting-card.spec.ts
+++ b/src/fight/core/cards/__tests__/fighting-card.spec.ts
@@ -1,7 +1,4 @@
 import { createFightingCard } from '../../../../../test/helpers/fighting-card';
-import { TurnEnd } from '../../trigger/turn-end';
-import { Launcher } from '../../targeting-card-strategies/launcher';
-import { AlterationSkill } from '../skills/alteration-skill';
 import { Player } from '../../player';
 
 describe('FightingCard.computeAttributeModifierValue()', () => {
@@ -143,18 +140,21 @@ describe('FightingCard.lifecycleEndEvents()', () => {
     let card;
 
     beforeEach(() => {
-      const skill = new AlterationSkill({
-        polarity: 'buff',
-        attributeType: 'attack',
-        rate: 0.4,
-        duration: Infinity,
-        trigger: new TurnEnd(),
-        targetingStrategy: new Launcher(),
-        activationLimit: 3,
-        endEvent: 'lions-end',
+      card = createFightingCard({
+        skills: {
+          others: [
+            {
+              buffType: 'attack' as const,
+              buffRate: 0.4,
+              duration: Infinity,
+              trigger: 'turn-end',
+              targetingStrategy: 'self',
+              activationLimit: 3,
+              endEvent: 'lions-end',
+            },
+          ],
+        },
       });
-      card = createFightingCard({});
-      (card as any).skills = [skill];
     });
 
     it('returns the endEvent strings of non-exhausted skills', () => {
@@ -166,27 +166,29 @@ describe('FightingCard.lifecycleEndEvents()', () => {
 
   describe('when the lifecycle skill is exhausted', () => {
     let card;
-    let skill;
 
     beforeEach(() => {
-      skill = new AlterationSkill({
-        polarity: 'buff',
-        attributeType: 'attack',
-        rate: 0.4,
-        duration: Infinity,
-        trigger: new TurnEnd(),
-        targetingStrategy: new Launcher(),
-        activationLimit: 1,
-        endEvent: 'lions-end',
+      card = createFightingCard({
+        skills: {
+          others: [
+            {
+              buffType: 'attack' as const,
+              buffRate: 0.4,
+              duration: Infinity,
+              trigger: 'turn-end',
+              targetingStrategy: 'self',
+              activationLimit: 1,
+              endEvent: 'lions-end',
+            },
+          ],
+        },
       });
-      card = createFightingCard({});
-      (card as any).skills = [skill];
       // exhaust by launching once
       const context = {
         sourcePlayer: new Player('p1', [card]),
         opponentPlayer: new Player('p2', []),
       };
-      skill.launch(card, context);
+      card.launchSkills('turn-end', context);
     });
 
     it('does not return the endEvent after exhaustion', () => {
@@ -198,8 +200,7 @@ describe('FightingCard.lifecycleEndEvents()', () => {
 
   describe('when card has no lifecycle skills', () => {
     it('returns empty array', () => {
-      const card = createFightingCard({});
-      (card as any).skills = [];
+      const card = createFightingCard({ skills: { others: [] } });
 
       expect(card.lifecycleEndEvents()).toHaveLength(0);
     });

--- a/src/fight/core/fight-simulator/__tests__/turn-manager-debuff-guard.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/turn-manager-debuff-guard.spec.ts
@@ -4,9 +4,6 @@ import { TurnManager } from '../turn-manager';
 import { DeathSkillHandler } from '../death-skill-handler';
 import { EndEventProcessor } from '../end-event-processor';
 import { StepKind } from '../@types/step';
-import { AlterationSkill } from '../../cards/skills/alteration-skill';
-import { TurnEnd } from '../../trigger/turn-end';
-import { Launcher } from '../../targeting-card-strategies/launcher';
 
 describe('TurnManager debuff guard', () => {
   describe('when a debuff skill produces empty results', () => {
@@ -14,18 +11,23 @@ describe('TurnManager debuff guard', () => {
     let turnManager: TurnManager;
 
     beforeEach(() => {
-      card = createFightingCard({ id: 'card-1', attack: 100, health: 5000 });
-
-      const debuffSkill = new AlterationSkill({
-        polarity: 'debuff',
-        attributeType: 'attack',
-        rate: 0.2,
-        duration: 2,
-        trigger: new TurnEnd(),
-        targetingStrategy: new Launcher(),
-        activationCondition: { id: 'never', evaluate: () => false },
+      card = createFightingCard({
+        id: 'card-1',
+        attack: 100,
+        health: 5000,
+        skills: {
+          others: [
+            {
+              debuffType: 'attack' as const,
+              debuffRate: 0.2,
+              duration: 2,
+              trigger: 'turn-end',
+              targetingStrategy: 'self',
+              activationCondition: { id: 'never', evaluate: () => false },
+            },
+          ],
+        },
       });
-      (card as any).skills = [debuffSkill];
 
       const player1 = new Player('p1', [card]);
       const player2 = new Player('p2', [createFightingCard()]);

--- a/test/helpers/fighting-card.ts
+++ b/test/helpers/fighting-card.ts
@@ -15,6 +15,7 @@ import { AllAllies } from '../../src/fight/core/targeting-card-strategies/all-al
 import { Healing } from '../../src/fight/core/cards/skills/healing';
 import { AlterationSkill } from '../../src/fight/core/cards/skills/alteration-skill';
 import { TurnEnd } from '../../src/fight/core/trigger/turn-end';
+import { NextAction } from '../../src/fight/core/trigger/next-action';
 import { AllyDeath } from '../../src/fight/core/trigger/ally-death';
 import { EnemyDeath } from '../../src/fight/core/trigger/enemy-death';
 import { DynamicTrigger } from '../../src/fight/core/trigger/dynamic-trigger';
@@ -27,6 +28,7 @@ import {
 import { Skill } from '../../src/fight/core/cards/skills/skill';
 import { TargetingOverrideSkill } from '../../src/fight/core/cards/skills/targeting-override';
 import { BuffApplication } from '../../src/fight/core/cards/@types/buff/buff-application';
+import { BuffCondition } from '../../src/fight/core/cards/@types/buff/buff-condition';
 import { Element } from '../../src/fight/core/cards/@types/damage/element';
 import { DamageComposition } from '../../src/fight/core/cards/@types/damage/damage-composition';
 import { DamageType } from '../../src/fight/core/cards/@types/damage/damage-type';
@@ -75,6 +77,9 @@ type FightingCardParams = {
           trigger: string;
           targetingStrategy: string;
           targetCardId?: string;
+          activationEvent?: string;
+          activationTargetCardId?: string;
+          replacementEvent?: string;
           powerId?: string;
         }
       | {
@@ -87,6 +92,10 @@ type FightingCardParams = {
           activationLimit?: number;
           endEvent?: string;
           terminationEvent?: string;
+          activationCondition?: BuffCondition;
+          activationEvent?: string;
+          activationTargetCardId?: string;
+          replacementEvent?: string;
           powerId?: string;
         }
       | {
@@ -96,6 +105,10 @@ type FightingCardParams = {
           trigger: string;
           targetingStrategy: string;
           targetCardId?: string;
+          activationCondition?: BuffCondition;
+          activationEvent?: string;
+          activationTargetCardId?: string;
+          replacementEvent?: string;
           powerId?: string;
         }
       | {
@@ -104,6 +117,9 @@ type FightingCardParams = {
           terminationEvent: string;
           trigger: string;
           targetCardId?: string;
+          activationEvent?: string;
+          activationTargetCardId?: string;
+          replacementEvent?: string;
           powerId?: string;
         }
     )[];
@@ -151,6 +167,8 @@ function createTrigger(
   switch (trigger) {
     case 'turn-end':
       return new TurnEnd();
+    case 'next-action':
+      return new NextAction();
     case 'ally-death':
       if (!targetCardId) {
         throw new Error('Ally death trigger requires targetCardId');
@@ -257,6 +275,25 @@ function createSpecialHealing(params: {
   );
 }
 
+function dormantConfig(skill: {
+  activationEvent?: string;
+  activationTargetCardId?: string;
+  replacementEvent?: string;
+}) {
+  if (
+    skill.activationEvent &&
+    skill.activationTargetCardId &&
+    skill.replacementEvent
+  ) {
+    return {
+      activationEvent: skill.activationEvent,
+      activationTargetCardId: skill.activationTargetCardId,
+      replacementEvent: skill.replacementEvent,
+    };
+  }
+  return undefined;
+}
+
 function createsSkills(
   params: (
     | {
@@ -264,6 +301,9 @@ function createsSkills(
         trigger: string;
         targetingStrategy: string;
         targetCardId?: string;
+        activationEvent?: string;
+        activationTargetCardId?: string;
+        replacementEvent?: string;
         powerId?: string;
       }
     | {
@@ -276,6 +316,10 @@ function createsSkills(
         activationLimit?: number;
         endEvent?: string;
         terminationEvent?: string;
+        activationCondition?: BuffCondition;
+        activationEvent?: string;
+        activationTargetCardId?: string;
+        replacementEvent?: string;
         powerId?: string;
       }
     | {
@@ -285,6 +329,10 @@ function createsSkills(
         trigger: string;
         targetingStrategy: string;
         targetCardId?: string;
+        activationCondition?: BuffCondition;
+        activationEvent?: string;
+        activationTargetCardId?: string;
+        replacementEvent?: string;
         powerId?: string;
       }
     | {
@@ -293,15 +341,19 @@ function createsSkills(
         terminationEvent: string;
         trigger: string;
         targetCardId?: string;
+        activationEvent?: string;
+        activationTargetCardId?: string;
+        replacementEvent?: string;
         powerId?: string;
       }
   )[],
 ): Skill[] {
   return params.map((skill) => {
+    const config = dormantConfig(skill);
     if ('effectRate' in skill) {
       return new Healing(
         skill.effectRate,
-        createTrigger(skill.trigger, skill.targetCardId),
+        createTrigger(skill.trigger, skill.targetCardId, config),
         createTargetingStrategy(skill.targetingStrategy),
         skill.powerId,
       );
@@ -311,11 +363,12 @@ function createsSkills(
         attributeType: skill.buffType,
         rate: skill.buffRate,
         duration: skill.duration,
-        trigger: createTrigger(skill.trigger, skill.targetCardId),
+        trigger: createTrigger(skill.trigger, skill.targetCardId, config),
         targetingStrategy: createTargetingStrategy(skill.targetingStrategy),
         activationLimit: skill.activationLimit,
         endEvent: skill.endEvent,
         terminationEvent: skill.terminationEvent,
+        activationCondition: skill.activationCondition,
         powerId: skill.powerId,
       });
     } else if ('debuffType' in skill) {
@@ -324,15 +377,16 @@ function createsSkills(
         attributeType: skill.debuffType,
         rate: skill.debuffRate,
         duration: skill.duration,
-        trigger: createTrigger(skill.trigger, skill.targetCardId),
+        trigger: createTrigger(skill.trigger, skill.targetCardId, config),
         targetingStrategy: createTargetingStrategy(skill.targetingStrategy),
+        activationCondition: skill.activationCondition,
         powerId: skill.powerId,
       });
     } else {
       return new TargetingOverrideSkill(
         createTargetingStrategy(skill.targetingStrategy),
         skill.terminationEvent,
-        createTrigger(skill.trigger, skill.targetCardId),
+        createTrigger(skill.trigger, skill.targetCardId, config),
         skill.powerId,
       );
     }


### PR DESCRIPTION
## Summary

- Extended `createFightingCard()` helper to support dormant skills natively via `activationEvent`, `activationTargetCardId`, and `replacementEvent` fields on any `others` skill config entry
- Added `activationCondition` support to buff and debuff skill configs (forwarded to `AlterationSkill`)
- Added `next-action` trigger support to `createTrigger`
- Replaced all 4 brittle `(card as any).skills = [...]` injections in unit tests with proper `createFightingCard` calls

## Test plan

- [ ] `npm test` — all 421 tests pass
- [ ] `npm run lint` — no lint errors
- [ ] Confirm no `(card as any).skills` patterns remain in the codebase

https://claude.ai/code/session_01WMvry67nk8hiR8EVFWQFRh

Closes: #146