### PR TITLE
feat: add StuntAttackEffect and related functionality

### DIFF
--- a/docs/tasks/2026_05_03-kaelion-multi-effect-stunt.md
+++ b/docs/tasks/2026_05_03-kaelion-multi-effect-stunt.md
@@ -1,0 +1,93 @@
+---
+name: plan
+description: Feature implementation plan template
+argument-hint: N/A
+---
+
+# Instruction: Kaelion — Multi-Effect Attack & STUNT Status
+
+## Feature
+
+- **Summary**: Add support for multiple status effects per attack with per-effect trigger probability, and introduce the STUNT effect type that prevents a card from acting. Enables Kaelion's "Flamme Terreuse" attack (PHYSICAL + FIRE + EARTH damages, BURN at 50%, STUNT at 20%).
+- **Stack**: `TypeScript, Node.js 24, NestJS 11, class-validator, class-transformer`
+- **Branch name**: `feat/kaelion-multi-effect-stunt`
+
+## Existing files
+
+- @src/fight/core/cards/@types/attack/attack-effect.ts
+- @src/fight/core/cards/@types/attack/attack-poison-effect.ts
+- @src/fight/core/cards/@types/attack/attack-burn-effect.ts
+- @src/fight/core/cards/@types/attack/attack-freeze-effect.ts
+- @src/fight/core/cards/@types/state/state-effect-type.ts
+- @src/fight/core/cards/@types/state/card-state-frozen.ts
+- @src/fight/core/cards/fighting-card.ts
+- @src/fight/core/card-action/action_stage.ts
+- @src/fight/core/cards/skills/simple-attack.ts
+- @src/fight/core/cards/skills/multiple-attack.ts
+- @src/fight/http-api/dto/fight-data.dto.ts
+- @src/fight/http-api/fight.controller.ts
+- @samples/cards.json
+
+### New files to create
+
+- src/fight/core/cards/@types/state/card-state-stunted.ts
+- src/fight/core/cards/@types/attack/attack-stunt-effect.ts
+- src/fight/core/cards/__tests__/stunt-effect.spec.ts
+- src/fight/core/cards/__tests__/multi-effect-attack.spec.ts
+- test/fight/kaelion-attack.e2e-spec.ts
+
+## Implementation phases
+
+### Phase 1 — STUNT domain implementation
+
+> Add STUNT as a new status effect: skip-action state with no damage tick, no damage amplification.
+
+1. Add `'stunt'` to `StateEffectType` union in `state-effect-type.ts`
+2. Create `CardStateStunted` implementing `CardState`: `type='stunt'`, `remainingTurns`, `applyState()` decrements turns only (no damage, returns 0-damage result), `terminationEvent?`
+3. Create `AttackStuntEffect` implementing `AttackEffect`: constructor `(level, probability?, terminationEvent?)`, `applyEffect()` calls `defender.setState(new CardStateStunted(...))`, returns `EffectResult`
+4. Add `stunted?: CardState` + `get isStunted()` getter to `FightingCard`; extend `setState()` to route `'stunt'` type; extend `applyStateEffects()` to tick stunt; extend `removeEventBoundEffects()` to clear stunt
+5. In `action_stage.ts`, add `|| card.isStunted` to the frozen-skip condition (line 44)
+6. Add `STUNT = 'STUNT'` to `Effect` enum in `fight-data.dto.ts`
+7. Add `case Effect.STUNT` to `buildEffect()` in `fight.controller.ts`
+
+### Phase 2 — Multiple effects + per-effect probability
+
+> Upgrade attack effects from a single optional field to an array; add probability-based triggering.
+
+1. Add `probability?: number` to `AttackEffect` interface; update each effect class (`PoisonAttackEffect`, `BurnAttackEffect`, `FreezeAttackEffect`, `AttackStuntEffect`) to accept `probability` in constructor and guard `applyEffect()` with a randomizer check: `if (probability && context.randomizer.random() > probability) return null`
+2. In `SimpleAttack` and `MultipleAttack`: replace `effect?: AttackEffect` with `effects?: AttackEffect[]`; in `launch()` iterate the array and collect non-null `EffectResult[]`
+3. In `fight-data.dto.ts`: rename `effect?` → `effects?` on `SimpleAttackDto` and `MultipleAttackDto` (type: `EffectDto[]`); add `@IsOptional() @IsNumber() probability?: number` to `EffectDto`
+4. In `fight.controller.ts`: rename `buildEffect()` → `buildEffects()` returning `AttackEffect[]`, pass `probability` from dto to each effect constructor
+
+### Phase 3 — Tests + Kaelion sample
+
+> Write functional harness tests first (TDD), then wire up samples.
+
+1. **Unit — STUNT**: stunted card skips its action; stunt expires after correct number of turns; `removeEventBoundEffects` clears stunt; freeze and stunt do not interfere
+2. **Unit — multi-effect + probability**: both effects applied when both trigger; neither applied when neither triggers; partial application when only one probability fires; null effect skipped gracefully
+3. **E2E — Kaelion `Flamme Terreuse`**: POST `/fight` with Kaelion card; assert `state_effect` step of type `burn` appears after hit; assert `state_effect` step of type `stunt` can appear; assert three damage compositions (PHYSICAL, FIRE, EARTH) reported per attack
+4. Add Kaelion card to `samples/cards.json` with full `effects` array payload
+
+## Reviewed implementation
+
+<!-- That section is filled by a review agent after implementation -->
+
+- [ ] Phase 1 — STUNT domain implementation
+- [ ] Phase 2 — Multiple effects + per-effect probability
+- [ ] Phase 3 — Tests + Kaelion sample
+
+## Validation flow
+
+1. Run `npm run test` — all unit tests pass including new STUNT and multi-effect specs
+2. Run `npm run test:e2e` — Kaelion E2E passes, both BURN and STUNT effects observable in fight log
+3. POST `/fight` manually with `samples/cards.json` Kaelion payload; verify `state_effect` steps appear for burn and stunt
+4. Run `npm run build` — no TypeScript errors
+
+## Estimations
+
+- **Confidence**: 9/10
+  - ✅ STUNT follows the exact same pattern as FREEZE (skip action + state object) — well-understood pattern
+  - ✅ Multi-effect is a straightforward array upgrade of existing single-effect plumbing
+  - ✅ Probability check pattern already exists in `EffectTriggeredDebuff.tryApply()`
+  - ❌ `applyEffect()` signature may need `context` added if it's not already there — needs verification during implementation
+- **Time to implement**: ~2-3h

--- a/samples/cards.json
+++ b/samples/cards.json
@@ -150,5 +150,43 @@
       ]
     },
     "behaviors": { "dodge": "simple-dodge" }
+  },
+  {
+    "id": "kaelion",
+    "name": "Kaelion",
+    "attack": 85,
+    "defense": 50,
+    "health": 430,
+    "speed": 80,
+    "agility": 60,
+    "accuracy": 85,
+    "criticalChance": 0.08,
+    "skills": {
+      "simpleAttack": {
+        "name": "Flamme Terreuse",
+        "targetingStrategy": "position-based",
+        "damages": [
+          { "type": "PHYSICAL", "rate": 0.8 },
+          { "type": "FIRE", "rate": 0.2 },
+          { "type": "EARTH", "rate": 0.1 }
+        ],
+        "effects": [
+          {
+            "type": "BURN",
+            "rate": 0.1,
+            "level": 2,
+            "probability": 0.5
+          },
+          {
+            "type": "STUNT",
+            "rate": 0.0,
+            "level": 1,
+            "probability": 0.2
+          }
+        ]
+      },
+      "others": []
+    },
+    "behaviors": { "dodge": "simple-dodge" }
   }
 ]

