### PR TITLE
fix: ensure 2-decimal rounding on all floating-point stat calculations

### DIFF
--- a/src/fight/core/cards/@types/attack/__tests__/attack-burn-effect.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/attack-burn-effect.spec.ts
@@ -11,6 +11,19 @@ function makeCards() {
   return { attacker, defender };
 }
 
+describe('BurnAttackEffect number precision', () => {
+  it('rounds damage value to 2 decimal places', () => {
+    const attacker = createFightingCard({ attack: 33 });
+    const defender = createFightingCard({ health: 100 });
+    const effect = new BurnAttackEffect(0.1, 1);
+    effect.applyEffect(defender, attacker, null);
+
+    const [stateResult] = defender.applyStateEffects();
+
+    expect(stateResult.damage).toBe(3.3);
+  });
+});
+
 describe('BurnAttackEffect with triggeredDebuff', () => {
   const randomizer = new RandomizerFake();
 

--- a/src/fight/core/cards/@types/attack/__tests__/attack-poison-effect.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/attack-poison-effect.spec.ts
@@ -11,6 +11,19 @@ function makeCards() {
   return { attacker, defender };
 }
 
+describe('PoisonAttackEffect number precision', () => {
+  it('rounds damage value to 2 decimal places', () => {
+    const attacker = createFightingCard({ attack: 33 });
+    const defender = createFightingCard({ health: 100 });
+    const effect = new PoisonAttackEffect(0.1, 1);
+    effect.applyEffect(defender, attacker, null);
+
+    const [stateResult] = defender.applyStateEffects();
+
+    expect(stateResult.damage).toBe(3.3);
+  });
+});
+
 describe('PoisonAttackEffect with triggeredDebuff', () => {
   const randomizer = new RandomizerFake();
 

--- a/src/fight/core/cards/@types/attack/attack-burn-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-burn-effect.ts
@@ -4,6 +4,7 @@ import { EffectLevel } from './effect-level';
 import { FightingContext } from '../fighting-context';
 import { CardStateBurned } from '../state/card-state-burned';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
+import { roundTo2 } from '../../../../tools/round';
 
 export class BurnAttackEffect implements AttackEffect {
   public readonly rate: number;
@@ -46,7 +47,7 @@ export class BurnAttackEffect implements AttackEffect {
     const burnedState = new CardStateBurned(
       effectLevel,
       this.computeBurnedTurns(effectLevel),
-      card.actualAttack * this.rate,
+      roundTo2(card.actualAttack * this.rate),
       this.terminationEvent,
     );
     defender.setState(burnedState);

--- a/src/fight/core/cards/@types/attack/attack-burn-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-burn-effect.ts
@@ -4,7 +4,7 @@ import { EffectLevel } from './effect-level';
 import { FightingContext } from '../fighting-context';
 import { CardStateBurned } from '../state/card-state-burned';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
-import { roundTo2 } from '../../../../tools/round';
+import { round2 } from '../../../../tools/round';
 
 export class BurnAttackEffect implements AttackEffect {
   public readonly rate: number;
@@ -47,7 +47,7 @@ export class BurnAttackEffect implements AttackEffect {
     const burnedState = new CardStateBurned(
       effectLevel,
       this.computeBurnedTurns(effectLevel),
-      roundTo2(card.actualAttack * this.rate),
+      round2(card.actualAttack * this.rate),
       this.terminationEvent,
     );
     defender.setState(burnedState);

--- a/src/fight/core/cards/@types/attack/attack-poison-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-poison-effect.ts
@@ -4,6 +4,7 @@ import { CardStatePoisoned } from '../state/card-state-poisoned';
 import { EffectLevel } from './effect-level';
 import { FightingContext } from '../fighting-context';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
+import { roundTo2 } from '../../../../tools/round';
 
 export class PoisonAttackEffect implements AttackEffect {
   public readonly rate: number;
@@ -35,7 +36,7 @@ export class PoisonAttackEffect implements AttackEffect {
     const poisonedState = new CardStatePoisoned(
       this.level,
       this.computePoisonedTurns(),
-      card.actualAttack * this.rate,
+      roundTo2(card.actualAttack * this.rate),
       this.terminationEvent,
     );
     defender.setState(poisonedState);

--- a/src/fight/core/cards/@types/attack/attack-poison-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-poison-effect.ts
@@ -4,7 +4,7 @@ import { CardStatePoisoned } from '../state/card-state-poisoned';
 import { EffectLevel } from './effect-level';
 import { FightingContext } from '../fighting-context';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
-import { roundTo2 } from '../../../../tools/round';
+import { round2 } from '../../../../tools/round';
 
 export class PoisonAttackEffect implements AttackEffect {
   public readonly rate: number;
@@ -36,7 +36,7 @@ export class PoisonAttackEffect implements AttackEffect {
     const poisonedState = new CardStatePoisoned(
       this.level,
       this.computePoisonedTurns(),
-      roundTo2(card.actualAttack * this.rate),
+      round2(card.actualAttack * this.rate),
       this.terminationEvent,
     );
     defender.setState(poisonedState);

--- a/src/fight/core/cards/__tests__/fighting-card.spec.ts
+++ b/src/fight/core/cards/__tests__/fighting-card.spec.ts
@@ -135,6 +135,69 @@ describe('FightingCard.removeEventBoundBuffs()', () => {
   });
 });
 
+describe('FightingCard number precision', () => {
+  describe('applyBuff()', () => {
+    it('rounds buff value to 2 decimal places', () => {
+      const card = createFightingCard({
+        attack: 33,
+        defense: 0,
+        accuracy: 0,
+        agility: 0,
+      });
+
+      const buff = card.applyBuff('attack', 0.1, 2);
+
+      expect(buff.value).toBe(3.3);
+    });
+  });
+
+  describe('applyDebuff()', () => {
+    it('rounds debuff value to 2 decimal places', () => {
+      const card = createFightingCard({
+        attack: 33,
+        defense: 0,
+        accuracy: 0,
+        agility: 0,
+      });
+
+      const debuff = card.applyDebuff('attack', 0.1, 2);
+
+      expect(debuff.value).toBe(3.3);
+    });
+  });
+
+  describe('heal()', () => {
+    it('rounds healed amount to 2 decimal places', () => {
+      const card = createFightingCard({
+        health: 100,
+        attack: 0,
+        defense: 0,
+        accuracy: 0,
+        agility: 0,
+      });
+      card.applyFinalDamage(20);
+
+      const healed = card.heal(33 * 0.1);
+
+      expect(healed).toBe(3.3);
+    });
+
+    it('keeps actualHealth clean after floating-point healing', () => {
+      const card = createFightingCard({
+        health: 100,
+        attack: 0,
+        defense: 0,
+        accuracy: 0,
+        agility: 0,
+      });
+      card.applyFinalDamage(20);
+      card.heal(33 * 0.1);
+
+      expect(card.actualHealth).toBe(83.3);
+    });
+  });
+});
+
 describe('FightingCard.lifecycleEndEvents()', () => {
   describe('when card has a lifecycle-limited buff skill with endEvent', () => {
     let card;

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -16,6 +16,7 @@ import { BuffType, DebuffType } from './@types/buff/type';
 import { Element } from './@types/damage/element';
 import { TargetingCardStrategy } from '../targeting-card-strategies/targeting-card-strategy';
 import { NamedAttackResult } from './@types/action-result/named-attack-result';
+import { roundTo2 } from '../../tools/round';
 
 export type TargetingOverrideEntry = {
   strategy: TargetingCardStrategy;
@@ -344,9 +345,10 @@ export class FightingCard {
   }
 
   public heal(hpToRestore: number): number {
-    let healed = hpToRestore;
+    const rounded = roundTo2(hpToRestore);
+    let healed = rounded;
 
-    if (this.actualHealth + hpToRestore > this.maxHealth) {
+    if (this.actualHealth + rounded > this.maxHealth) {
       healed = this.maxHealth - this.actualHealth;
     }
 
@@ -476,13 +478,13 @@ export class FightingCard {
   ): number {
     switch (type) {
       case 'attack':
-        return rate * this.attack;
+        return roundTo2(rate * this.attack);
       case 'defense':
-        return rate * this.defense;
+        return roundTo2(rate * this.defense);
       case 'agility':
-        return rate * this.agility;
+        return roundTo2(rate * this.agility);
       case 'accuracy':
-        return rate * this.accuracy;
+        return roundTo2(rate * this.accuracy);
       default:
         throw new Error(`Unknown attribute type: ${type}`);
     }

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -16,7 +16,7 @@ import { BuffType, DebuffType } from './@types/buff/type';
 import { Element } from './@types/damage/element';
 import { TargetingCardStrategy } from '../targeting-card-strategies/targeting-card-strategy';
 import { NamedAttackResult } from './@types/action-result/named-attack-result';
-import { roundTo2 } from '../../tools/round';
+import { round2 } from '../../tools/round';
 
 export type TargetingOverrideEntry = {
   strategy: TargetingCardStrategy;
@@ -345,10 +345,10 @@ export class FightingCard {
   }
 
   public heal(hpToRestore: number): number {
-    const rounded = roundTo2(hpToRestore);
-    let healed = rounded;
+    const roundedHpToRestore = round2(hpToRestore);
+    let healed = roundedHpToRestore;
 
-    if (this.actualHealth + rounded > this.maxHealth) {
+    if (this.actualHealth + roundedHpToRestore > this.maxHealth) {
       healed = this.maxHealth - this.actualHealth;
     }
 
@@ -478,13 +478,13 @@ export class FightingCard {
   ): number {
     switch (type) {
       case 'attack':
-        return roundTo2(rate * this.attack);
+        return round2(rate * this.attack);
       case 'defense':
-        return roundTo2(rate * this.defense);
+        return round2(rate * this.defense);
       case 'agility':
-        return roundTo2(rate * this.agility);
+        return round2(rate * this.agility);
       case 'accuracy':
-        return roundTo2(rate * this.accuracy);
+        return round2(rate * this.accuracy);
       default:
         throw new Error(`Unknown attribute type: ${type}`);
     }

--- a/src/fight/tools/round.ts
+++ b/src/fight/tools/round.ts
@@ -1,3 +1,3 @@
-export function roundTo2(value: number): number {
-  return Math.round(value * 100) / 100;
+export function round2(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
 }

--- a/src/fight/tools/round.ts
+++ b/src/fight/tools/round.ts
@@ -1,0 +1,3 @@
+export function roundTo2(value: number): number {
+  return Math.round(value * 100) / 100;
+}


### PR DESCRIPTION
Introduce roundTo2() utility and apply it to buff/debuff values,
healing amounts, and poison/burn damage values to prevent
imprecision like 3.3000000000000003 propagating into fight reports.

Fixes #193
https://claude.ai/code/session_01MnnPVDhMe1RNSzWgmYuywM