### PR TITLE
refactor: remove unused _player parameter from notifyDeath (#144)

### DIFF
--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -242,10 +242,8 @@ export class ActionStage {
   }
 
   private notifyDeath(card: FightingCard, killerCard?: FightingCard): void {
-    const player = this.player1.ownCard(card) ? this.player1 : this.player2;
-
     this.eventBroker.onCardDeath.forEach((subscriber) =>
-      subscriber.notifyDeath(player, card, killerCard),
+      subscriber.notifyDeath(card, killerCard),
     );
   }
 }

--- a/src/fight/core/fight-simulator/__tests__/death-skill-handler-targeting-override.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/death-skill-handler-targeting-override.spec.ts
@@ -50,28 +50,28 @@ describe('DeathSkillHandler with TargetingOverride skill', () => {
   });
 
   it('produces a targeting_override step', () => {
-    handler.notifyDeath(player1, player1.allCards[0]);
+    handler.notifyDeath(player1.allCards[0]);
     const steps = handler.drainSteps();
 
     expect(steps[0].kind).toBe(StepKind.TargetingOverride);
   });
 
   it('the step contains the new targeting strategy', () => {
-    handler.notifyDeath(player1, player1.allCards[0]);
+    handler.notifyDeath(player1.allCards[0]);
     const steps = handler.drainSteps();
 
     expect((steps[0] as any).newStrategy).toBe('all');
   });
 
   it('the step contains the source card identity', () => {
-    handler.notifyDeath(player1, player1.allCards[0]);
+    handler.notifyDeath(player1.allCards[0]);
     const steps = handler.drainSteps();
 
     expect((steps[0] as any).source.id).toBe('rager-01');
   });
 
   it('the step propagates the powerId', () => {
-    handler.notifyDeath(player1, player1.allCards[0]);
+    handler.notifyDeath(player1.allCards[0]);
     const steps = handler.drainSteps();
 
     expect((steps[0] as any).powerId).toBe('rage-power');

--- a/src/fight/core/fight-simulator/__tests__/death-skill-handler.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/death-skill-handler.spec.ts
@@ -76,14 +76,14 @@ describe('DeathSkillHandler', () => {
     });
 
     it('produces a healing step', () => {
-      handler.notifyDeath(player1, player1.allCards[0]);
+      handler.notifyDeath(player1.allCards[0]);
       const steps = handler.drainSteps();
 
       expect(steps[0].kind).toBe('healing');
     });
 
     it('drains steps only once', () => {
-      handler.notifyDeath(player1, player1.allCards[0]);
+      handler.notifyDeath(player1.allCards[0]);
       handler.drainSteps();
 
       expect(handler.drainSteps()).toHaveLength(0);
@@ -128,7 +128,7 @@ describe('DeathSkillHandler', () => {
     });
 
     it('produces no steps', () => {
-      handler.notifyDeath(player1, player1.allCards[0]);
+      handler.notifyDeath(player1.allCards[0]);
 
       expect(handler.drainSteps()).toHaveLength(0);
     });
@@ -190,14 +190,14 @@ describe('DeathSkillHandler', () => {
     });
 
     it('produces a buff_removed step after death', () => {
-      handler.notifyDeath(player1, deadCard);
+      handler.notifyDeath(deadCard);
       const steps = handler.drainSteps();
 
       expect(steps.some((s) => s.kind === StepKind.BuffRemoved)).toBe(true);
     });
 
     it('the buff_removed step is immediately after the death event processing', () => {
-      handler.notifyDeath(player1, deadCard);
+      handler.notifyDeath(deadCard);
       const steps = handler.drainSteps();
       const buffRemovedStep = steps.find(
         (s) => s.kind === StepKind.BuffRemoved,
@@ -244,7 +244,7 @@ describe('DeathSkillHandler', () => {
     });
 
     it('does not emit a buff step', () => {
-      handler.notifyDeath(player1, deadCard);
+      handler.notifyDeath(deadCard);
       const steps = handler.drainSteps();
 
       expect(steps.find((s) => s.kind === StepKind.Buff)).toBeUndefined();
@@ -291,7 +291,7 @@ describe('DeathSkillHandler', () => {
     });
 
     it('does not emit a debuff step', () => {
-      handler.notifyDeath(player1, deadCard);
+      handler.notifyDeath(deadCard);
       const steps = handler.drainSteps();
 
       expect(steps.find((s) => s.kind === StepKind.Debuff)).toBeUndefined();
@@ -337,14 +337,14 @@ describe('DeathSkillHandler', () => {
     });
 
     it('produces steps after ally-death triggers on player2 surviving cards', () => {
-      handler.notifyDeath(player2, deadCard);
+      handler.notifyDeath(deadCard);
       const steps = handler.drainSteps();
 
       expect(steps.length).toBeGreaterThan(0);
     });
 
     it('produces a buff step', () => {
-      handler.notifyDeath(player2, deadCard);
+      handler.notifyDeath(deadCard);
       const steps = handler.drainSteps();
 
       expect(steps[0].kind).toBe(StepKind.Buff);

--- a/src/fight/core/fight-simulator/card-death-subscriber.ts
+++ b/src/fight/core/fight-simulator/card-death-subscriber.ts
@@ -1,10 +1,5 @@
 import { FightingCard } from '../cards/fighting-card';
-import { Player } from '../player';
 
 export interface CardDeathSubscriber {
-  notifyDeath: (
-    player: Player,
-    card: FightingCard,
-    killerCard?: FightingCard,
-  ) => void;
+  notifyDeath: (card: FightingCard, killerCard?: FightingCard) => void;
 }

--- a/src/fight/core/fight-simulator/card-selectors/player-by-player.ts
+++ b/src/fight/core/fight-simulator/card-selectors/player-by-player.ts
@@ -47,7 +47,8 @@ export class PlayerByPlayerCardSelector implements CardSelector {
     return [player1NextCard, player2NextCard];
   }
 
-  public notifyDeath(player: Player, card: FightingCard): void {
+  public notifyDeath(card: FightingCard): void {
+    const player = this.player1.ownCard(card) ? this.player1 : this.player2;
     this.updateAlreadyPlayedCard(player, card);
   }
 

--- a/src/fight/core/fight-simulator/card-selectors/speed-weighted-card-pool.ts
+++ b/src/fight/core/fight-simulator/card-selectors/speed-weighted-card-pool.ts
@@ -23,7 +23,7 @@ export class SpeedWeightedCardSelector implements CardSelector {
     return [this.cardPool.pop()!];
   }
 
-  public notifyDeath(_player: Player, card: FightingCard): void {
+  public notifyDeath(card: FightingCard): void {
     this.cardPool = this.cardPool.filter((c) => c !== card);
   }
 

--- a/src/fight/core/fight-simulator/death-skill-handler.ts
+++ b/src/fight/core/fight-simulator/death-skill-handler.ts
@@ -1,11 +1,11 @@
 import { FightingCard } from '../cards/fighting-card';
-import { Player } from '../player';
 import { CardDeathSubscriber } from './card-death-subscriber';
 import { Step } from './@types/step';
 import { SkillResults } from '../cards/skills/skill';
 import { EndEventProcessor } from './end-event-processor';
 import { FightingContext } from '../cards/@types/fighting-context';
 import { skillResultsToSteps } from './skill-results-to-steps';
+import { Player } from '../player';
 
 /**
  * Handles the cascade of effects that must fire immediately after a card dies.
@@ -45,16 +45,11 @@ export class DeathSkillHandler implements CardDeathSubscriber {
    * class. Steps produced by each phase are appended to the internal buffer in
    * order; retrieve them with `drainSteps()`.
    *
-   * @param _player - Unused; the owning player is resolved from `deadCard` directly.
    * @param deadCard - The card that just died.
    * @param killerCard - The card responsible for the kill (forwarded to triggered
    *   skills so they can, for example, target the killer via a `DynamicTrigger`).
    */
-  notifyDeath(
-    _player: Player,
-    deadCard: FightingCard,
-    killerCard?: FightingCard,
-  ): void {
+  notifyDeath(deadCard: FightingCard, killerCard?: FightingCard): void {
     const ownerPlayer = this.player1.ownCard(deadCard)
       ? this.player1
       : this.player2;

--- a/src/fight/core/fight-simulator/turn-manager.ts
+++ b/src/fight/core/fight-simulator/turn-manager.ts
@@ -88,10 +88,8 @@ export class TurnManager {
   }
 
   private notifyDeath(card: FightingCard): void {
-    const player = this.player1.ownCard(card) ? this.player1 : this.player2;
-
     this.eventBroker.onCardDeath.forEach((subscriber) =>
-      subscriber.notifyDeath(player, card),
+      subscriber.notifyDeath(card),
     );
   }
 }


### PR DESCRIPTION
## Summary

- Remove the unused `_player` parameter from `CardDeathSubscriber.notifyDeath` interface and its implementation in `DeathSkillHandler`
- Update all call sites: `ActionStage`, `TurnManager`, `PlayerByPlayerCardSelector`, `SpeedWeightedCardSelector`
- Add missing `Player` import to `death-skill-handler.ts` (was accidentally removed when `_player` param was dropped)
- Fix test call sites in `death-skill-handler.spec.ts` and `death-skill-handler-targeting-override.spec.ts` that still used the old `(player, card)` signature

The owning player is resolved internally from `deadCard` via `player1.ownCard()`, so passing it from callers was redundant.

## Test plan

- [ ] `npm test` — all 421 tests pass
- [ ] `npm run build` — TypeScript compilation succeeds with no errors

https://claude.ai/code/session_01WMvry67nk8hiR8EVFWQFRh
Closes: #144