--- a/src/fight/core/__tests__/stunt_effect.spec.ts
+++ b/src/fight/core/__tests__/stunt_effect.spec.ts
@@ -1,0 +1,144 @@
+import { Fight } from '../fight-simulator/fight';
+import { DamageComposition } from '../cards/@types/damage/damage-composition';
+import { DamageType } from '../cards/@types/damage/damage-type';
+import { Player } from '../player';
+import { PlayerByPlayerCardSelector } from '../fight-simulator/card-selectors/player-by-player';
+import { createFightingCard } from '../../../../test/helpers/fighting-card';
+import { CardStateStunted } from '../cards/@types/state/card-state-stunted';
+import { CardStateFrozen } from '../cards/@types/state/card-state-frozen';
+import { FightingCard } from '../cards/fighting-card';
+
+describe('Stunt effect increases damage received by 20%', () => {
+  let card1: FightingCard;
+  let card2: FightingCard;
+  let player1: Player;
+  let player2: Player;
+  let fight: Fight;
+
+  beforeEach(() => {
+    card1 = createFightingCard({
+      attack: 100,
+      defense: 0,
+      health: 1000,
+      speed: 100,
+      criticalChance: 0,
+      agility: 0,
+      accuracy: 9999,
+      skills: {
+        simpleAttack: {
+          damages: [new DamageComposition(DamageType.PHYSICAL, 1.0)],
+        },
+      },
+    });
+
+    card2 = createFightingCard({
+      attack: 1,
+      defense: 0,
+      health: 1000,
+      speed: 1,
+      criticalChance: 0,
+      agility: 0,
+    });
+
+    player1 = new Player('Player 1', [card1]);
+    player2 = new Player('Player 2', [card2]);
+
+    card2.setState(new CardStateStunted(1, 1));
+
+    fight = new Fight(
+      player1,
+      player2,
+      new PlayerByPlayerCardSelector(player1, player2),
+    );
+  });
+
+  it('applies 20% extra damage to the stunted defender', () => {
+    const result = fight.start();
+    expect(result[1]).toMatchObject({
+      kind: 'attack',
+      damages: [
+        {
+          damage: 120,
+          defender: card2.identityInfo,
+          dodge: false,
+          isCritical: false,
+        },
+      ],
+    });
+  });
+
+  it('returns to normal damage after stunt expires', () => {
+    const result = fight.start();
+    expect(result[3]).toMatchObject({
+      kind: 'attack',
+      damages: [
+        {
+          damage: 100,
+          defender: card2.identityInfo,
+        },
+      ],
+    });
+  });
+});
+
+describe('Stunt paused by freeze, resumes after freeze expires', () => {
+  let card1: FightingCard;
+  let card2: FightingCard;
+  let player1: Player;
+  let player2: Player;
+  let fight: Fight;
+
+  beforeEach(() => {
+    card1 = createFightingCard({
+      attack: 100,
+      defense: 0,
+      health: 10000,
+      speed: 100,
+      criticalChance: 0,
+      agility: 0,
+      accuracy: 9999,
+      skills: {
+        simpleAttack: {
+          damages: [new DamageComposition(DamageType.PHYSICAL, 1.0)],
+        },
+      },
+    });
+
+    card2 = createFightingCard({
+      attack: 1,
+      defense: 0,
+      health: 10000,
+      speed: 1,
+      criticalChance: 0,
+      agility: 0,
+    });
+
+    player1 = new Player('Player 1', [card1]);
+    player2 = new Player('Player 2', [card2]);
+
+    card2.setState(new CardStateStunted(1, 1));
+    card2.setState(new CardStateFrozen(1, 1, 0));
+
+    fight = new Fight(
+      player1,
+      player2,
+      new PlayerByPlayerCardSelector(player1, player2),
+    );
+  });
+
+  it('still deals 20% extra damage on the turn after freeze expires', () => {
+    const result = fight.start();
+    expect(result[3]).toMatchObject({
+      kind: 'attack',
+      damages: [{ damage: 120, defender: card2.identityInfo }],
+    });
+  });
+
+  it('deals normal damage once stunt expires after freeze', () => {
+    const result = fight.start();
+    expect(result[5]).toMatchObject({
+      kind: 'attack',
+      damages: [{ damage: 100, defender: card2.identityInfo }],
+    });
+  });
+});

--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -18,6 +18,7 @@ import { DeathSkillHandler } from '../../fight-simulator/death-skill-handler';
 import { BurnAttackEffect } from '../../cards/@types/attack/attack-burn-effect';
 import { EffectTriggeredDebuff } from '../../cards/@types/attack/effect-triggered-debuff';
 import { RandomizerFake } from '../../../../../test/helpers/randomizer-fake';
+import { MathRandomizer } from '../../../tools/math-randomizer';
 import { StepKind } from '../../fight-simulator/@types/step';
 import { BuffApplication } from '../../cards/@types/buff/buff-application';
 import { BuffReport } from '../../fight-simulator/@types/buff-report';
