### PR TITLE
feat: add Fight Replayer frontend feature

### DIFF
--- a/frontend/fight-replayer/css/design-system.css
+++ b/frontend/fight-replayer/css/design-system.css
@@ -1,0 +1,537 @@
+/* ═══════════════════════════════════════════════════════════════
+   Fight Replayer — Design System
+   Dark "embers" theme · Caveat UI font · JetBrains Mono for data
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Tokens ──────────────────────────────────────────────────── */
+:root {
+  /* Surfaces */
+  --bg:          #1c1917;
+  --surface:     #292524;
+  --surface-low: #1a1918;
+  --border:      #44403c;
+  --border-sub:  #2a2825;
+
+  /* Text */
+  --text:        #e7e5e4;
+  --text-sec:    #a8a29e;
+  --text-muted:  #78716c;
+  --text-faint:  #52525b;
+
+  /* Accent */
+  --accent:      #f97316;
+  --accent-dim:  #f9731622;
+
+  /* Teams */
+  --hero:        #3b82f6;
+  --hero-text:   #93c5fd;
+  --hero-glow:   rgba(59,130,246,.33);
+  --boss:        #ef4444;
+  --boss-text:   #fca5a5;
+  --boss-glow:   rgba(239,68,68,.33);
+
+  /* HP */
+  --hp-hi:       #22c55e;
+  --hp-mid:      #f59e0b;
+  --hp-lo:       #ef4444;
+
+  /* Event kind colours */
+  --col-attack:          #fb923c;
+  --col-special:         #f59e0b;
+  --col-healing:         #22c55e;
+  --col-buff:            #a3e635;
+  --col-debuff:          #f87171;
+  --col-status:          #f97316;
+  --col-neutral:         #94a3b8;
+  --col-targeting:       #c084fc;
+  --col-end-win:         #22c55e;
+  --col-end-loss:        #f43f5e;
+
+  /* Element colours */
+  --elem-fire:     #ef4444;
+  --elem-physical: #94a3b8;
+  --elem-water:    #38bdf8;
+  --elem-earth:    #84cc16;
+  --elem-air:      #a78bfa;
+
+  /* Typography */
+  --font-ui:   'Caveat', cursive;
+  --font-mono: 'JetBrains Mono', monospace;
+
+  /* Radius */
+  --r-sm: 4px;
+  --r-md: 6px;
+  --r-lg: 8px;
+  --r-xl: 10px;
+  --r-pill: 12px;
+
+  /* Transitions */
+  --t-fast: 0.15s ease;
+  --t-norm: 0.30s ease;
+}
+
+/* ── Reset ───────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+  height: 100vh;
+  overflow: hidden;
+  line-height: 1.4;
+}
+
+button { cursor: pointer; font-family: var(--font-ui); }
+textarea, input { font-family: var(--font-mono); }
+
+/* ── Scrollbar ───────────────────────────────────────────────── */
+::-webkit-scrollbar       { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: var(--bg); }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+/* ── Typography helpers ──────────────────────────────────────── */
+.mono        { font-family: var(--font-mono); }
+.text-muted  { color: var(--text-muted); }
+.text-accent { color: var(--accent); }
+.hidden      { display: none !important; }
+
+/* ── Element badge ───────────────────────────────────────────── */
+.elem-badge {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: var(--r-sm);
+  color: #fff;
+  margin-right: 3px;
+  line-height: 1.6;
+  vertical-align: middle;
+}
+.elem-badge--FIRE     { background: var(--elem-fire); }
+.elem-badge--PHYSICAL { background: var(--elem-physical); }
+.elem-badge--WATER    { background: var(--elem-water); }
+.elem-badge--EARTH    { background: var(--elem-earth); }
+.elem-badge--AIR      { background: var(--elem-air); }
+
+/* ── Status badge ────────────────────────────────────────────── */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  background: #3f3f46;
+  padding: 1px 7px;
+  border-radius: var(--r-pill);
+  border: 1px solid #52525b;
+  white-space: nowrap;
+}
+
+/* ── HP bar ──────────────────────────────────────────────────── */
+.hp-bar__info {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  margin-bottom: 3px;
+}
+.hp-bar__pct { font-size: 11px; color: var(--text-muted); }
+.hp-bar__track {
+  height: 8px;
+  background: var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.hp-bar__fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width var(--t-norm), background var(--t-norm);
+}
+
+/* ── Card panel ──────────────────────────────────────────────── */
+.card-panel {
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  transition: border-color var(--t-norm), box-shadow var(--t-norm), opacity var(--t-norm);
+  position: relative;
+}
+.card-panel--dead { opacity: 0.4; }
+.card-panel__dead-icon {
+  position: absolute;
+  top: 4px; right: 8px;
+  font-size: 18px;
+  line-height: 1;
+}
+.card-panel__name     { font-weight: 700; font-size: 16px; margin-bottom: 4px; }
+.card-panel__identity { font-size: 11px; color: var(--text-muted); font-family: var(--font-mono); margin-bottom: 6px; }
+.card-panel__statuses { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 6px; }
+.card-panel__buffs    { margin-top: 5px; }
+.card-panel__buff-row {
+  font-size: 11px;
+  color: #86efac;
+  font-family: var(--font-mono);
+  line-height: 1.6;
+}
+.card-panel__debuff-row {
+  font-size: 11px;
+  color: #fca5a5;
+  font-family: var(--font-mono);
+  line-height: 1.6;
+}
+
+/* ── Button ──────────────────────────────────────────────────── */
+.btn {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: var(--r-md);
+  padding: 6px 14px;
+  font-size: 16px;
+  font-family: var(--font-ui);
+  transition: background var(--t-fast);
+  line-height: 1.4;
+}
+.btn:hover { background: var(--border); }
+
+.btn--cta {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-size: 20px;
+  font-weight: 700;
+  padding: 12px 32px;
+  border-radius: var(--r-lg);
+  flex: 1;
+}
+.btn--cta:hover { background: #ea6c09; }
+
+.btn--ghost {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border);
+}
+.btn--ghost:hover { background: var(--surface); }
+
+.btn--play {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-size: 22px;
+  padding: 6px 24px;
+}
+.btn--play:hover { background: #ea6c09; }
+
+.btn--speed {
+  font-size: 13px;
+  padding: 4px 10px;
+  background: transparent;
+  color: var(--text-muted);
+  border-color: transparent;
+}
+.btn--speed.active {
+  background: var(--surface);
+  color: var(--accent);
+  border-color: var(--border);
+}
+
+.btn--sm {
+  font-size: 15px;
+  padding: 4px 10px;
+}
+
+/* ── Timeline scrubber ───────────────────────────────────────── */
+.timeline__scrubber {
+  width: 100%;
+  accent-color: var(--accent);
+  cursor: pointer;
+  height: 4px;
+}
+
+/* ── Playback controls row ───────────────────────────────────── */
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.controls__speeds { display: flex; gap: 4px; margin-left: 8px; }
+
+/* ── Input screen ────────────────────────────────────────────── */
+.input-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  padding: 40px;
+  gap: 32px;
+}
+.input-header { text-align: center; }
+.input-header__label {
+  font-size: 11px;
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.input-header__title {
+  font-size: 42px;
+  font-weight: 700;
+  color: #fef3c7;
+  margin-bottom: 8px;
+}
+.input-header__subtitle { color: var(--text-muted); font-size: 18px; }
+
+.input-form { width: 100%; max-width: 700px; }
+.input-textarea {
+  width: 100%;
+  height: 280px;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  border-radius: var(--r-lg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 16px;
+  resize: vertical;
+  outline: none;
+  transition: border-color var(--t-fast);
+}
+.input-textarea:focus { border-color: var(--accent); }
+.input-textarea--error { border-color: #ef4444; }
+
+.input-error {
+  color: #f87171;
+  font-size: 13px;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+}
+.input-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+/* ── Viewer layout ───────────────────────────────────────────── */
+.viewer {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  max-height: 100vh;
+  overflow: hidden;
+}
+
+.viewer-main {
+  display: grid;
+  grid-template-columns: 220px 1fr 220px;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Topbar */
+.topbar {
+  background: var(--bg);
+  border-bottom: 1px solid var(--surface);
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  gap: 16px;
+  flex-shrink: 0;
+}
+.topbar__center {
+  flex: 1;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+}
+.topbar__label { font-size: 11px; letter-spacing: 3px; }
+.topbar__sep   { color: var(--border); margin: 0 12px; }
+.topbar__name  { font-size: 16px; color: #d6d3d1; }
+.topbar__counter { font-family: var(--font-mono); font-size: 13px; color: var(--text-muted); }
+
+/* Side panels */
+.side-panel {
+  background: var(--bg);
+  padding: 12px;
+  overflow-y: auto;
+  min-height: 0;
+}
+.side-panel--left  { border-right: 1px solid var(--surface); }
+.side-panel--right { border-left: 1px solid var(--surface); }
+.side-panel__header {
+  font-size: 13px;
+  margin-bottom: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+.side-panel__header--hero { color: var(--hero); }
+.side-panel__header--boss { color: var(--boss); }
+
+/* Center panel */
+.center-panel {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  padding: 16px 20px;
+  gap: 12px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Event card */
+.event-card {
+  flex: 1;
+  background: var(--surface);
+  border-radius: var(--r-xl);
+  border: 1.5px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  justify-content: center;
+  min-height: 0;
+  overflow-y: auto;
+  transition: border-color var(--t-norm), box-shadow var(--t-norm);
+}
+.event-card--empty { padding: 20px; }
+.event-empty {
+  text-align: center;
+  color: var(--text-faint);
+  font-size: 20px;
+  padding: 20px;
+}
+.event-empty__icon { font-size: 48px; margin-bottom: 12px; }
+
+.event-inner { padding: 20px; display: flex; flex-direction: column; gap: 10px; }
+.event-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+.event-icon  { font-size: 32px; line-height: 1; flex-shrink: 0; }
+.event-meta  { font-size: 11px; color: var(--text-muted); font-family: var(--font-mono); }
+.event-title { font-size: 22px; font-weight: 700; margin-top: 2px; }
+
+.event-detail-text {
+  background: var(--bg);
+  border-radius: var(--r-md);
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--text-sec);
+  line-height: 1.7;
+}
+
+/* Attack detail */
+.attack-targets { display: flex; flex-direction: column; gap: 6px; }
+.attack-target {
+  background: var(--bg);
+  border-radius: var(--r-md);
+  padding: 8px 14px;
+}
+.attack-target__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.attack-target__name-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.attack-target__name { font-size: 14px; color: var(--text); }
+.attack-target__tag  { font-size: 11px; color: var(--text-muted); }
+.attack-target__tag--crit  { color: #f59e0b; }
+.attack-target__tag--dodge { color: var(--text-muted); }
+.attack-target__dmg {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  flex-shrink: 0;
+}
+.attack-target__dmg--dealt { color: #f87171; }
+.attack-target__dmg--zero  { color: var(--text-muted); }
+.attack-target__hp { color: var(--text-faint); font-size: 12px; }
+.attack-target__types { margin-top: 4px; display: flex; gap: 4px; flex-wrap: wrap; }
+.attack-target__breakdown {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.attack-breakdown-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-left: 8px;
+  border-left: 2px solid var(--surface);
+}
+.attack-breakdown-row__count { font-size: 11px; color: var(--text-faint); font-family: var(--font-mono); }
+.attack-breakdown-row__dmg   { font-size: 12px; font-family: var(--font-mono); }
+.attack-breakdown-row__dmg--dealt { color: #fca5a5; }
+.attack-breakdown-row__dmg--zero  { color: var(--text-faint); }
+
+/* Buff / Heal detail rows */
+.detail-rows { display: flex; flex-direction: column; gap: 4px; }
+.detail-row {
+  background: var(--bg);
+  border-radius: var(--r-md);
+  padding: 8px 14px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.detail-row--buff   { color: #86efac; }
+.detail-row--debuff { color: #fca5a5; }
+.detail-row--heal   { color: #86efac; }
+
+/* Event log (bottom) */
+.event-log {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--surface);
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+.event-log__label {
+  padding: 6px 12px 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 2px;
+  flex-shrink: 0;
+}
+.event-log__scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  display: flex;
+  padding: 0 8px 8px;
+  gap: 4px;
+  align-items: stretch;
+}
+
+.log-item {
+  flex-shrink: 0;
+  width: 120px;
+  cursor: pointer;
+  border-radius: var(--r-md);
+  padding: 6px 8px;
+  background: var(--bg);
+  border: 1.5px solid var(--border-sub);
+  transition: all var(--t-fast);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.log-item:hover { background: var(--surface); }
+.log-item__step  { font-size: 10px; color: var(--text-faint); font-family: var(--font-mono); }
+.log-item__icon  { font-size: 16px; line-height: 1; }
+.log-item__label { font-size: 11px; color: var(--text-muted); line-height: 1.3; word-break: break-word; }
+.log-item--active .log-item__label { color: var(--text); }

--- a/frontend/fight-replayer/index.html
+++ b/frontend/fight-replayer/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fight Replayer — Card Game</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link
+    href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;600;700&family=JetBrains+Mono:wght@400;600&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="css/design-system.css">
+</head>
+<body>
+  <div id="app"></div>
+  <!--
+    Fight Replayer — vanilla HTML/CSS/JS, no framework.
+    Serve via HTTP (e.g. `npx serve .` or configure NestJS ServeStaticModule).
+    ES modules require HTTP — opening index.html as a local file:// will not work.
+  -->
+  <script type="module" src="js/replayer.js"></script>
+</body>
+</html>

--- a/frontend/fight-replayer/js/icons.js
+++ b/frontend/fight-replayer/js/icons.js
@@ -1,0 +1,74 @@
+/**
+ * Fight Replayer — Icon & Color Design System
+ * Centralises all icon glyphs and event colour tokens.
+ */
+
+/** Emoji icons by category */
+export const ICON = {
+  /* Attacks */
+  attack:            '⚔️',
+  special_attack:    '✨',
+  /* Healing */
+  healing:           '💚',
+  /* Buff / Debuff */
+  buff:              '⬆️',
+  debuff:            '⬇️',
+  buff_removed:      '✖️',
+  debuff_removed:    '✖️',
+  buff_expired:      '⬇️',
+  debuff_expired:    '⬇️',
+  /* Status effects */
+  burn:              '🔥',
+  poison:            '☠️',
+  freeze:            '❄️',
+  dead:              '💀',
+  status_change:     '⚡',
+  state_effect:      '💢',
+  /* Targeting */
+  targeting_override: '🎯',
+  targeting_reverted: '🔄',
+  /* Events */
+  effect_removed:    '✖️',
+  fight_end:         '🏆',
+  fight_end_loss:    '💀',
+  /* Fallbacks */
+  start:             '⚡',
+  unknown:           '•',
+};
+
+/** Per-status icon lookup */
+export const STATUS_ICON = {
+  burn:   ICON.burn,
+  poison: ICON.poison,
+  freeze: ICON.freeze,
+};
+
+/** Primary colour per event kind */
+export const EVENT_COLOR = {
+  attack:            '#fb923c',
+  special_attack:    '#f59e0b',
+  healing:           '#22c55e',
+  buff:              '#a3e635',
+  debuff:            '#f87171',
+  buff_removed:      '#94a3b8',
+  debuff_removed:    '#94a3b8',
+  buff_expired:      '#94a3b8',
+  debuff_expired:    '#94a3b8',
+  status_change:     '#f97316',
+  state_effect_burn: '#f97316',
+  state_effect_poison: '#84cc16',
+  state_effect_freeze: '#38bdf8',
+  targeting_override: '#c084fc',
+  targeting_reverted: '#c084fc',
+  effect_removed:    '#94a3b8',
+  fight_end:         '#22c55e',
+};
+
+/** Elemental damage type colours */
+export const ELEM_COLOR = {
+  FIRE:     '#ef4444',
+  PHYSICAL: '#94a3b8',
+  WATER:    '#38bdf8',
+  EARTH:    '#84cc16',
+  AIR:      '#a78bfa',
+};

--- a/frontend/fight-replayer/js/parser.js
+++ b/frontend/fight-replayer/js/parser.js
@@ -1,0 +1,301 @@
+/**
+ * Fight Replayer — Data Parser
+ *
+ * Transforms a raw fight-result JSON object into:
+ *   - events[]     — sorted array of step objects
+ *   - snapshots[]  — card-state after each event (index 0 = initial)
+ *   - teams        — { A: { ids: Set, name }, B: { ids: Set, name } }
+ *   - cardsMeta    — { [id]: { id, name, deckIdentity } }
+ */
+
+// ── Card discovery helpers ─────────────────────────────────────
+
+function registerCard(meta, c) {
+  if (!c?.id || meta[c.id]) return;
+  meta[c.id] = { id: c.id, name: c.name, deckIdentity: c.deckIdentity ?? '' };
+}
+
+function trackFirstHP(firstHP, card, remaining, damage) {
+  if (!card?.id || firstHP[card.id] !== undefined) return;
+  firstHP[card.id] = (remaining ?? 0) + (damage ?? 0);
+}
+
+function discoverCards(events) {
+  const meta = {};
+  const firstHP = {};
+
+  events.forEach(ev => {
+    registerCard(meta, ev.attacker);
+    registerCard(meta, ev.source);
+    registerCard(meta, ev.card);
+    ev.damages?.forEach(d => {
+      registerCard(meta, d.defender);
+      trackFirstHP(firstHP, d.defender, d.remainingHealth, d.damage);
+    });
+    ev.heal?.forEach(h => registerCard(meta, h.target));
+    ev.buffs?.forEach(b => registerCard(meta, b.target));
+    ev.debuffs?.forEach(b => registerCard(meta, b.target));
+    ev.removed?.forEach(r => registerCard(meta, r.target));
+    if (ev.kind === 'state_effect') {
+      trackFirstHP(firstHP, ev.card, ev.remainingHealth, ev.damage);
+    }
+  });
+
+  return { meta, firstHP };
+}
+
+// ── Team detection ─────────────────────────────────────────────
+
+function detectTeams(cardsMeta, events) {
+  const ids = Object.keys(cardsMeta);
+
+  // Strategy 1: group by deckIdentity prefix (strip trailing "-N" or " N")
+  const groups = {};
+  ids.forEach(id => {
+    const identity = cardsMeta[id]?.deckIdentity;
+    if (identity) {
+      const base = identity.replace(/[-\s]\d+$/, '').trim() || identity;
+      (groups[base] = groups[base] ?? []).push(id);
+    }
+  });
+
+  const groupNames = Object.keys(groups);
+  if (groupNames.length >= 2) {
+    const nameA = groupNames[0];
+    const nameB = groupNames.length === 2 ? groupNames[1] : groupNames.slice(1).join(' & ');
+    const idsB = groupNames.slice(1).flatMap(n => groups[n]);
+    return {
+      A: { ids: new Set(groups[nameA]), name: nameA },
+      B: { ids: new Set(idsB), name: nameB },
+    };
+  }
+
+  // Strategy 2: attack-graph colouring (BFS)
+  const teamA = new Set();
+  const teamB = new Set();
+  const visited = new Set();
+
+  const firstAttack = events.find(e => e.kind === 'attack' || e.kind === 'special_attack');
+  const seed = firstAttack?.attacker?.id;
+
+  if (seed) {
+    teamA.add(seed);
+    visited.add(seed);
+    const queue = [{ id: seed, side: teamA, other: teamB }];
+
+    while (queue.length) {
+      const { id, side, other } = queue.shift();
+      events.forEach(ev => {
+        if (ev.kind !== 'attack' && ev.kind !== 'special_attack') return;
+        if (ev.attacker?.id === id) {
+          ev.damages?.forEach(d => {
+            const did = d.defender?.id;
+            if (did && !visited.has(did)) {
+              visited.add(did);
+              other.add(did);
+              queue.push({ id: did, side: other, other: side });
+            }
+          });
+        }
+      });
+    }
+  }
+
+  ids.forEach(id => {
+    if (!teamA.has(id) && !teamB.has(id)) teamA.add(id);
+  });
+
+  return {
+    A: { ids: teamA, name: 'Team 1' },
+    B: { ids: teamB, name: 'Team 2' },
+  };
+}
+
+// ── State building ─────────────────────────────────────────────
+
+function buildInitialState(cardsMeta, firstHP) {
+  const state = {};
+  Object.values(cardsMeta).forEach(c => {
+    const maxHP = firstHP[c.id] ?? 1000;
+    state[c.id] = {
+      id: c.id,
+      name: c.name,
+      deckIdentity: c.deckIdentity,
+      maxHP,
+      hp: maxHP,
+      statuses: [],     // active status names: ['burn', 'poison', ...]
+      stateEffects: {}, // { [type]: remainingTurns }
+      buffs: [],        // { kind, value, turns, name, powerId }
+      debuffs: [],      // { kind, value, turns, name, powerId }
+      dead: false,
+    };
+  });
+  return state;
+}
+
+function applyEvent(state, ev) {
+  const get = id => state[id];
+
+  switch (ev.kind) {
+    case 'attack':
+    case 'special_attack':
+      ev.damages?.forEach(d => {
+        const c = get(d.defender?.id);
+        if (c) c.hp = d.remainingHealth;
+      });
+      break;
+
+    case 'healing':
+      ev.heal?.forEach(h => {
+        const c = get(h.target?.id);
+        if (c) c.hp = h.remainingHealth;
+      });
+      break;
+
+    case 'state_effect': {
+      const c = get(ev.card?.id);
+      if (!c) break;
+      c.hp = ev.remainingHealth;
+      if (ev.remainingTurns <= 0) {
+        c.statuses = c.statuses.filter(s => s !== ev.type);
+        delete c.stateEffects[ev.type];
+      } else {
+        c.stateEffects[ev.type] = ev.remainingTurns;
+      }
+      break;
+    }
+
+    case 'status_change': {
+      const c = get(ev.card?.id);
+      if (!c) break;
+      if (ev.status === 'dead') {
+        c.dead = true;
+        c.hp = 0;
+        c.buffs = [];
+        c.debuffs = [];
+        c.statuses = [];
+        c.stateEffects = {};
+      } else if (!c.statuses.includes(ev.status)) {
+        c.statuses = [...c.statuses, ev.status];
+      }
+      break;
+    }
+
+    case 'buff':
+      ev.buffs?.forEach(b => {
+        const c = get(b.target?.id);
+        if (!c) return;
+        c.buffs = [...c.buffs, {
+          kind: b.kind,
+          value: b.value,
+          turns: b.remainingTurns,
+          name: ev.name ?? '',
+          powerId: ev.powerId ?? null,
+        }];
+      });
+      break;
+
+    case 'debuff':
+      ev.debuffs?.forEach(b => {
+        const c = get(b.target?.id);
+        if (!c) return;
+        c.debuffs = [...c.debuffs, {
+          kind: b.kind,
+          value: b.value,
+          turns: b.remainingTurns,
+          name: ev.name ?? '',
+          powerId: ev.powerId ?? null,
+        }];
+      });
+      break;
+
+    case 'buff_expired': {
+      const c = get(ev.card?.id);
+      if (!c) break;
+      (ev.expired ?? []).forEach(e => {
+        const idx = c.buffs.findIndex(b => b.kind === e.kind);
+        if (idx !== -1) c.buffs.splice(idx, 1);
+      });
+      break;
+    }
+
+    case 'debuff_expired': {
+      const c = get(ev.card?.id);
+      if (!c) break;
+      (ev.expired ?? []).forEach(e => {
+        const idx = c.debuffs.findIndex(b => b.kind === e.kind);
+        if (idx !== -1) c.debuffs.splice(idx, 1);
+      });
+      break;
+    }
+
+    case 'buff_removed':
+      (ev.removed ?? []).forEach(r => {
+        const c = get(r.target?.id);
+        if (!c) return;
+        const idx = c.buffs.findIndex(b => b.kind === r.kind);
+        if (idx !== -1) c.buffs.splice(idx, 1);
+      });
+      if (ev.powerId) {
+        Object.values(state).forEach(c => {
+          c.buffs = c.buffs.filter(b => b.powerId !== ev.powerId);
+        });
+      }
+      break;
+
+    case 'debuff_removed':
+      (ev.removed ?? []).forEach(r => {
+        const c = get(r.target?.id);
+        if (!c) return;
+        const idx = c.debuffs.findIndex(b => b.kind === r.kind);
+        if (idx !== -1) c.debuffs.splice(idx, 1);
+      });
+      break;
+
+    case 'effect_removed':
+      (ev.removed ?? []).forEach(r => {
+        const c = get(r.target?.id);
+        if (!c) return;
+        c.statuses = c.statuses.filter(s => s !== r.effectType);
+        delete c.stateEffects[r.effectType];
+      });
+      if (ev.powerId) {
+        Object.values(state).forEach(c => {
+          c.buffs = c.buffs.filter(b => b.powerId !== ev.powerId);
+        });
+      }
+      break;
+
+    // targeting_override / targeting_reverted don't mutate card stats
+    default: break;
+  }
+}
+
+// ── Public API ─────────────────────────────────────────────────
+
+/**
+ * Parse a raw fight-result JSON object.
+ * @param {Object} rawJson — { "1": { kind, ... }, "2": { ... }, ... }
+ * @returns {{ events, snapshots, teams, cardsMeta }}
+ */
+export function parseReport(rawJson) {
+  const events = Object.entries(rawJson)
+    .sort(([a], [b]) => +a - +b)
+    .map(([k, v]) => ({ _step: +k, ...v }));
+
+  const { meta: cardsMeta, firstHP } = discoverCards(events);
+  const teams = detectTeams(cardsMeta, events);
+
+  // Build snapshot array: index 0 = before any event
+  const snapshots = [];
+  let cur = buildInitialState(cardsMeta, firstHP);
+  snapshots.push(JSON.parse(JSON.stringify(cur)));
+
+  events.forEach(ev => {
+    cur = JSON.parse(JSON.stringify(cur));
+    applyEvent(cur, ev);
+    snapshots.push(JSON.parse(JSON.stringify(cur)));
+  });
+
+  return { events, snapshots, teams, cardsMeta };
+}

--- a/frontend/fight-replayer/js/replayer.js
+++ b/frontend/fight-replayer/js/replayer.js
@@ -1,0 +1,616 @@
+/**
+ * Fight Replayer — Main Application
+ * Vanilla JS, no framework.  Manages state, renders DOM, drives playback.
+ */
+
+import { ICON, STATUS_ICON, EVENT_COLOR, ELEM_COLOR } from './icons.js';
+import { parseReport } from './parser.js';
+
+// ── Utilities ──────────────────────────────────────────────────
+
+/** HTML-escape a value so it's safe to inject via innerHTML. */
+const esc = v => String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/** Return the CSS variable name for an event's colour. */
+function eventColor(kind, subtype) {
+  if (kind === 'state_effect') return EVENT_COLOR[`state_effect_${subtype}`] ?? EVENT_COLOR.state_effect_burn;
+  if (kind === 'fight_end') return EVENT_COLOR.fight_end;
+  return EVENT_COLOR[kind] ?? null;
+}
+
+/** Render an element-type badge HTML string. */
+function elemBadge(type) {
+  return `<span class="elem-badge elem-badge--${esc(type)}">${esc(type)}</span>`;
+}
+
+// ── Application state ──────────────────────────────────────────
+
+const app = {
+  data: null,       // parseReport() result
+  step: 0,          // 0 = before any event
+  isPlaying: false,
+  speed: 1,
+  timer: null,
+};
+
+// ── Bootstrap ──────────────────────────────────────────────────
+
+document.addEventListener('DOMContentLoaded', renderInputScreen);
+
+// ── Input screen ───────────────────────────────────────────────
+
+function renderInputScreen() {
+  document.getElementById('app').innerHTML = `
+    <div class="input-screen">
+      <div class="input-header">
+        <div class="input-header__label mono text-accent">CARD GAME · FIGHT REPLAYER</div>
+        <h1 class="input-header__title">Fight Replayer</h1>
+        <p class="input-header__subtitle">Paste your fight result JSON to analyze the battle</p>
+      </div>
+      <div class="input-form">
+        <textarea id="json-input" class="input-textarea"
+          placeholder='{ "1": { "kind": "attack", ... }, "2": { ... } }'
+          spellcheck="false"></textarea>
+        <div id="json-error" class="input-error hidden"></div>
+        <div class="input-actions">
+          <button id="btn-analyze" class="btn btn--cta">Analyze fight →</button>
+          <button id="btn-demo" class="btn btn--ghost">Load demo</button>
+        </div>
+      </div>
+    </div>`;
+
+  document.getElementById('btn-analyze').addEventListener('click', handleAnalyze);
+  document.getElementById('btn-demo').addEventListener('click', handleDemo);
+  document.getElementById('json-input').addEventListener('input', () => {
+    document.getElementById('json-error').classList.add('hidden');
+    document.getElementById('json-input').classList.remove('input-textarea--error');
+  });
+}
+
+function handleAnalyze() {
+  const raw = document.getElementById('json-input').value.trim();
+  if (!raw) return;
+  try {
+    loadData(parseReport(JSON.parse(raw)));
+  } catch (e) {
+    const err = document.getElementById('json-error');
+    err.textContent = 'Invalid JSON: ' + e.message;
+    err.classList.remove('hidden');
+    document.getElementById('json-input').classList.add('input-textarea--error');
+  }
+}
+
+function handleDemo() {
+  try { loadData(parseReport(DEMO_DATA)); }
+  catch (e) { console.error('Demo load failed', e); }
+}
+
+function loadData(data) {
+  app.data = data;
+  app.step = 0;
+  stopPlay();
+  renderViewer();
+}
+
+// ── Viewer ─────────────────────────────────────────────────────
+
+function renderViewer() {
+  const { data } = app;
+  const total = data.events.length;
+
+  document.getElementById('app').innerHTML = `
+    <div class="viewer">
+
+      <header class="topbar">
+        <button id="btn-back" class="btn btn--ghost btn--sm">← Back</button>
+        <div class="topbar__center">
+          <span class="mono text-accent topbar__label">CARD GAME</span>
+          <span class="topbar__sep">|</span>
+          <span class="topbar__name">Fight Replayer</span>
+        </div>
+        <div id="step-counter" class="topbar__counter">0 / ${total}</div>
+      </header>
+
+      <main class="viewer-main">
+
+        <aside class="side-panel side-panel--left">
+          <div class="side-panel__header side-panel__header--hero">
+            ⚔ ${esc(data.teams.A.name)}
+          </div>
+          <div id="cards-team-a"></div>
+        </aside>
+
+        <section class="center-panel">
+          <div class="event-card event-card--empty" id="event-card"></div>
+          <div class="timeline">
+            <input type="range" class="timeline__scrubber" id="scrubber"
+              min="0" max="${total}" value="0">
+          </div>
+          <div class="controls">
+            <button class="btn" id="btn-first"  title="First">⏮</button>
+            <button class="btn" id="btn-prev"   title="Previous">⏪</button>
+            <button class="btn btn--play" id="btn-play">▶</button>
+            <button class="btn" id="btn-next"   title="Next">⏩</button>
+            <button class="btn" id="btn-last"   title="Last">⏭</button>
+            <div class="controls__speeds" id="speed-buttons">
+              ${[0.5, 1, 2, 4].map(s =>
+                `<button class="btn btn--speed${s === app.speed ? ' active' : ''}"
+                   data-speed="${s}">${s}x</button>`
+              ).join('')}
+            </div>
+          </div>
+        </section>
+
+        <aside class="side-panel side-panel--right">
+          <div class="side-panel__header side-panel__header--boss">
+            🔥 ${esc(data.teams.B.name)}
+          </div>
+          <div id="cards-team-b"></div>
+        </aside>
+
+      </main>
+
+      <footer class="event-log">
+        <div class="event-log__label mono">📋 EVENT LOG</div>
+        <div class="event-log__scroll" id="log-scroll">
+          ${data.events.map((ev, i) => buildLogItem(ev, i)).join('')}
+        </div>
+      </footer>
+
+    </div>`;
+
+  // ── Bind controls ────────────────────────────────────────────
+
+  document.getElementById('btn-back').addEventListener('click', () => {
+    stopPlay();
+    renderInputScreen();
+  });
+
+  document.getElementById('btn-first').addEventListener('click', () => goTo(0));
+  document.getElementById('btn-prev').addEventListener('click', () => goTo(app.step - 1));
+  document.getElementById('btn-play').addEventListener('click', togglePlay);
+  document.getElementById('btn-next').addEventListener('click', () => goTo(app.step + 1));
+  document.getElementById('btn-last').addEventListener('click', () => goTo(total));
+
+  document.getElementById('scrubber').addEventListener('input', e => {
+    stopPlay();
+    goTo(+e.target.value);
+  });
+
+  document.getElementById('speed-buttons').addEventListener('click', e => {
+    const btn = e.target.closest('[data-speed]');
+    if (!btn) return;
+    app.speed = +btn.dataset.speed;
+    document.querySelectorAll('[data-speed]').forEach(b =>
+      b.classList.toggle('active', +b.dataset.speed === app.speed)
+    );
+    if (app.isPlaying) { stopPlay(); startPlay(); }
+  });
+
+  document.getElementById('log-scroll').addEventListener('click', e => {
+    const item = e.target.closest('.log-item');
+    if (!item) return;
+    stopPlay();
+    goTo(+item.dataset.step);
+  });
+
+  // Initial display
+  updateDisplay();
+}
+
+// ── Step navigation ────────────────────────────────────────────
+
+function goTo(step) {
+  const max = app.data.events.length;
+  app.step = Math.max(0, Math.min(max, step));
+  if (app.step === max) stopPlay();
+  updateDisplay();
+}
+
+function togglePlay() {
+  app.isPlaying ? stopPlay() : startPlay();
+}
+
+function startPlay() {
+  if (app.step >= app.data.events.length) goTo(0);
+  app.isPlaying = true;
+  document.getElementById('btn-play').textContent = '⏸';
+  app.timer = setInterval(() => {
+    if (app.step >= app.data.events.length) { stopPlay(); return; }
+    goTo(app.step + 1);
+  }, 1000 / app.speed);
+}
+
+function stopPlay() {
+  clearInterval(app.timer);
+  app.isPlaying = false;
+  const btn = document.getElementById('btn-play');
+  if (btn) btn.textContent = '▶';
+}
+
+// ── Display update ─────────────────────────────────────────────
+
+function updateDisplay() {
+  const { data, step } = app;
+  const snapshot = data.snapshots[step];
+  const event    = step > 0 ? data.events[step - 1] : null;
+
+  const activeIds = getActiveIds(event);
+  const total = data.events.length;
+
+  // Counter
+  const counter = document.getElementById('step-counter');
+  if (counter) {
+    const fightEnd = data.events.find(e => e.kind === 'fight_end');
+    const winner   = fightEnd?.winner;
+    let extra = '';
+    if (winner && step === total) {
+      const col = winner === data.teams.B.name ? 'var(--col-end-loss)' : 'var(--col-end-win)';
+      extra = ` <span style="color:${col};margin-left:12px">
+        ${winner === data.teams.B.name ? '💀' : '🏆'} ${esc(winner)} wins
+      </span>`;
+    }
+    counter.innerHTML = `${step} / ${total}${extra}`;
+  }
+
+  // Scrubber
+  const scrubber = document.getElementById('scrubber');
+  if (scrubber) scrubber.value = step;
+
+  // Card panels
+  const teamACards = [...data.teams.A.ids].map(id => snapshot[id]).filter(Boolean);
+  const teamBCards = [...data.teams.B.ids].map(id => snapshot[id]).filter(Boolean);
+
+  const panelA = document.getElementById('cards-team-a');
+  const panelB = document.getElementById('cards-team-b');
+  if (panelA) panelA.innerHTML = teamACards.map(c => buildCardPanel(c, true, activeIds.has(c.id))).join('');
+  if (panelB) panelB.innerHTML = teamBCards.map(c => buildCardPanel(c, false, activeIds.has(c.id))).join('');
+
+  // Event card
+  const eventCard = document.getElementById('event-card');
+  if (eventCard) {
+    eventCard.innerHTML = buildEventCard(event);
+    const color = event ? (eventColor(event.kind, event.type ?? event.status) ?? null) : null;
+    eventCard.style.borderColor  = color ? color + '55' : 'var(--border)';
+    eventCard.style.boxShadow    = color ? `0 0 24px ${color}22` : 'none';
+    eventCard.classList.toggle('event-card--empty', !event);
+  }
+
+  // Log highlight: only touch affected items
+  const prevActive = document.querySelector('.log-item--active');
+  if (prevActive) {
+    prevActive.classList.remove('log-item--active');
+    prevActive.style.borderColor = 'var(--border-sub)';
+    prevActive.style.background  = '';
+    prevActive.style.boxShadow   = '';
+    prevActive.querySelector('.log-item__label').style.color = 'var(--text-muted)';
+  }
+
+  if (step > 0) {
+    const current = document.querySelector(`.log-item[data-step="${step}"]`);
+    if (current) {
+      const ev    = data.events[step - 1];
+      const color = eventColor(ev.kind, ev.type ?? ev.status) ?? 'var(--accent)';
+      current.classList.add('log-item--active');
+      current.style.borderColor = color;
+      current.style.background  = 'var(--surface)';
+      current.style.boxShadow   = `0 0 8px ${color}44`;
+      current.querySelector('.log-item__label').style.color = 'var(--text)';
+      current.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  }
+}
+
+function getActiveIds(event) {
+  const ids = new Set();
+  if (!event) return ids;
+  if (event.attacker) ids.add(event.attacker.id);
+  if (event.source)   ids.add(event.source.id);
+  if (event.card)     ids.add(event.card.id);
+  event.damages?.forEach(d => ids.add(d.defender?.id));
+  event.buffs?.forEach(b => ids.add(b.target?.id));
+  event.debuffs?.forEach(b => ids.add(b.target?.id));
+  event.heal?.forEach(h => ids.add(h.target?.id));
+  return ids;
+}
+
+// ── HTML builders ──────────────────────────────────────────────
+
+function buildLogItem(ev, i) {
+  const { icon } = describeEvent(ev);
+  const label = esc(ev.name || ev.kind);
+  return `
+    <div class="log-item" data-step="${i + 1}">
+      <div class="log-item__step">#${ev._step}</div>
+      <div class="log-item__icon">${icon}</div>
+      <div class="log-item__label">${label}</div>
+    </div>`;
+}
+
+function buildCardPanel(card, isTeamA, isActive) {
+  const teamColor  = isTeamA ? 'var(--hero)' : 'var(--boss)';
+  const nameColor  = isTeamA ? 'var(--hero-text)' : 'var(--boss-text)';
+  const glowColor  = isTeamA ? 'var(--hero-glow)' : 'var(--boss-glow)';
+  const borderCol  = isActive ? teamColor : 'var(--border)';
+  const shadow     = isActive ? `0 0 12px ${glowColor}` : 'none';
+
+  const pct    = Math.max(0, Math.min(1, card.hp / card.maxHP));
+  const hpCol  = pct > 0.6 ? 'var(--hp-hi)' : pct > 0.3 ? 'var(--hp-mid)' : 'var(--hp-lo)';
+
+  const statusesHtml = card.statuses.length
+    ? `<div class="card-panel__statuses">
+        ${card.statuses.map(s =>
+          `<span class="status-badge">${STATUS_ICON[s] ?? '⚡'} ${esc(s)}</span>`
+        ).join('')}
+      </div>`
+    : '';
+
+  const buffsHtml = card.buffs.length
+    ? `<div class="card-panel__buffs">
+        ${card.buffs.slice(-3).map(b =>
+          `<div class="card-panel__buff-row">
+            ↑ ${esc(b.kind)} +${b.value}${b.turns != null ? ` (${b.turns}T)` : ' (∞)'}
+          </div>`
+        ).join('')}
+      </div>`
+    : '';
+
+  const debuffsHtml = card.debuffs.length
+    ? `<div class="card-panel__buffs">
+        ${card.debuffs.slice(-3).map(b =>
+          `<div class="card-panel__debuff-row">
+            ↓ ${esc(b.kind)} −${b.value}${b.turns != null ? ` (${b.turns}T)` : ''}
+          </div>`
+        ).join('')}
+      </div>`
+    : '';
+
+  const hpHtml = !card.dead ? `
+    <div class="hp-bar">
+      <div class="hp-bar__info">
+        <span class="mono" style="color:${hpCol}">${Math.round(card.hp)} / ${card.maxHP}</span>
+        <span class="hp-bar__pct">${(pct * 100).toFixed(0)}%</span>
+      </div>
+      <div class="hp-bar__track">
+        <div class="hp-bar__fill" style="width:${pct * 100}%;background:${hpCol}"></div>
+      </div>
+    </div>` : '';
+
+  return `
+    <div class="card-panel${card.dead ? ' card-panel--dead' : ''}"
+         style="border-color:${borderCol};box-shadow:${shadow}">
+      ${card.dead ? '<div class="card-panel__dead-icon">💀</div>' : ''}
+      <div class="card-panel__name" style="color:${nameColor}">${esc(card.name)}</div>
+      ${card.deckIdentity ? `<div class="card-panel__identity">${esc(card.deckIdentity)}</div>` : ''}
+      ${hpHtml}
+      ${statusesHtml}
+      ${buffsHtml}
+      ${debuffsHtml}
+    </div>`;
+}
+
+function buildEventCard(ev) {
+  if (!ev) {
+    return `
+      <div class="event-empty">
+        <div class="event-empty__icon">⚡</div>
+        <div>Press ▶ to start</div>
+      </div>`;
+  }
+
+  const { icon, text, color } = describeEvent(ev);
+  let contentHtml = '';
+
+  if (ev.kind === 'attack' || ev.kind === 'special_attack') {
+    contentHtml = buildAttackDetail(ev);
+  } else if (ev.kind === 'buff') {
+    contentHtml = buildBuffDebuffDetail(ev, 'buff');
+  } else if (ev.kind === 'debuff') {
+    contentHtml = buildBuffDebuffDetail(ev, 'debuff');
+  } else if (ev.kind === 'healing') {
+    contentHtml = buildHealDetail(ev);
+  } else {
+    const detail = buildGenericDetail(ev);
+    if (detail) contentHtml = `<div class="event-detail-text mono">${detail}</div>`;
+  }
+
+  return `
+    <div class="event-inner">
+      <div class="event-header">
+        <span class="event-icon">${icon}</span>
+        <div class="event-heading">
+          <div class="event-meta mono">EVENT #${ev._step} · ${esc(ev.kind.toUpperCase())}</div>
+          <div class="event-title" style="color:${color ?? 'var(--text)'}">${esc(text)}</div>
+        </div>
+      </div>
+      ${contentHtml}
+    </div>`;
+}
+
+function buildAttackDetail(ev) {
+  if (!ev.damages?.length) return '';
+
+  // Group hits by defender id
+  const grouped = {};
+  ev.damages.forEach((d, i) => {
+    const key = d.defender?.id ?? i;
+    if (!grouped[key]) {
+      grouped[key] = { defender: d.defender, hits: [], dodge: false, critical: false, finalHP: d.remainingHealth };
+    }
+    grouped[key].hits.push(d);
+    grouped[key].finalHP = d.remainingHealth;
+    if (d.dodge)      grouped[key].dodge    = true;
+    if (d.isCritical) grouped[key].critical = true;
+  });
+
+  const rows = Object.values(grouped).map(g => {
+    const totalDmg = g.hits.reduce((s, h) => s + (h.damage ?? 0), 0);
+    const multiHit = g.hits.length > 1;
+
+    const tags = [
+      g.dodge    ? `<span class="attack-target__tag attack-target__tag--dodge">DODGED</span>` : '',
+      g.critical ? `<span class="attack-target__tag attack-target__tag--crit">CRIT!</span>` : '',
+      multiHit   ? `<span class="attack-target__tag">${g.hits.length} hits</span>` : '',
+    ].filter(Boolean).join('');
+
+    const dmgClass = totalDmg > 0 ? 'attack-target__dmg--dealt' : 'attack-target__dmg--zero';
+
+    let typesHtml = '';
+    if (multiHit) {
+      // Group hits by element type
+      const byType = {};
+      g.hits.forEach(h => {
+        const key = (h.kind ?? ['?']).join('+');
+        byType[key] = byType[key] ?? { kinds: h.kind ?? [], count: 0, total: 0 };
+        byType[key].count++;
+        byType[key].total += h.damage ?? 0;
+      });
+      const breakdownRows = Object.entries(byType).map(([, t]) => {
+        const dmgCls = t.total > 0 ? 'attack-breakdown-row__dmg--dealt' : 'attack-breakdown-row__dmg--zero';
+        return `
+          <div class="attack-breakdown-row">
+            <span class="attack-breakdown-row__count">${t.count}×</span>
+            ${t.kinds.map(elemBadge).join('')}
+            <span class="attack-breakdown-row__dmg ${dmgCls}">
+              ${t.total > 0 ? `−${t.total}` : '0 dmg'}
+            </span>
+          </div>`;
+      }).join('');
+      typesHtml = `<div class="attack-target__breakdown">${breakdownRows}</div>`;
+    } else {
+      const kinds = g.hits[0]?.kind ?? [];
+      if (kinds.length) {
+        typesHtml = `<div class="attack-target__types">${kinds.map(elemBadge).join('')}</div>`;
+      }
+    }
+
+    return `
+      <div class="attack-target">
+        <div class="attack-target__row">
+          <div class="attack-target__name-row">
+            <span class="attack-target__name">${esc(g.defender?.name ?? '?')}</span>
+            ${tags}
+          </div>
+          <div class="attack-target__dmg ${dmgClass}">
+            ${totalDmg > 0 ? `−${totalDmg}` : '0'}
+            <span class="attack-target__hp"> → ${(g.finalHP ?? 0).toFixed(1)} HP</span>
+          </div>
+        </div>
+        ${typesHtml}
+      </div>`;
+  }).join('');
+
+  return `<div class="attack-targets">${rows}</div>`;
+}
+
+function buildBuffDebuffDetail(ev, type) {
+  const items = type === 'buff' ? ev.buffs : ev.debuffs;
+  if (!items?.length) return '';
+
+  const cssClass = `detail-row--${type}`;
+  const sign = type === 'buff' ? '+' : '−';
+
+  const rows = items.map(b => {
+    const turns = b.remainingTurns != null ? `(${b.remainingTurns}T)` : '(∞)';
+    return `
+      <div class="detail-row ${cssClass}">
+        <span>${esc(b.target?.name)} ← ${esc(b.kind)}</span>
+        <span>${sign}${b.value} ${turns}</span>
+      </div>`;
+  }).join('');
+
+  return `<div class="detail-rows">${rows}</div>`;
+}
+
+function buildHealDetail(ev) {
+  if (!ev.heal?.length) return '';
+
+  const rows = ev.heal.map(h => `
+    <div class="detail-row detail-row--heal">
+      <span>${esc(h.target?.name)}</span>
+      <span>+${(h.healed ?? 0).toFixed(1)} → ${(h.remainingHealth ?? 0).toFixed(1)} HP</span>
+    </div>`
+  ).join('');
+
+  return `<div class="detail-rows">${rows}</div>`;
+}
+
+function buildGenericDetail(ev) {
+  switch (ev.kind) {
+    case 'state_effect':
+      return `−${ev.damage} HP · ${ev.remainingTurns} turn(s) remaining · HP: ${(ev.remainingHealth ?? 0).toFixed(1)}`;
+    case 'buff_expired':
+    case 'debuff_expired': {
+      const types = (ev.expired ?? []).map(e => esc(e.kind)).join(', ');
+      return `on ${esc(ev.card?.name)}: ${types}`;
+    }
+    case 'buff_removed':
+    case 'debuff_removed':
+      return (ev.removed ?? []).map(r => `${esc(r.kind)} from ${esc(r.target?.name)}`).join(', ');
+    case 'effect_removed':
+      return (ev.removed ?? []).map(r => `${esc(r.effectType)} removed from ${esc(r.target?.name)}`).join(', ');
+    case 'targeting_override':
+      return `${esc(ev.previousStrategy)} → ${esc(ev.newStrategy)}`;
+    case 'targeting_reverted':
+      return `${esc(ev.revertedStrategy)} → ${esc(ev.restoredStrategy)}`;
+    case 'fight_end':
+      return ev.winner ? `Winner: ${esc(ev.winner)}` : 'Draw';
+    default:
+      return null;
+  }
+}
+
+// ── Event description (icon + text + colour) ───────────────────
+
+function describeEvent(ev) {
+  if (!ev) return { icon: ICON.start, text: 'Battle in progress…', color: null };
+
+  switch (ev.kind) {
+    case 'attack':
+      return { icon: ICON.attack, text: `${ev.attacker?.name} — ${ev.name ?? 'Attack'}`, color: EVENT_COLOR.attack };
+    case 'special_attack':
+      return { icon: ICON.special_attack, text: `${ev.attacker?.name} — ${ev.name ?? 'Special'} (SPECIAL)`, color: EVENT_COLOR.special_attack };
+    case 'healing':
+      return { icon: ICON.healing, text: `${ev.source?.name} — ${ev.name ?? 'Healing'}`, color: EVENT_COLOR.healing };
+    case 'buff':
+      return { icon: ICON.buff, text: `${ev.source?.name} — ${ev.name ?? 'Buff'}`, color: EVENT_COLOR.buff };
+    case 'debuff':
+      return { icon: ICON.debuff, text: `${ev.source?.name} — ${ev.name ?? 'Debuff'}`, color: EVENT_COLOR.debuff };
+    case 'buff_removed':
+      return { icon: ICON.buff_removed, text: `Buff removed — ${ev.eventName ?? ''}`, color: EVENT_COLOR.buff_removed };
+    case 'debuff_removed':
+      return { icon: ICON.debuff_removed, text: `Debuff removed — ${ev.eventName ?? ''}`, color: EVENT_COLOR.debuff_removed };
+    case 'buff_expired': {
+      const types = (ev.expired ?? []).map(e => e.kind).join(', ') || 'effect';
+      return { icon: ICON.buff_expired, text: `Buff expired: ${types}`, color: EVENT_COLOR.buff_expired };
+    }
+    case 'debuff_expired': {
+      const types = (ev.expired ?? []).map(e => e.kind).join(', ') || 'effect';
+      return { icon: ICON.debuff_expired, text: `Debuff expired: ${types}`, color: EVENT_COLOR.debuff_expired };
+    }
+    case 'status_change':
+      if (ev.status === 'dead')
+        return { icon: ICON.dead, text: `${ev.card?.name} eliminated`, color: '#f43f5e' };
+      return { icon: STATUS_ICON[ev.status] ?? ICON.status_change, text: `${ev.card?.name} — ${ev.status}`, color: EVENT_COLOR.status_change };
+    case 'state_effect': {
+      const col = ev.type === 'burn' ? EVENT_COLOR.state_effect_burn
+                : ev.type === 'poison' ? EVENT_COLOR.state_effect_poison
+                : EVENT_COLOR.state_effect_freeze;
+      return { icon: STATUS_ICON[ev.type] ?? ICON.state_effect, text: `${ev.card?.name} — ${ev.type} tick`, color: col };
+    }
+    case 'targeting_override':
+      return { icon: ICON.targeting_override, text: `${ev.source?.name} — ${ev.name ?? 'Targeting override'}`, color: EVENT_COLOR.targeting_override };
+    case 'targeting_reverted':
+      return { icon: ICON.targeting_reverted, text: `Targeting reverted — ${ev.eventName ?? ''}`, color: EVENT_COLOR.targeting_reverted };
+    case 'effect_removed':
+      return { icon: ICON.effect_removed, text: `Effects removed — ${ev.eventName ?? ''}`, color: EVENT_COLOR.effect_removed };
+    case 'fight_end':
+      return { icon: ev.winner ? ICON.fight_end : ICON.fight_end_loss, text: `FIGHT END — ${ev.winner ? `Winner: ${ev.winner}` : 'Draw'}`, color: EVENT_COLOR.fight_end };
+    default:
+      return { icon: ICON.unknown, text: ev.kind ?? 'Unknown event', color: '#94a3b8' };
+  }
+}
+
+// ── Demo data ──────────────────────────────────────────────────
+
+const DEMO_DATA = {"1":{"kind":"attack","name":"Frappe solide","attacker":{"id":"kaelion","name":"Kaelion","deckIdentity":"Héros-0"},"damages":[{"defender":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"},"damage":60,"isCritical":false,"dodge":false,"remainingHealth":1140,"kind":["PHYSICAL"]}],"energy":10},"2":{"kind":"attack","name":"Poings de Braise","attacker":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"damages":[{"defender":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"damage":0,"isCritical":false,"dodge":false,"remainingHealth":700,"kind":["PHYSICAL","FIRE"]}],"energy":10},"3":{"kind":"status_change","status":"burn","card":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"}},"4":{"kind":"buff","name":"Fierté du lion","source":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"buffs":[{"target":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"kind":"attack","value":4.25,"remainingTurns":null}],"energy":10},"5":{"kind":"attack","name":"Écrasement","attacker":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"},"damages":[{"defender":{"id":"kaelion","name":"Kaelion","deckIdentity":"Héros-0"},"damage":100,"isCritical":false,"dodge":false,"remainingHealth":600,"kind":["PHYSICAL","FIRE"]}],"energy":10},"6":{"kind":"status_change","status":"poison","card":{"id":"kaelion","name":"Kaelion","deckIdentity":"Héros-0"}},"7":{"kind":"buff","name":"Rage du boss","source":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"},"buffs":[{"target":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"},"kind":"attack","value":18,"remainingTurns":3}],"energy":10},"8":{"kind":"attack","name":"Frappe solide","attacker":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"damages":[{"defender":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"damage":0,"isCritical":false,"dodge":false,"remainingHealth":550,"kind":["PHYSICAL"]}],"energy":10},"9":{"kind":"state_effect","card":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"type":"burn","damage":8.5,"remainingTurns":2,"remainingHealth":691.5},"10":{"kind":"attack","name":"Poings de Braise","attacker":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"damages":[{"defender":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"damage":0,"isCritical":false,"dodge":false,"remainingHealth":691.5,"kind":["PHYSICAL","FIRE"]}],"energy":20},"11":{"kind":"buff","name":"Fierté du lion","source":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"buffs":[{"target":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"kind":"attack","value":4.25,"remainingTurns":null}],"energy":20},"12":{"kind":"attack","name":"Frappe solide","attacker":{"id":"kaelion","name":"Kaelion","deckIdentity":"Héros-0"},"damages":[{"defender":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"},"damage":60,"isCritical":false,"dodge":false,"remainingHealth":1080,"kind":["PHYSICAL"]}],"energy":20},"13":{"kind":"state_effect","card":{"id":"kaelion","name":"Kaelion","deckIdentity":"Héros-0"},"type":"poison","damage":36,"remainingTurns":2,"remainingHealth":564},"18":{"kind":"special_attack","name":"Rugissement solaire","attacker":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"damages":[{"defender":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"},"damage":153,"isCritical":false,"dodge":false,"remainingHealth":927},{"defender":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"damage":73,"isCritical":false,"dodge":false,"remainingHealth":618.5}],"energy":0},"19":{"kind":"buff","name":"Rugissement solaire","source":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"buffs":[{"target":{"id":"kaelion","name":"Kaelion","deckIdentity":"Héros-0"},"kind":"attack","value":6,"remainingTurns":1},{"target":{"id":"kaelion","name":"Kaelion","deckIdentity":"Héros-0"},"kind":"defense","value":8,"remainingTurns":1}],"energy":0},"20":{"kind":"status_change","status":"burn","card":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"}},"33":{"kind":"attack","name":"Griffes ardentes","attacker":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"damages":[{"defender":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"damage":0,"isCritical":false,"dodge":false,"remainingHealth":610,"kind":["PHYSICAL"]},{"defender":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"damage":0,"isCritical":false,"dodge":false,"remainingHealth":610,"kind":["PHYSICAL"]},{"defender":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"damage":0,"isCritical":false,"dodge":false,"remainingHealth":610,"kind":["PHYSICAL"]},{"defender":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"damage":0,"isCritical":false,"dodge":false,"remainingHealth":610,"kind":["PHYSICAL"]},{"defender":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"damage":5,"isCritical":false,"dodge":false,"remainingHealth":605,"kind":["FIRE"]}],"energy":10},"39":{"kind":"attack","name":"Écrasement","attacker":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"},"damages":[{"defender":{"id":"kaelion","name":"Kaelion","deckIdentity":"Héros-0"},"damage":154,"isCritical":false,"dodge":false,"remainingHealth":0,"kind":["PHYSICAL","FIRE"]}],"energy":50},"40":{"kind":"status_change","card":{"id":"kaelion","name":"Kaelion","deckIdentity":"Héros-0"},"status":"dead"},"44":{"kind":"buff","name":"Buff Héroïque","source":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"buffs":[{"target":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"kind":"attack","value":34,"remainingTurns":null}],"energy":20,"powerId":"lion-heritage"},"45":{"name":"Vengeance","kind":"targeting_override","source":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"previousStrategy":"from-position","newStrategy":"targeted-card","powerId":"lion-heritage"},"48":{"kind":"special_attack","name":"Tempête infernale","attacker":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"},"damages":[{"defender":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"damage":408,"isCritical":false,"dodge":false,"remainingHealth":142}],"energy":0},"49":{"kind":"status_change","status":"burn","card":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"}},"52":{"kind":"attack","name":"Écrasement","attacker":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"},"damages":[{"defender":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"damage":184,"isCritical":false,"dodge":false,"remainingHealth":0,"kind":["PHYSICAL","FIRE"]}],"energy":10},"53":{"kind":"status_change","card":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"status":"dead"},"54":{"kind":"effect_removed","source":{"id":"arionis","name":"Arionis","deckIdentity":"Héros-1"},"eventName":"lion-heritage-end","removed":[{"target":{"id":"boss","name":"Seigneur des Cendres","deckIdentity":"Boss-0"},"effectType":"burn"},{"target":{"id":"ennemy","name":"Ennemy 1","deckIdentity":"Boss-1"},"effectType":"burn"}]},"56":{"kind":"fight_end","winner":"Boss"}};

--- a/frontend/fight-replayer/js/replayer.js
+++ b/frontend/fight-replayer/js/replayer.js
@@ -12,9 +12,12 @@ import { parseReport } from './parser.js';
 const esc = v => String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 /** Return the CSS variable name for an event's colour. */
-function eventColor(kind, subtype) {
+function eventColor(kind, subtype, ev) {
   if (kind === 'state_effect') return EVENT_COLOR[`state_effect_${subtype}`] ?? EVENT_COLOR.state_effect_burn;
-  if (kind === 'fight_end') return EVENT_COLOR.fight_end;
+  if (kind === 'fight_end') {
+    const bossWins = ev?.winner && ev.winner === app.data?.teams?.B?.name;
+    return bossWins ? '#f43f5e' : '#22c55e';
+  }
   return EVENT_COLOR[kind] ?? null;
 }
 
@@ -270,7 +273,7 @@ function updateDisplay() {
   const eventCard = document.getElementById('event-card');
   if (eventCard) {
     eventCard.innerHTML = buildEventCard(event);
-    const color = event ? (eventColor(event.kind, event.type ?? event.status) ?? null) : null;
+    const color = event ? (eventColor(event.kind, event.type ?? event.status, event) ?? null) : null;
     eventCard.style.borderColor  = color ? color + '55' : 'var(--border)';
     eventCard.style.boxShadow    = color ? `0 0 24px ${color}22` : 'none';
     eventCard.classList.toggle('event-card--empty', !event);
@@ -290,7 +293,7 @@ function updateDisplay() {
     const current = document.querySelector(`.log-item[data-step="${step}"]`);
     if (current) {
       const ev    = data.events[step - 1];
-      const color = eventColor(ev.kind, ev.type ?? ev.status) ?? 'var(--accent)';
+      const color = eventColor(ev.kind, ev.type ?? ev.status, ev) ?? 'var(--accent)';
       current.classList.add('log-item--active');
       current.style.borderColor = color;
       current.style.background  = 'var(--surface)';
@@ -604,8 +607,10 @@ function describeEvent(ev) {
       return { icon: ICON.targeting_reverted, text: `Targeting reverted — ${ev.eventName ?? ''}`, color: EVENT_COLOR.targeting_reverted };
     case 'effect_removed':
       return { icon: ICON.effect_removed, text: `Effects removed — ${ev.eventName ?? ''}`, color: EVENT_COLOR.effect_removed };
-    case 'fight_end':
-      return { icon: ev.winner ? ICON.fight_end : ICON.fight_end_loss, text: `FIGHT END — ${ev.winner ? `Winner: ${ev.winner}` : 'Draw'}`, color: EVENT_COLOR.fight_end };
+    case 'fight_end': {
+      const bossWins = ev.winner && ev.winner === app.data?.teams?.B?.name;
+      return { icon: (ev.winner && !bossWins) ? ICON.fight_end : ICON.fight_end_loss, text: `FIGHT END — ${ev.winner ? `Winner: ${ev.winner}` : 'Draw'}`, color: bossWins ? '#f43f5e' : '#22c55e' };
+    }
     default:
       return { icon: ICON.unknown, text: ev.kind ?? 'Unknown event', color: '#94a3b8' };
   }


### PR DESCRIPTION
A standalone vanilla HTML/CSS/JS tool for visualizing fight results step by step. No framework — pure web standards with ES modules.

Layout: Hero team (left) vs Boss team (right), event detail center, horizontal event log bottom, playback controls with speed selection.

Design system in css/design-system.css: dark "embers" theme, Caveat UI font, JetBrains Mono for data, CSS custom properties for all tokens.

Icons module (icons.js) centralises all emoji glyphs, event colours, and element-type colours. Parser module (parser.js) builds per-step state snapshots and infers teams via deckIdentity grouping or attack-graph colouring as fallback.

Supports all fight step kinds: attack, special_attack, healing, buff, debuff, buff/debuff_expired, buff/debuff_removed, status_change, state_effect, targeting_override/reverted, effect_removed, fight_end.

https://claude.ai/code/session_01BuoVSWncUmLzAzsCxwEFUq