### PR TITLE
fix: position-based targeting crash on asymmetric deck sizes

### DIFF
--- a/src/fight/core/targeting-card-strategies/__tests__/targeted-from-position.spec.ts
+++ b/src/fight/core/targeting-card-strategies/__tests__/targeted-from-position.spec.ts
@@ -111,6 +111,33 @@ describe('Targeted From Position Targeting Strategy', () => {
     });
   });
 
+  describe('when attacker position exceeds defending deck size', () => {
+    let attackingPlayer: Player;
+    let targets: FightingCard[];
+
+    beforeEach(() => {
+      attackingPlayer = new Player('Attacking Player', [
+        createFightingCard({ name: 'Other Card' }),
+        sourceCard,
+      ]);
+
+      defendingPlayer = new Player('Defending Player', [
+        createFightingCard({ name: 'Only Card' }),
+      ]);
+
+      targets = strategy.targetedCards(
+        sourceCard,
+        attackingPlayer,
+        defendingPlayer,
+      );
+    });
+
+    it('targets the first alive card in the defending deck', () => {
+      const targetsNames = targets.map((target) => target.name);
+      expect(targetsNames).toEqual(['Only Card']);
+    });
+  });
+
   describe('when all cards are dead', () => {
     let attackingPlayer: Player;
     let targets: FightingCard[];

--- a/src/fight/core/targeting-card-strategies/targeted-from-position.ts
+++ b/src/fight/core/targeting-card-strategies/targeted-from-position.ts
@@ -14,7 +14,7 @@ export class TargetedFromPosition implements TargetingCardStrategy {
     const defendingCards = defendingPlayer.allCards;
     const targetedCard = defendingCards[attackingCardPosition];
 
-    if (targetedCard.isDead()) {
+    if (!targetedCard || targetedCard.isDead()) {
       // check if there is a card alive after the dead card and go back to the first alive card
       const nextCard =
         defendingCards


### PR DESCRIPTION
When an attacker's position exceeds the defending deck size (e.g. 2v1), `targetedCard` was undefined causing a crash. The existing fallback now handles both undefined and dead card cases.