@@ -74,13 +75,14 @@ describe('ActionStage', () => {
       const burnEffect = new BurnAttackEffect(
         0.1,
         1,
+        new MathRandomizer(),
         new EffectTriggeredDebuff(1.0, 'defense', 0.1, 2, randomizer),
       );
       const attackWithBurn = new SimpleAttack(
         'attack',
         [new DamageComposition(DamageType.PHYSICAL, 1)],
         POSITION_BASED,
-        burnEffect,
+        [burnEffect],
       );
       const HIGH_ENERGY_SPECIAL = new SpecialAttack(
         'special',

--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -41,7 +41,7 @@ export class ActionStage {
 
   public computeNextAction(cards: FightingCard[]): Step[] {
     const attacksReports = cards.reduce((acc: ActionReport[], card) => {
-      if (card.frozenLevel > 0) return acc;
+      if (card.frozenLevel > 0 || card.isStunted) return acc;
 
       card.tickSkills();
 
@@ -233,28 +233,29 @@ export class ActionStage {
           status: 'dead',
         });
         report.statusChanges.push(...this.deathSkillHandler.drainSteps());
-      } else if (!defensiveCard.isDead() && damageDealt.effect) {
-        report.statusChanges.push({
-          kind: StepKind.StatusChange,
-          status: damageDealt.effect.type,
-          card: damageDealt.effect.card.identityInfo,
-        });
-        if (damageDealt.effect.triggeredDebuff) {
-          const { card: debuffTarget, debuff } =
-            damageDealt.effect.triggeredDebuff;
+      } else if (!defensiveCard.isDead() && damageDealt.effects?.length) {
+        for (const effect of damageDealt.effects) {
           report.statusChanges.push({
-            kind: StepKind.Debuff,
-            source: attackerCard.identityInfo,
-            debuffs: [
-              {
-                target: debuffTarget.identityInfo,
-                kind: debuff.type,
-                value: debuff.value,
-                remainingTurns: debuff.duration,
-              },
-            ],
-            energy: attackerCard.actualEnergy,
+            kind: StepKind.StatusChange,
+            status: effect.type,
+            card: effect.card.identityInfo,
           });
+          if (effect.triggeredDebuff) {
+            const { card: debuffTarget, debuff } = effect.triggeredDebuff;
+            report.statusChanges.push({
+              kind: StepKind.Debuff,
+              source: attackerCard.identityInfo,
+              debuffs: [
+                {
+                  target: debuffTarget.identityInfo,
+                  kind: debuff.type,
+                  value: debuff.value,
+                  remainingTurns: debuff.duration,
+                },
+              ],
+              energy: attackerCard.actualEnergy,
+            });
+          }
         }
       }
     });

--- a/src/fight/core/cards/@types/action-result/attack-result.ts
+++ b/src/fight/core/cards/@types/action-result/attack-result.ts
@@ -9,7 +9,7 @@ export type AttackResult = {
   dodge: boolean;
   defender: FightingCard;
   remainingHealth?: number;
-  effect?: EffectResult;
+  effects?: EffectResult[];
   buffResults?: BuffResults;
   kind?: DamageType[];
 };

--- a/src/fight/core/cards/@types/attack/__tests__/attack-burn-effect.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/attack-burn-effect.spec.ts
@@ -2,6 +2,7 @@ import { BurnAttackEffect } from '../attack-burn-effect';
 import { EffectTriggeredDebuff } from '../effect-triggered-debuff';
 import { CardStateBurned } from '../../state/card-state-burned';
 import { RandomizerFake } from '../../../../../../../test/helpers/randomizer-fake';
+import { MathRandomizer } from '../../../../../tools/math-randomizer';
 import { createFightingCard } from '../../../../../../../test/helpers/fighting-card';
 import { EffectResult } from '../attack-effect';
 
@@ -15,7 +16,7 @@ describe('BurnAttackEffect number precision', () => {
   it('rounds damage value to 2 decimal places', () => {
     const attacker = createFightingCard({ attack: 33 });
     const defender = createFightingCard({ health: 100 });
-    const effect = new BurnAttackEffect(0.1, 1);
+    const effect = new BurnAttackEffect(0.1, 1, new MathRandomizer());
     effect.applyEffect(defender, attacker, null);
 
     const [stateResult] = defender.applyStateEffects();
@@ -44,7 +45,12 @@ describe('BurnAttackEffect with triggeredDebuff', () => {
         2,
         randomizer,
       );
-      const effect = new BurnAttackEffect(0.2, 1, triggered);
+      const effect = new BurnAttackEffect(
+        0.2,
+        1,
+        new MathRandomizer(),
+        triggered,
+      );
       result = effect.applyEffect(defender, attacker, null);
     });
 
@@ -73,7 +79,12 @@ describe('BurnAttackEffect with triggeredDebuff', () => {
         2,
         randomizer,
       );
-      const effect = new BurnAttackEffect(0.2, 1, triggered);
+      const effect = new BurnAttackEffect(
+        0.2,
+        1,
+        new MathRandomizer(),
+        triggered,
+      );
       result = effect.applyEffect(defender, attacker, null);
     });
 

--- a/src/fight/core/cards/@types/attack/__tests__/attack-freeze-effect.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/attack-freeze-effect.spec.ts
@@ -2,6 +2,7 @@ import { FreezeAttackEffect } from '../attack-freeze-effect';
 import { EffectTriggeredDebuff } from '../effect-triggered-debuff';
 import { CardStateFrozen } from '../../state/card-state-frozen';
 import { RandomizerFake } from '../../../../../../../test/helpers/randomizer-fake';
+import { MathRandomizer } from '../../../../../tools/math-randomizer';
 import { createFightingCard } from '../../../../../../../test/helpers/fighting-card';
 import { EffectResult } from '../attack-effect';
 
@@ -31,7 +32,12 @@ describe('FreezeAttackEffect with triggeredDebuff', () => {
         2,
         randomizer,
       );
-      const effect = new FreezeAttackEffect(0.2, 1, triggered);
+      const effect = new FreezeAttackEffect(
+        0.2,
+        1,
+        new MathRandomizer(),
+        triggered,
+      );
       result = effect.applyEffect(defender, attacker, null);
     });
 
@@ -60,7 +66,12 @@ describe('FreezeAttackEffect with triggeredDebuff', () => {
         2,
         randomizer,
       );
-      const effect = new FreezeAttackEffect(0.2, 1, triggered);
+      const effect = new FreezeAttackEffect(
+        0.2,
+        1,
+        new MathRandomizer(),
+        triggered,
+      );
       result = effect.applyEffect(defender, attacker, null);
     });
 

--- a/src/fight/core/cards/@types/attack/__tests__/attack-poison-effect.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/attack-poison-effect.spec.ts
@@ -2,6 +2,7 @@ import { PoisonAttackEffect } from '../attack-poison-effect';
 import { EffectTriggeredDebuff } from '../effect-triggered-debuff';
 import { CardStateFrozen } from '../../state/card-state-frozen';
 import { RandomizerFake } from '../../../../../../../test/helpers/randomizer-fake';
+import { MathRandomizer } from '../../../../../tools/math-randomizer';
 import { createFightingCard } from '../../../../../../../test/helpers/fighting-card';
 import { EffectResult } from '../attack-effect';
 
@@ -15,7 +16,7 @@ describe('PoisonAttackEffect number precision', () => {
   it('rounds damage value to 2 decimal places', () => {
     const attacker = createFightingCard({ attack: 33 });
     const defender = createFightingCard({ health: 100 });
-    const effect = new PoisonAttackEffect(0.1, 1);
+    const effect = new PoisonAttackEffect(0.1, 1, new MathRandomizer());
     effect.applyEffect(defender, attacker, null);
 
     const [stateResult] = defender.applyStateEffects();
@@ -44,7 +45,12 @@ describe('PoisonAttackEffect with triggeredDebuff', () => {
         2,
         randomizer,
       );
-      const effect = new PoisonAttackEffect(0.2, 1, triggered);
+      const effect = new PoisonAttackEffect(
+        0.2,
+        1,
+        new MathRandomizer(),
+        triggered,
+      );
       result = effect.applyEffect(defender, attacker, null);
     });
 
@@ -73,7 +79,12 @@ describe('PoisonAttackEffect with triggeredDebuff', () => {
         2,
         randomizer,
       );
-      const effect = new PoisonAttackEffect(0.2, 1, triggered);
+      const effect = new PoisonAttackEffect(
+        0.2,
+        1,
+        new MathRandomizer(),
+        triggered,
+      );
       result = effect.applyEffect(defender, attacker, null);
     });
 

--- a/src/fight/core/cards/@types/attack/attack-burn-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-burn-effect.ts
@@ -5,6 +5,7 @@ import { FightingContext } from '../fighting-context';
 import { CardStateBurned } from '../state/card-state-burned';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
 import { round2 } from '../../../../tools/round';
+import { Randomizer } from '../../../randomizer';
 
 export class BurnAttackEffect implements AttackEffect {
   public readonly rate: number;
@@ -12,17 +13,23 @@ export class BurnAttackEffect implements AttackEffect {
   public readonly type = 'burn' as const;
   public readonly triggeredDebuff?: EffectTriggeredDebuff;
   public readonly terminationEvent?: string;
+  public readonly probability?: number;
+  private readonly randomizer: Randomizer;
 
   constructor(
     rate: number,
     level: EffectLevel,
+    randomizer: Randomizer,
     triggeredDebuff?: EffectTriggeredDebuff,
     terminationEvent?: string,
+    probability?: number,
   ) {
     this.rate = rate;
     this.level = level;
+    this.randomizer = randomizer;
     this.triggeredDebuff = triggeredDebuff;
     this.terminationEvent = terminationEvent;
+    this.probability = probability;
   }
 
   public applyEffect(
@@ -30,6 +37,11 @@ export class BurnAttackEffect implements AttackEffect {
     card: FightingCard,
     _context: FightingContext,
   ): EffectResult {
+    if (
+      this.probability !== undefined &&
+      this.randomizer.random() >= this.probability
+    )
+      return;
     if (defender.burnLevel >= this.level) return;
     if (defender.frozenLevel > this.level) return;
 

--- a/src/fight/core/cards/@types/attack/attack-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-effect.ts
@@ -17,6 +17,7 @@ export interface AttackEffect {
   type: string;
   triggeredDebuff?: EffectTriggeredDebuff;
   terminationEvent?: string;
+  probability?: number;
 
   applyEffect(
     defender: FightingCard,

--- a/src/fight/core/cards/@types/attack/attack-freeze-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-freeze-effect.ts
@@ -4,6 +4,7 @@ import { CardStateFrozen } from '../state/card-state-frozen';
 import { AttackEffect, EffectResult } from './attack-effect';
 import { EffectLevel } from './effect-level';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
+import { Randomizer } from '../../../randomizer';
 
 export class FreezeAttackEffect implements AttackEffect {
   public readonly rate: number;
@@ -11,17 +12,23 @@ export class FreezeAttackEffect implements AttackEffect {
   public readonly type = 'freeze' as const;
   public readonly triggeredDebuff?: EffectTriggeredDebuff;
   public readonly terminationEvent?: string;
+  public readonly probability?: number;
+  private readonly randomizer: Randomizer;
 
   constructor(
     rate: number,
     level: EffectLevel,
+    randomizer: Randomizer,
     triggeredDebuff?: EffectTriggeredDebuff,
     terminationEvent?: string,
+    probability?: number,
   ) {
     this.rate = rate;
     this.level = level;
+    this.randomizer = randomizer;
     this.triggeredDebuff = triggeredDebuff;
     this.terminationEvent = terminationEvent;
+    this.probability = probability;
   }
 
   public applyEffect(
@@ -29,6 +36,11 @@ export class FreezeAttackEffect implements AttackEffect {
     _card: FightingCard,
     _context: FightingContext,
   ): EffectResult {
+    if (
+      this.probability !== undefined &&
+      this.randomizer.random() >= this.probability
+    )
+      return;
     if (defender.frozenLevel >= this.level) return;
     if (defender.burnLevel > this.level) return;
 

--- a/src/fight/core/cards/@types/attack/attack-poison-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-poison-effect.ts
@@ -5,6 +5,7 @@ import { EffectLevel } from './effect-level';
 import { FightingContext } from '../fighting-context';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
 import { round2 } from '../../../../tools/round';
+import { Randomizer } from '../../../randomizer';
 
 export class PoisonAttackEffect implements AttackEffect {
   public readonly rate: number;
@@ -12,17 +13,23 @@ export class PoisonAttackEffect implements AttackEffect {
   public readonly type = 'poison' as const;
   public readonly triggeredDebuff?: EffectTriggeredDebuff;
   public readonly terminationEvent?: string;
+  public readonly probability?: number;
+  private readonly randomizer: Randomizer;
 
   constructor(
     rate: number,
     level: EffectLevel,
+    randomizer: Randomizer,
     triggeredDebuff?: EffectTriggeredDebuff,
     terminationEvent?: string,
+    probability?: number,
   ) {
     this.rate = rate;
     this.level = level;
+    this.randomizer = randomizer;
     this.triggeredDebuff = triggeredDebuff;
     this.terminationEvent = terminationEvent;
+    this.probability = probability;
   }
 
   public applyEffect(
@@ -30,6 +37,11 @@ export class PoisonAttackEffect implements AttackEffect {
     card: FightingCard,
     _context: FightingContext,
   ): EffectResult {
+    if (
+      this.probability !== undefined &&
+      this.randomizer.random() >= this.probability
+    )
+      return;
     if (defender.frozenLevel > 0) return;
     if (defender.poisonLevel >= this.level) return;
 

--- a/src/fight/core/cards/@types/attack/attack-stunt-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-stunt-effect.ts
@@ -1,0 +1,52 @@
+import { FightingCard } from '../../fighting-card';
+import { AttackEffect, EffectResult } from './attack-effect';
+import { EffectLevel } from './effect-level';
+import { FightingContext } from '../fighting-context';
+import { CardStateStunted } from '../state/card-state-stunted';
+import { Randomizer } from '../../../randomizer';
+
+export class StuntAttackEffect implements AttackEffect {
+  public readonly rate: number;
+  public readonly level: EffectLevel;
+  public readonly type = 'stunt' as const;
+  public readonly terminationEvent?: string;
+  public readonly probability?: number;
+  private readonly randomizer: Randomizer;
+
+  constructor(
+    rate: number,
+    level: EffectLevel,
+    randomizer: Randomizer,
+    probability?: number,
+    terminationEvent?: string,
+  ) {
+    this.rate = rate;
+    this.level = level;
+    this.randomizer = randomizer;
+    this.probability = probability;
+    this.terminationEvent = terminationEvent;
+  }
+
+  public applyEffect(
+    defender: FightingCard,
+    _card: FightingCard,
+    _context: FightingContext,
+  ): EffectResult {
+    if (
+      this.probability !== undefined &&
+      this.randomizer.random() >= this.probability
+    )
+      return;
+    if (defender.isFrozen) return;
+    if (defender.isStunted) return;
+
+    const stuntState = new CardStateStunted(
+      this.level,
+      2 * this.level - 1,
+      this.terminationEvent,
+    );
+    defender.setState(stuntState);
+
+    return { type: this.type, card: defender };
+  }
+}

--- a/src/fight/core/cards/@types/state/card-state-stunted.ts
+++ b/src/fight/core/cards/@types/state/card-state-stunted.ts
@@ -1,0 +1,37 @@
+import { FightingCard } from '../../fighting-card';
+import { StateResult } from '../action-result/state-result';
+import { EffectLevel } from '../attack/effect-level';
+import { CardState } from './card-state';
+
+export class CardStateStunted implements CardState {
+  public readonly type = 'stunt' as const;
+  public readonly level: EffectLevel;
+  public remainingTurns: number;
+  public readonly terminationEvent?: string;
+
+  constructor(
+    level: EffectLevel,
+    remainingTurns: number,
+    terminationEvent?: string,
+  ) {
+    this.level = level;
+    this.remainingTurns = remainingTurns;
+    this.terminationEvent = terminationEvent;
+  }
+
+  public applyState(card: FightingCard): StateResult {
+    this.remainingTurns--;
+
+    return {
+      type: 'stunt',
+      card,
+      damage: 0,
+      remainingHealth: card.actualHealth,
+      remainingTurns: this.remainingTurns,
+    };
+  }
+
+  public applyDamageRate(damage: number): number {
+    return damage + Math.round(damage * 0.2);
+  }
+}

--- a/src/fight/core/cards/@types/state/state-effect-type.ts
+++ b/src/fight/core/cards/@types/state/state-effect-type.ts
@@ -1,1 +1,1 @@
-export type StateEffectType = 'burn' | 'poison' | 'freeze';
+export type StateEffectType = 'burn' | 'poison' | 'freeze' | 'stunt';

--- a/src/fight/core/cards/__tests__/multi-effect-attack.spec.ts
+++ b/src/fight/core/cards/__tests__/multi-effect-attack.spec.ts
@@ -1,0 +1,132 @@
+import { Player } from '../../player';
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+import { SimpleAttack } from '../skills/simple-attack';
+import { DamageComposition } from '../@types/damage/damage-composition';
+import { DamageType } from '../@types/damage/damage-type';
+import { TargetedFromPosition } from '../../targeting-card-strategies/targeted-from-position';
+import { BurnAttackEffect } from '../@types/attack/attack-burn-effect';
+import { StuntAttackEffect } from '../@types/attack/attack-stunt-effect';
+import { EffectLevel } from '../@types/attack/effect-level';
+import { MathRandomizer } from '../../../tools/math-randomizer';
+
+const POSITION_BASED = new TargetedFromPosition();
+
+function makeCard(
+  overrides: { attack?: number; defense?: number; health?: number } = {},
+) {
+  return createFightingCard({
+    attack: overrides.attack ?? 200,
+    defense: overrides.defense ?? 0,
+    health: overrides.health ?? 5000,
+    criticalChance: 0,
+    agility: 0,
+    accuracy: 9999,
+  });
+}
+
+function makeContext(attacker = makeCard(), defender = makeCard()) {
+  return {
+    sourcePlayer: new Player('P1', [attacker]),
+    opponentPlayer: new Player('P2', [defender]),
+  };
+}
+
+describe('SimpleAttack with multiple effects', () => {
+  const damages = [new DamageComposition(DamageType.PHYSICAL, 1.0)];
+
+  describe('when all effects trigger (probability=1)', () => {
+    const attack = new SimpleAttack('combo', damages, POSITION_BASED, [
+      new BurnAttackEffect(
+        0.1,
+        1 as EffectLevel,
+        new MathRandomizer(),
+        undefined,
+        undefined,
+        1.0,
+      ),
+      new StuntAttackEffect(0, 1 as EffectLevel, new MathRandomizer(), 1.0),
+    ]);
+
+    it('returns two effect results', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      const result = attack.launch(attacker, makeContext(attacker, defender));
+      expect(result.results[0].effects?.length).toBe(2);
+    });
+
+    it('applies burn to defender', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      attack.launch(attacker, makeContext(attacker, defender));
+      expect(defender.burnLevel).toBeGreaterThan(0);
+    });
+
+    it('applies stunt to defender', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      attack.launch(attacker, makeContext(attacker, defender));
+      expect(defender.isStunted).toBe(true);
+    });
+  });
+
+  describe('when no effects trigger (probability=0)', () => {
+    const attack = new SimpleAttack('combo', damages, POSITION_BASED, [
+      new BurnAttackEffect(
+        0.1,
+        1 as EffectLevel,
+        new MathRandomizer(),
+        undefined,
+        undefined,
+        0,
+      ),
+      new StuntAttackEffect(0, 1 as EffectLevel, new MathRandomizer(), 0),
+    ]);
+
+    it('returns no effect results', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      const result = attack.launch(attacker, makeContext(attacker, defender));
+      expect(result.results[0].effects).toBeUndefined();
+    });
+  });
+
+  describe('when only the first effect triggers', () => {
+    const attack = new SimpleAttack('combo', damages, POSITION_BASED, [
+      new BurnAttackEffect(
+        0.1,
+        1 as EffectLevel,
+        new MathRandomizer(),
+        undefined,
+        undefined,
+        1.0,
+      ),
+      new StuntAttackEffect(0, 1 as EffectLevel, new MathRandomizer(), 0),
+    ]);
+
+    it('returns one effect result', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      const result = attack.launch(attacker, makeContext(attacker, defender));
+      expect(result.results[0].effects?.length).toBe(1);
+    });
+
+    it('applies burn but not stunt', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      attack.launch(attacker, makeContext(attacker, defender));
+      expect(defender.burnLevel).toBeGreaterThan(0);
+      expect(defender.isStunted).toBe(false);
+    });
+  });
+
+  describe('when effects array is empty', () => {
+    const attack = new SimpleAttack('strike', damages, POSITION_BASED, []);
+
+    it('returns no effects', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      const result = attack.launch(attacker, makeContext(attacker, defender));
+      expect(result.results[0].effects).toBeUndefined();
+    });
+  });
+});

--- a/src/fight/core/cards/__tests__/multiple-attack.spec.ts
+++ b/src/fight/core/cards/__tests__/multiple-attack.spec.ts
@@ -130,10 +130,10 @@ describe('MultipleAttack', () => {
         damages,
         new TargetedAll(),
         0,
-        effect,
+        [effect],
       );
       const attack = multipleAttack.launch(attacker, context);
-      expect(attack.results[0].effect).toBeDefined();
+      expect(attack.results[0].effects?.[0]).toBeDefined();
     });
   });
 

--- a/src/fight/core/cards/__tests__/stunt-effect.spec.ts
+++ b/src/fight/core/cards/__tests__/stunt-effect.spec.ts
@@ -1,0 +1,233 @@
+import { Player } from '../../player';
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+import { StuntAttackEffect } from '../@types/attack/attack-stunt-effect';
+import { EffectLevel } from '../@types/attack/effect-level';
+import { MathRandomizer } from '../../../tools/math-randomizer';
+import { CardStateFrozen } from '../@types/state/card-state-frozen';
+import { CardStateStunted } from '../@types/state/card-state-stunted';
+
+function makeCard() {
+  return createFightingCard({
+    attack: 200,
+    defense: 0,
+    health: 5000,
+    criticalChance: 0,
+    agility: 0,
+    accuracy: 9999,
+  });
+}
+
+function fightingContext(attacker = makeCard(), defender = makeCard()) {
+  return {
+    sourcePlayer: new Player('P1', [attacker]),
+    opponentPlayer: new Player('P2', [defender]),
+  };
+}
+
+describe('StuntAttackEffect', () => {
+  describe('with probability=1 (always triggers)', () => {
+    const stuntEffect = new StuntAttackEffect(
+      0,
+      1 as EffectLevel,
+      new MathRandomizer(),
+      1.0,
+    );
+
+    it('sets defender isStunted to true', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      stuntEffect.applyEffect(
+        defender,
+        attacker,
+        fightingContext(attacker, defender),
+      );
+      expect(defender.isStunted).toBe(true);
+    });
+
+    it('returns an EffectResult with type stunt', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      const result = stuntEffect.applyEffect(
+        defender,
+        attacker,
+        fightingContext(attacker, defender),
+      );
+      expect(result?.type).toBe('stunt');
+    });
+  });
+
+  describe('with probability=0 (never triggers)', () => {
+    const stuntEffect = new StuntAttackEffect(
+      0,
+      1 as EffectLevel,
+      new MathRandomizer(),
+      0,
+    );
+
+    it('does not stunt the defender', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      stuntEffect.applyEffect(
+        defender,
+        attacker,
+        fightingContext(attacker, defender),
+      );
+      expect(defender.isStunted).toBe(false);
+    });
+
+    it('returns undefined', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      const result = stuntEffect.applyEffect(
+        defender,
+        attacker,
+        fightingContext(attacker, defender),
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('without probability (always triggers)', () => {
+    it('sets defender isStunted to true', () => {
+      const stuntEffect = new StuntAttackEffect(
+        0,
+        1 as EffectLevel,
+        new MathRandomizer(),
+      );
+      const attacker = makeCard();
+      const defender = makeCard();
+      stuntEffect.applyEffect(
+        defender,
+        attacker,
+        fightingContext(attacker, defender),
+      );
+      expect(defender.isStunted).toBe(true);
+    });
+  });
+
+  describe('stunt expiry', () => {
+    it('isStunted becomes false after applyStateEffects ticks down level-1 stunt', () => {
+      const stuntEffect = new StuntAttackEffect(
+        0,
+        1 as EffectLevel,
+        new MathRandomizer(),
+        1.0,
+      );
+      const attacker = makeCard();
+      const defender = makeCard();
+      stuntEffect.applyEffect(
+        defender,
+        attacker,
+        fightingContext(attacker, defender),
+      );
+
+      defender.applyStateEffects();
+
+      expect(defender.isStunted).toBe(false);
+    });
+  });
+
+  describe('event-bound removal', () => {
+    it('clears the stunt when its terminationEvent fires', () => {
+      const stuntEffect = new StuntAttackEffect(
+        0,
+        3 as EffectLevel,
+        new MathRandomizer(),
+        1.0,
+        'shield-end',
+      );
+      const attacker = makeCard();
+      const defender = makeCard();
+      stuntEffect.applyEffect(
+        defender,
+        attacker,
+        fightingContext(attacker, defender),
+      );
+
+      defender.removeEventBoundEffects('shield-end');
+
+      expect(defender.isStunted).toBe(false);
+    });
+
+    it('does not clear the stunt for a different event', () => {
+      const stuntEffect = new StuntAttackEffect(
+        0,
+        3 as EffectLevel,
+        new MathRandomizer(),
+        1.0,
+        'shield-end',
+      );
+      const attacker = makeCard();
+      const defender = makeCard();
+      stuntEffect.applyEffect(
+        defender,
+        attacker,
+        fightingContext(attacker, defender),
+      );
+
+      defender.removeEventBoundEffects('other-event');
+
+      expect(defender.isStunted).toBe(true);
+    });
+  });
+
+  describe('when card is frozen while stunted', () => {
+    it('stunt is still active after freeze expires', () => {
+      const card = makeCard();
+      card.setState(new CardStateStunted(1, 1));
+      card.setState(new CardStateFrozen(1, 1, 0));
+
+      card.applyStateEffects();
+
+      expect(card.isStunted).toBe(true);
+    });
+
+    it('stunt expires on the following turn after freeze', () => {
+      const card = makeCard();
+      card.setState(new CardStateStunted(1, 1));
+      card.setState(new CardStateFrozen(1, 1, 0));
+
+      card.applyStateEffects();
+      card.applyStateEffects();
+
+      expect(card.isStunted).toBe(false);
+    });
+  });
+
+  describe('when defender is frozen', () => {
+    const stuntEffect = new StuntAttackEffect(
+      0,
+      1 as EffectLevel,
+      new MathRandomizer(),
+      1.0,
+    );
+
+    it('does not apply the stunt', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      defender.setState(new CardStateFrozen(1, 1, 0.5));
+
+      stuntEffect.applyEffect(
+        defender,
+        attacker,
+        fightingContext(attacker, defender),
+      );
+
+      expect(defender.isStunted).toBe(false);
+    });
+
+    it('returns undefined', () => {
+      const attacker = makeCard();
+      const defender = makeCard();
+      defender.setState(new CardStateFrozen(1, 1, 0.5));
+
+      const result = stuntEffect.applyEffect(
+        defender,
+        attacker,
+        fightingContext(attacker, defender),
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -8,6 +8,7 @@ import { CardState } from './@types/state/card-state';
 import { StateEffectType } from './@types/state/state-effect-type';
 import { StateResult } from './@types/action-result/state-result';
 import { CardStateFrozen } from './@types/state/card-state-frozen';
+import { CardStateStunted } from './@types/state/card-state-stunted';
 import { EffectLevel } from './@types/attack/effect-level';
 import { Buff } from './@types/buff/buff';
 import { Debuff } from './@types/buff/debuff';
@@ -66,6 +67,7 @@ export class FightingCard {
   private poisoned?: CardState;
   private burned?: CardState;
   private frozen?: CardState;
+  private stunted?: CardState;
 
   constructor(
     id: string,
@@ -168,6 +170,10 @@ export class FightingCard {
     return !!this.frozen;
   }
 
+  public get isStunted(): boolean {
+    return !!this.stunted;
+  }
+
   public get burnLevel(): EffectLevel {
     return this.burned?.level ?? 0;
   }
@@ -189,6 +195,10 @@ export class FightingCard {
 
     if (newState.type === 'freeze') {
       this.frozen = newState;
+    }
+
+    if (newState.type === 'stunt') {
+      this.stunted = newState;
     }
   }
 
@@ -281,9 +291,14 @@ export class FightingCard {
       stateResults.push(this.burned.applyState(this));
     }
 
+    if (this.stunted && !this.frozen) {
+      stateResults.push(this.stunted.applyState(this));
+    }
+
     this.frozen = this.frozen?.remainingTurns ? this.frozen : undefined;
     this.poisoned = this.poisoned?.remainingTurns ? this.poisoned : undefined;
     this.burned = this.burned?.remainingTurns ? this.burned : undefined;
+    this.stunted = this.stunted?.remainingTurns ? this.stunted : undefined;
 
     return stateResults.filter((result) => result !== undefined);
   }
@@ -319,8 +334,14 @@ export class FightingCard {
   public collectsDamages(damage: number): number {
     let causedDamages = Math.max(0, damage - this.defense);
     if (this.frozen) {
-      const frozenState = this.frozen as CardStateFrozen;
-      causedDamages = frozenState.applyDamageRate(causedDamages);
+      causedDamages = (this.frozen as CardStateFrozen).applyDamageRate(
+        causedDamages,
+      );
+    }
+    if (this.stunted) {
+      causedDamages = (this.stunted as CardStateStunted).applyDamageRate(
+        causedDamages,
+      );
     }
     this.receivedDamages += causedDamages;
 
@@ -330,8 +351,14 @@ export class FightingCard {
   public applyFinalDamage(damage: number): number {
     let causedDamages = damage;
     if (this.frozen) {
-      const frozenState = this.frozen as CardStateFrozen;
-      causedDamages = frozenState.applyDamageRate(causedDamages);
+      causedDamages = (this.frozen as CardStateFrozen).applyDamageRate(
+        causedDamages,
+      );
+    }
+    if (this.stunted) {
+      causedDamages = (this.stunted as CardStateStunted).applyDamageRate(
+        causedDamages,
+      );
     }
     this.receivedDamages += causedDamages;
 
@@ -411,6 +438,11 @@ export class FightingCard {
     if (this.frozen?.terminationEvent === eventName) {
       removed.push({ type: this.frozen.type, card });
       this.frozen = undefined;
+    }
+
+    if (this.stunted?.terminationEvent === eventName) {
+      removed.push({ type: this.stunted.type, card });
+      this.stunted = undefined;
     }
 
     return removed;

--- a/src/fight/core/cards/skills/multiple-attack.ts
+++ b/src/fight/core/cards/skills/multiple-attack.ts
@@ -15,7 +15,7 @@ export class MultipleAttack implements AttackSkill {
     private readonly damages: DamageComposition[],
     private readonly targetingStrategy: TargetingCardStrategy,
     private readonly amplifier: number = 0,
-    private readonly effect?: AttackEffect,
+    private readonly effects?: AttackEffect[],
     private readonly comboFinisher?: DamageComposition[],
   ) {}
 
@@ -83,10 +83,9 @@ export class MultipleAttack implements AttackSkill {
         );
         const collectedDamage = defender.applyFinalDamage(total);
 
-        let effectResult: EffectResult;
-        if (this.effect) {
-          effectResult = this.effect.applyEffect(defender, card, context);
-        }
+        const effects = this.effects
+          ?.map((e) => e.applyEffect(defender, card, context))
+          .filter((r): r is EffectResult => r != null);
 
         results.results.push({
           damage: collectedDamage,
@@ -94,7 +93,7 @@ export class MultipleAttack implements AttackSkill {
           dodge: false,
           defender,
           remainingHealth: defender.actualHealth,
-          effect: effectResult,
+          effects: effects?.length ? effects : undefined,
           kind,
         });
       }

--- a/src/fight/core/cards/skills/simple-attack.ts
+++ b/src/fight/core/cards/skills/simple-attack.ts
@@ -12,7 +12,7 @@ export class SimpleAttack implements AttackSkill {
     public readonly name: string,
     private readonly damages: DamageComposition[],
     private readonly targetingStrategy: TargetingCardStrategy,
-    private readonly effect?: AttackEffect,
+    private readonly effects?: AttackEffect[],
   ) {}
 
   public get targetingId(): string {
@@ -59,17 +59,16 @@ export class SimpleAttack implements AttackSkill {
         );
         const collectedDamage = defender.applyFinalDamage(total);
 
-        let effectResult: EffectResult;
-        if (this.effect) {
-          effectResult = this.effect.applyEffect(defender, card, context);
-        }
+        const effects = this.effects
+          ?.map((e) => e.applyEffect(defender, card, context))
+          .filter((r): r is EffectResult => r != null);
 
         return {
           damage: collectedDamage,
           isCritical,
           dodge: false,
           defender,
-          effect: effectResult,
+          effects: effects?.length ? effects : undefined,
           kind,
         };
       }),

--- a/src/fight/core/cards/skills/special-attack.ts
+++ b/src/fight/core/cards/skills/special-attack.ts
@@ -61,7 +61,7 @@ export class SpecialAttack implements Special {
         isCritical,
         dodge: false,
         defender: target,
-        effect: effectResult,
+        effects: effectResult ? [effectResult] : undefined,
       };
     });
 

--- a/src/fight/core/fight-simulator/@types/status-change-report.ts
+++ b/src/fight/core/fight-simulator/@types/status-change-report.ts
@@ -1,7 +1,7 @@
 import { CardInfo } from '../../cards/@types/card-info';
 import { StepKind } from './step';
 
-export type status = 'dead' | 'poison' | 'burn' | 'freeze';
+export type status = 'dead' | 'poison' | 'burn' | 'freeze' | 'stunt';
 
 export type StatusChangeReport = {
   kind: StepKind.StatusChange;

--- a/src/fight/core/fight-simulator/skill-results-to-steps.ts
+++ b/src/fight/core/fight-simulator/skill-results-to-steps.ts
@@ -88,14 +88,12 @@ export function skillResultsToSteps(
                 },
               ];
             }
-            if (r.effect) {
-              return [
-                {
-                  kind: StepKind.StatusChange,
-                  status: r.effect.type as status,
-                  card: r.effect.card.identityInfo,
-                },
-              ];
+            if (r.effects?.length) {
+              return r.effects.map((effect) => ({
+                kind: StepKind.StatusChange as const,
+                status: effect.type as status,
+                card: effect.card.identityInfo,
+              }));
             }
             return [];
           },

--- a/src/fight/core/randomizer.ts
+++ b/src/fight/core/randomizer.ts
@@ -1,3 +1,4 @@
 export interface Randomizer {
   random_int_between(min: number, max: number): number;
+  random(): number;
 }

--- a/src/fight/http-api/__test__/fight.controller.spec.ts
+++ b/src/fight/http-api/__test__/fight.controller.spec.ts
@@ -444,7 +444,7 @@ describe('FightController', () => {
 
         const poisonedSimpleAttack = {
           ...simpleAttack,
-          effect,
+          effects: [effect],
         };
 
         fightData = {
@@ -497,7 +497,7 @@ describe('FightController', () => {
       it('creates a fighting card with a simple attack effect defined', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0],
           ).toBeDefined();
         });
       });
@@ -505,7 +505,7 @@ describe('FightController', () => {
       it('creates a fighting card with a poisoned simple attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect.type,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0].type,
           ).toBe('poison');
         });
       });
@@ -513,7 +513,7 @@ describe('FightController', () => {
       it('creates a fighting card with a poisoned simple attack effect rate', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0].rate,
           ).toBe(0.5);
         });
       });
@@ -521,7 +521,7 @@ describe('FightController', () => {
       it('creates a fighting card with a poisoned simple attack effect level', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect.level,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0].level,
           ).toBe(2);
         });
       });
@@ -537,7 +537,7 @@ describe('FightController', () => {
 
         const burnedSimpleAttack = {
           ...simpleAttack,
-          effect,
+          effects: [effect],
         };
 
         fightData = {
@@ -590,7 +590,7 @@ describe('FightController', () => {
       it('creates a fighting card with a simple attack effect defined', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0],
           ).toBeDefined();
         });
       });
@@ -598,7 +598,7 @@ describe('FightController', () => {
       it('creates a fighting card with a burned simple attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect.type,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0].type,
           ).toBe('burn');
         });
       });
@@ -606,7 +606,7 @@ describe('FightController', () => {
       it('creates a fighting card with a burned simple attack effect rate', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0].rate,
           ).toBe(0.2);
         });
       });
@@ -614,7 +614,7 @@ describe('FightController', () => {
       it('creates a fighting card with a burned simple attack effect level', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect.level,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0].level,
           ).toBe(3);
         });
       });
@@ -630,7 +630,7 @@ describe('FightController', () => {
 
         const freezeSimpleAttack = {
           ...simpleAttack,
-          effect,
+          effects: [effect],
         };
 
         fightData = {
@@ -683,7 +683,7 @@ describe('FightController', () => {
       it('creates a fighting card with a simple attack effect defined', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0],
           ).toBeDefined();
         });
       });
@@ -691,7 +691,7 @@ describe('FightController', () => {
       it('creates a fighting card with a freeze simple attack effect type', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect.type,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0].type,
           ).toBe('freeze');
         });
       });
