### PR TITLE
Add damage kind to attack output (#192)

### DIFF
--- a/src/fight/core/__tests__/attack.spec.ts
+++ b/src/fight/core/__tests__/attack.spec.ts
@@ -157,6 +157,79 @@ describe('Trigger an attack without effect', () => {
   });
 });
 
+describe('Trigger an attack with damage kind', () => {
+  let attacker: FightingCard;
+  let defender: FightingCard;
+  let player1: Player;
+  let player2: Player;
+  let fight: Fight;
+
+  beforeEach(() => {
+    attacker = createFightingCard({
+      attack: 100,
+      criticalChance: 0,
+      speed: 100,
+      agility: 0,
+      skills: {
+        simpleAttack: {
+          damages: [new DamageComposition(DamageType.FIRE, 1.0)],
+        },
+      },
+    });
+    defender = createFightingCard({
+      attack: 0,
+      defense: 0,
+      health: 100,
+      speed: 0,
+      agility: 0,
+      skills: {
+        simpleAttack: {
+          damages: [new DamageComposition(DamageType.PHYSICAL, 1.0)],
+        },
+      },
+    });
+    player1 = new Player('Player 1', [attacker]);
+    player2 = new Player('Player 2', [defender]);
+    fight = new Fight(
+      player1,
+      player2,
+      new PlayerByPlayerCardSelector(player1, player2),
+    );
+  });
+
+  it('includes kind in damage entry', () => {
+    expect(fight.start()).toMatchObject({
+      1: { damages: [{ kind: [DamageType.FIRE] }] },
+    });
+  });
+
+  it('includes kind for multi-type damage', () => {
+    const multiAttacker = createFightingCard({
+      attack: 100,
+      criticalChance: 0,
+      speed: 100,
+      agility: 0,
+      skills: {
+        simpleAttack: {
+          damages: [
+            new DamageComposition(DamageType.PHYSICAL, 0.7),
+            new DamageComposition(DamageType.FIRE, 0.3),
+          ],
+        },
+      },
+    });
+    const p1 = new Player('P1', [multiAttacker]);
+    const p2 = new Player('P2', [
+      createFightingCard({ defense: 0, health: 100, speed: 0 }),
+    ]);
+    const f = new Fight(p1, p2, new PlayerByPlayerCardSelector(p1, p2));
+
+    expect(f.start()).toMatchObject({
+      1: { damages: [{ kind: [DamageType.PHYSICAL, DamageType.FIRE] }] },
+    });
+  });
+});
+
 describe('Trigger an attack with critical hit', () => {
   let attacker: FightingCard;
   let defender: FightingCard;

--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -221,6 +221,7 @@ export class ActionStage {
         dodge: damageDealt.dodge,
         remainingHealth:
           damageDealt.remainingHealth ?? defensiveCard.actualHealth,
+        kind: damageDealt.kind,
       });
 
       if (defensiveCard.isDead() && !reportedDeaths.has(defensiveCard)) {

--- a/src/fight/core/cards/@types/action-result/attack-result.ts
+++ b/src/fight/core/cards/@types/action-result/attack-result.ts
@@ -1,6 +1,7 @@
 import { FightingCard } from '../../fighting-card';
 import { EffectResult } from '../attack/attack-effect';
 import { BuffResults } from './buff-results';
+import { DamageType } from '../damage/damage-type';
 
 export type AttackResult = {
   damage: number;
@@ -10,4 +11,5 @@ export type AttackResult = {
   remainingHealth?: number;
   effect?: EffectResult;
   buffResults?: BuffResults;
+  kind?: DamageType[];
 };

--- a/src/fight/core/cards/skills/multiple-attack.ts
+++ b/src/fight/core/cards/skills/multiple-attack.ts
@@ -46,6 +46,7 @@ export class MultipleAttack implements AttackSkill {
     };
     const hitTargets = new Set<FightingCard>();
     const dodgedTargets = new Set<FightingCard>();
+    const kind = this.damages.map((d) => d.type);
 
     for (let i = 0; i < this.hits; i++) {
       const attackPower = card.actualAttack * (1 + this.amplifier * i);
@@ -70,6 +71,7 @@ export class MultipleAttack implements AttackSkill {
             dodge: true,
             defender,
             remainingHealth: defender.actualHealth,
+            kind,
           });
           continue;
         }
@@ -93,11 +95,13 @@ export class MultipleAttack implements AttackSkill {
           defender,
           remainingHealth: defender.actualHealth,
           effect: effectResult,
+          kind,
         });
       }
     }
 
     if (this.comboFinisher) {
+      const finisherKind = this.comboFinisher.map((d) => d.type);
       for (const defender of hitTargets) {
         if (dodgedTargets.has(defender) || defender.isDead()) continue;
 
@@ -113,6 +117,7 @@ export class MultipleAttack implements AttackSkill {
           dodge: false,
           defender,
           remainingHealth: defender.actualHealth,
+          kind: finisherKind,
         });
       }
     }

--- a/src/fight/core/cards/skills/simple-attack.ts
+++ b/src/fight/core/cards/skills/simple-attack.ts
@@ -44,11 +44,12 @@ export class SimpleAttack implements AttackSkill {
       context.opponentPlayer,
     );
 
+    const kind = this.damages.map((d) => d.type);
     return {
       name: this.name,
       results: defensiveCards.map((defender) => {
         if (defender.dodge(card.actualAccuracy)) {
-          return { damage: 0, isCritical, dodge: true, defender: defender };
+          return { damage: 0, isCritical, dodge: true, defender, kind };
         }
 
         const { total } = DamageCalculator.calculateDamage(
@@ -69,6 +70,7 @@ export class SimpleAttack implements AttackSkill {
           dodge: false,
           defender,
           effect: effectResult,
+          kind,
         };
       }),
     };

--- a/src/fight/core/fight-simulator/@types/damage-report.ts
+++ b/src/fight/core/fight-simulator/@types/damage-report.ts
@@ -1,4 +1,5 @@
 import { CardInfo } from '../../cards/@types/card-info';
+import { DamageType } from '../../cards/@types/damage/damage-type';
 import { StepKind } from './step';
 
 export type Damage = {
@@ -7,6 +8,7 @@ export type Damage = {
   isCritical: boolean;
   dodge: boolean;
   remainingHealth: number;
+  kind?: DamageType[];
 };
 
 export type DamageReport = {

--- a/src/fight/core/fight-simulator/skill-results-to-steps.ts
+++ b/src/fight/core/fight-simulator/skill-results-to-steps.ts
@@ -72,6 +72,7 @@ export function skillResultsToSteps(
             isCritical: r.isCritical,
             dodge: r.dodge,
             remainingHealth: r.defender.actualHealth,
+            kind: r.kind,
           })),
           energy: card.actualEnergy,
         });


### PR DESCRIPTION
Expose the damage type(s) of each hit as a `kind: DamageType[]` field
on every entry in the `damages` array of attack/special_attack steps.
SimpleAttack and MultipleAttack (including combo finisher) now carry
the type list through to the serialized report.

https://claude.ai/code/session_01YaeN6zGrHtBjxW8gF2vDrF

closes: #192 