@@ -699,7 +699,7 @@ describe('FightController', () => {
       it('creates a fighting card with a freeze simple attack effect rate', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect.rate,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0].rate,
           ).toBe(0.2);
         });
       });
@@ -707,7 +707,7 @@ describe('FightController', () => {
       it('creates a fighting card with a freeze simple attack effect level', () => {
         fightSimulatorStub.validatePlayer1FirstCard((card) => {
           expect(
-            JSON.parse(JSON.stringify(card)).simpleAttack.effect.level,
+            JSON.parse(JSON.stringify(card)).simpleAttack.effects[0].level,
           ).toBe(2);
         });
       });
@@ -747,7 +747,7 @@ describe('FightController', () => {
                   },
                   simpleAttack: {
                     ...simpleAttack,
-                    effect,
+                    effects: [effect],
                   },
                   others: [],
                 },
@@ -770,7 +770,7 @@ describe('FightController', () => {
         const validation = (card: FightingCard) => {
           const jsonCard = JSON.parse(JSON.stringify(card));
 
-          expect(jsonCard.simpleAttack.effect.terminationEvent).toBe(
+          expect(jsonCard.simpleAttack.effects[0].terminationEvent).toBe(
             'fire-shield-end',
           );
         };

--- a/src/fight/http-api/dto/fight-data.dto.ts
+++ b/src/fight/http-api/dto/fight-data.dto.ts
@@ -71,6 +71,7 @@ export enum Effect {
   POISON = 'POISON',
   BURN = 'BURN',
   FREEZE = 'FREEZE',
+  STUNT = 'STUNT',
 }
 
 export enum DodgeStrategy {
@@ -147,6 +148,10 @@ class EffectDto {
   @IsString()
   @IsNotEmpty()
   terminationEvent?: string;
+
+  @IsOptional()
+  @IsNumber()
+  probability?: number;
 }
 
 class BuffApplicationDto {
@@ -236,9 +241,10 @@ class SimpleAttackDto {
   targetingStrategy: TargetingStrategy;
 
   @IsOptional()
-  @ValidateNested()
+  @IsArray()
+  @ValidateNested({ each: true })
   @Type(/* istanbul ignore next */ () => EffectDto)
-  effect?: EffectDto;
+  effects?: EffectDto[];
 }
 
 class MultipleAttackDto {
@@ -266,9 +272,10 @@ class MultipleAttackDto {
   amplifier?: number;
 
   @IsOptional()
-  @ValidateNested()
+  @IsArray()
+  @ValidateNested({ each: true })
   @Type(/* istanbul ignore next */ () => EffectDto)
-  effect?: EffectDto;
+  effects?: EffectDto[];
 
   @IsOptional()
   @IsArray()

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -38,6 +38,7 @@ import { EffectLevel } from '../core/cards/@types/attack/effect-level';
 import { AttackEffect } from '../core/cards/@types/attack/attack-effect';
 import { BurnAttackEffect } from '../core/cards/@types/attack/attack-burn-effect';
 import { FreezeAttackEffect } from '../core/cards/@types/attack/attack-freeze-effect';
+import { StuntAttackEffect } from '../core/cards/@types/attack/attack-stunt-effect';
 import { EffectTriggeredDebuff } from '../core/cards/@types/attack/effect-triggered-debuff';
 import { MathRandomizer } from '../tools/math-randomizer';
 import { BuffApplication } from '../core/cards/@types/buff/buff-application';
@@ -154,7 +155,7 @@ export class FightController {
       const maDamages = ma.damages.map(
         (d) => new DamageComposition(d.type, d.rate),
       );
-      const maEffect = ma.effect ? this.buildEffect(ma.effect) : undefined;
+      const maEffects = this.buildEffects(ma.effects);
       const maComboFinisher = ma.comboFinisher
         ? ma.comboFinisher.map((d) => new DamageComposition(d.type, d.rate))
         : undefined;
@@ -164,7 +165,7 @@ export class FightController {
         maDamages,
         buildTargetingStrategy(ma.targetingStrategy),
         ma.amplifier ?? 0,
-        maEffect,
+        maEffects,
         maComboFinisher,
       );
     } else {
@@ -174,7 +175,7 @@ export class FightController {
           'Either simpleAttack or multipleAttack must be provided',
         );
       }
-      const effect = sa.effect ? this.buildEffect(sa.effect) : undefined;
+      const saEffects = this.buildEffects(sa.effects);
       const damages = sa.damages.map(
         (d) => new DamageComposition(d.type, d.rate),
       );
@@ -182,7 +183,7 @@ export class FightController {
         sa.name,
         damages,
         buildTargetingStrategy(sa.targetingStrategy),
-        effect,
+        saEffects,
       );
     }
 
@@ -217,6 +218,26 @@ export class FightController {
     );
   }
 
+  private buildEffects(
+    effectDtos?: {
+      type: Effect;
+      rate: number;
+      level: number;
+      triggeredDebuff?: {
+        debuffType: BuffType;
+        debuffRate: number;
+        duration: number;
+        probability: number;
+        terminationEvent?: string;
+      };
+      terminationEvent?: string;
+      probability?: number;
+    }[],
+  ): AttackEffect[] | undefined {
+    if (!effectDtos?.length) return undefined;
+    return effectDtos.map((dto) => this.buildEffect(dto));
+  }
+
   private buildEffect(effectDto: {
     type: Effect;
     rate: number;
@@ -229,6 +250,7 @@ export class FightController {
       terminationEvent?: string;
     };
     terminationEvent?: string;
+    probability?: number;
   }): AttackEffect {
     const triggeredDebuff = effectDto.triggeredDebuff
       ? new EffectTriggeredDebuff(
@@ -246,21 +268,35 @@ export class FightController {
         return new PoisonAttackEffect(
           effectDto.rate,
           effectDto.level as EffectLevel,
+          new MathRandomizer(),
           triggeredDebuff,
           effectDto.terminationEvent,
+          effectDto.probability,
         );
       case Effect.BURN:
         return new BurnAttackEffect(
           effectDto.rate,
           effectDto.level as EffectLevel,
+          new MathRandomizer(),
           triggeredDebuff,
           effectDto.terminationEvent,
+          effectDto.probability,
         );
       case Effect.FREEZE:
         return new FreezeAttackEffect(
           effectDto.rate,
           effectDto.level as EffectLevel,
+          new MathRandomizer(),
           triggeredDebuff,
+          effectDto.terminationEvent,
+          effectDto.probability,
+        );
+      case Effect.STUNT:
+        return new StuntAttackEffect(
+          effectDto.rate,
+          effectDto.level as EffectLevel,
+          new MathRandomizer(),
+          effectDto.probability,
           effectDto.terminationEvent,
         );
     }
@@ -331,8 +367,8 @@ export class FightController {
         const caDamages = skillData.damages.map(
           (d) => new DamageComposition(d.type, d.rate),
         );
-        const caEffect = skillData.effect
-          ? this.buildEffect(skillData.effect)
+        const caEffects = skillData.effect
+          ? [this.buildEffect(skillData.effect)]
           : undefined;
         const caComboFinisher = skillData.comboFinisher
           ? skillData.comboFinisher.map(
@@ -346,14 +382,14 @@ export class FightController {
               caDamages,
               buildTargetingStrategy(skillData.targetingStrategy),
               skillData.amplifier ?? 0,
-              caEffect,
+              caEffects,
               caComboFinisher,
             )
           : new SimpleAttack(
               skillData.name,
               caDamages,
               buildTargetingStrategy(skillData.targetingStrategy),
-              caEffect,
+              caEffects,
             );
         return new ConditionalAttack(
           skillData.name,

--- a/src/fight/tools/math-randomizer.ts
+++ b/src/fight/tools/math-randomizer.ts
@@ -4,4 +4,8 @@ export class MathRandomizer implements Randomizer {
   public random_int_between(min: number, max: number): number {
     return Math.floor(Math.random() * (max - min + 1)) + min;
   }
+
+  public random(): number {
+    return Math.random();
+  }
 }

--- a/test/fight/event-bound-effect-termination.e2e-spec.ts
+++ b/test/fight/event-bound-effect-termination.e2e-spec.ts
@@ -75,12 +75,14 @@ function buildPayload() {
               name: 'Fire Strike',
               damages: [{ type: 'FIRE', rate: 1.0 }],
               targetingStrategy: 'position-based',
-              effect: {
-                type: 'BURN',
-                rate: 1.0,
-                level: 1,
-                terminationEvent: 'fire-aura-end',
-              },
+              effects: [
+                {
+                  type: 'BURN',
+                  rate: 1.0,
+                  level: 1,
+                  terminationEvent: 'fire-aura-end',
+                },
+              ],
             },
             others: [
               {

--- a/test/fight/kaelion-attack.e2e-spec.ts
+++ b/test/fight/kaelion-attack.e2e-spec.ts
@@ -1,0 +1,164 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module';
+
+const KAELION = {
+  id: 'kaelion-01',
+  name: 'Kaelion',
+  attack: 200,
+  defense: 50,
+  health: 5000,
+  speed: 10,
+  agility: 20,
+  accuracy: 80,
+  criticalChance: 0.1,
+  skills: {
+    special: {
+      kind: 'ATTACK',
+      name: 'Inferno Surge',
+      rate: 2.0,
+      energy: 100,
+      targetingStrategy: 'position-based',
+    },
+    simpleAttack: {
+      name: 'Flamme Terreuse',
+      targetingStrategy: 'position-based',
+      damages: [
+        { type: 'PHYSICAL', rate: 0.8 },
+        { type: 'FIRE', rate: 0.2 },
+        { type: 'EARTH', rate: 0.1 },
+      ],
+      effects: [
+        { type: 'BURN', rate: 0.1, level: 2, probability: 0.5 },
+        { type: 'STUNT', rate: 0.0, level: 1, probability: 0.2 },
+      ],
+    },
+    others: [],
+  },
+  behaviors: { dodge: 'simple-dodge' },
+};
+
+const DUMMY_OPPONENT = {
+  id: 'dummy-01',
+  name: 'Dummy',
+  attack: 1,
+  defense: 0,
+  health: 99999,
+  speed: 1,
+  agility: 0,
+  accuracy: 0,
+  criticalChance: 0,
+  skills: {
+    special: {
+      kind: 'ATTACK',
+      name: 'Weak Hit',
+      rate: 0.01,
+      energy: 9999,
+      targetingStrategy: 'position-based',
+    },
+    simpleAttack: {
+      name: 'Poke',
+      damages: [{ type: 'PHYSICAL', rate: 0.01 }],
+      targetingStrategy: 'position-based',
+    },
+    others: [],
+  },
+  behaviors: { dodge: 'simple-dodge' },
+};
+
+describe('Kaelion — Flamme Terreuse attack', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('accepts the Kaelion payload and returns a valid fight result', () => {
+    const payload = {
+      cardSelectorStrategy: 'player-by-player',
+      player1: { name: 'Kaelion Player', deck: [KAELION] },
+      player2: { name: 'Dummy Player', deck: [DUMMY_OPPONENT] },
+    };
+
+    return request(app.getHttpServer())
+      .post('/fight')
+      .send(payload)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toBeDefined();
+        expect(typeof res.body).toBe('object');
+      });
+  });
+
+  it('reports multi-type damage compositions in attack steps', () => {
+    const payload = {
+      cardSelectorStrategy: 'player-by-player',
+      player1: { name: 'Kaelion Player', deck: [KAELION] },
+      player2: { name: 'Dummy Player', deck: [DUMMY_OPPONENT] },
+    };
+
+    return request(app.getHttpServer())
+      .post('/fight')
+      .send(payload)
+      .expect(200)
+      .expect((res) => {
+        const steps = Object.values(res.body) as any[];
+        const attackStep = steps.find(
+          (s) => s.kind === 'attack' && s.attacker?.id === 'kaelion-01',
+        );
+        expect(attackStep).toBeDefined();
+        const kinds = attackStep.damages[0].kind;
+        expect(kinds).toContain('PHYSICAL');
+        expect(kinds).toContain('FIRE');
+        expect(kinds).toContain('EARTH');
+      });
+  });
+
+  it('validates STUNT is accepted as an effect type', () => {
+    const payload = {
+      cardSelectorStrategy: 'player-by-player',
+      player1: {
+        name: 'P1',
+        deck: [
+          {
+            ...KAELION,
+            skills: {
+              ...KAELION.skills,
+              simpleAttack: {
+                name: 'Stun Strike',
+                targetingStrategy: 'position-based',
+                damages: [{ type: 'PHYSICAL', rate: 1.0 }],
+                effects: [
+                  { type: 'STUNT', rate: 0.0, level: 1, probability: 1.0 },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      player2: { name: 'P2', deck: [DUMMY_OPPONENT] },
+    };
+
+    return request(app.getHttpServer())
+      .post('/fight')
+      .send(payload)
+      .expect(200)
+      .expect((res) => {
+        const steps = Object.values(res.body) as any[];
+        const stuntStep = steps.find(
+          (s) => s.kind === 'status_change' && s.status === 'stunt',
+        );
+        expect(stuntStep).toBeDefined();
+      });
+  });
+});

--- a/test/fight/simulate.e2e-spec.ts
+++ b/test/fight/simulate.e2e-spec.ts
@@ -52,11 +52,13 @@ describe('Simulate fight', () => {
                 name: 'Simple Attack',
                 damages: [{ type: 'PHYSICAL', rate: 1.0 }],
                 targetingStrategy: 'position-based',
-                effect: {
-                  type: 'BURN',
-                  rate: 0.2,
-                  level: 3,
-                },
+                effects: [
+                  {
+                    type: 'BURN',
+                    rate: 0.2,
+                    level: 3,
+                  },
+                ],
               },
               others: [
                 {
@@ -99,11 +101,13 @@ describe('Simulate fight', () => {
                 name: 'Simple Attack',
                 damages: [{ type: 'PHYSICAL', rate: 1.0 }],
                 targetingStrategy: 'position-based',
-                effect: {
-                  type: 'FREEZE',
-                  rate: 0.35,
-                  level: 2,
-                },
+                effects: [
+                  {
+                    type: 'FREEZE',
+                    rate: 0.35,
+                    level: 2,
+                  },
+                ],
               },
               others: [],
             },
@@ -149,11 +153,13 @@ describe('Simulate fight', () => {
                 name: 'Simple Attack',
                 damages: [{ type: 'PHYSICAL', rate: 1.0 }],
                 targetingStrategy: 'position-based',
-                effect: {
-                  type: 'POISON',
-                  rate: 0.5,
-                  level: 1,
-                },
+                effects: [
+                  {
+                    type: 'POISON',
+                    rate: 0.5,
+                    level: 1,
+                  },
+                ],
               },
               others: [],
             },

--- a/test/helpers/effect.ts
+++ b/test/helpers/effect.ts
@@ -5,6 +5,8 @@ import { BurnAttackEffect } from '../../src/fight/core/cards/@types/attack/attac
 import { AttackEffect } from '../../src/fight/core/cards/@types/attack/attack-effect';
 import { EffectLevel } from '../../src/fight/core/cards/@types/attack/effect-level';
 import { FreezeAttackEffect } from '../../src/fight/core/cards/@types/attack/attack-freeze-effect';
+import { StuntAttackEffect } from '../../src/fight/core/cards/@types/attack/attack-stunt-effect';
+import { MathRandomizer } from '../../src/fight/tools/math-randomizer';
 
 export function createEffect(params: {
   rate?: number;
@@ -21,6 +23,7 @@ export function createEffect(params: {
       return new PoisonAttackEffect(
         effectRate,
         effectLevel,
+        new MathRandomizer(),
         undefined,
         params.terminationEvent,
       );
@@ -28,6 +31,7 @@ export function createEffect(params: {
       return new BurnAttackEffect(
         effectRate,
         effectLevel,
+        new MathRandomizer(),
         undefined,
         params.terminationEvent,
       );
@@ -35,6 +39,15 @@ export function createEffect(params: {
       return new FreezeAttackEffect(
         effectRate,
         effectLevel,
+        new MathRandomizer(),
+        undefined,
+        params.terminationEvent,
+      );
+    case 'stunt':
+      return new StuntAttackEffect(
+        effectRate,
+        effectLevel,
+        new MathRandomizer(),
         undefined,
         params.terminationEvent,
       );

--- a/test/helpers/fighting-card.ts
+++ b/test/helpers/fighting-card.ts
@@ -196,13 +196,13 @@ function createSimpleAttack(params: {
     ),
   ];
   const targetingStrategy = params.targetingStrategy ?? 'position-based';
-  const effect = params.effect ? createEffect(params.effect) : undefined;
+  const effects = params.effect ? [createEffect(params.effect)] : undefined;
 
   return new SimpleAttack(
     params.name ?? faker.word.noun(),
     damages,
     createTargetingStrategy(targetingStrategy),
-    effect,
+    effects,
   );
 }
 

--- a/test/helpers/randomizer-fake.ts
+++ b/test/helpers/randomizer-fake.ts
@@ -8,6 +8,10 @@ export class RandomizerFake implements Randomizer {
     return this.nextRandomValue;
   }
 
+  public random(): number {
+    return this.nextRandomValue;
+  }
+
   public setNextRandomValue(value: number): RandomizerFake {
     this.nextRandomValue = value;
     return this;


### PR DESCRIPTION
- Implemented StuntAttackEffect class to apply stunt effects on defending cards.
- Created CardStateStunted class to manage the state of stunted cards.
- Updated FightingCard class to handle stunted state and effects.
- Modified attack skills (SimpleAttack, MultipleAttack, SpecialAttack) to support multiple effects.
- Enhanced tests to cover new stunt effects and their interactions.
- Updated API DTOs and controllers to accommodate the new stunt effect type.
- Added integration tests for Kaelion's attack with stunt effects.

closes: #205 