### PR TITLE
fix: standardize applyDebuff() parameter order to match applyBuff()

### DIFF
--- a/src/fight/core/cards/@types/attack/effect-triggered-debuff.ts
+++ b/src/fight/core/cards/@types/attack/effect-triggered-debuff.ts
@@ -35,7 +35,6 @@ export class EffectTriggeredDebuff {
       this.debuffType,
       this.debuffRate,
       this.duration,
-      undefined,
       this.terminationEvent,
     );
   }

--- a/src/fight/core/cards/__tests__/fighting-card.spec.ts
+++ b/src/fight/core/cards/__tests__/fighting-card.spec.ts
@@ -146,7 +146,7 @@ describe('FightingCard.removeEventBoundDebuffs()', () => {
         accuracy: 0,
         agility: 0,
       });
-      card.applyDebuff('attack', 0.4, Infinity, undefined, 'lions-end');
+      card.applyDebuff('attack', 0.4, Infinity, 'lions-end');
     });
 
     it('returns the list of removed debuffs', () => {
@@ -178,7 +178,7 @@ describe('FightingCard.removeEventBoundDebuffs()', () => {
         accuracy: 0,
         agility: 0,
       });
-      card.applyDebuff('attack', 0.4, Infinity, undefined, 'other-event');
+      card.applyDebuff('attack', 0.4, Infinity, 'other-event');
     });
 
     it('leaves non-matching debuffs in place', () => {

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -473,8 +473,8 @@ export class FightingCard {
     debuffType: AlterationType,
     debuffRate: number,
     duration: number,
-    powerId?: string,
     terminationEvent?: string,
+    powerId?: string,
   ): AlterationDetail {
     const debuff: AlterationDetail = {
       type: debuffType,

--- a/src/fight/core/cards/skills/__tests__/alteration-skill.spec.ts
+++ b/src/fight/core/cards/skills/__tests__/alteration-skill.spec.ts
@@ -158,5 +158,22 @@ describe('AlterationSkill lifecycle', () => {
 
       expect(source.actualAttack).toBe(initialAttack - 10);
     });
+
+    it('sets terminationEvent on applied debuff', () => {
+      const source = createFightingCard({ attack: 100, health: 100 });
+      const skill = new AlterationSkill({
+        name: 'skill',
+        polarity: 'debuff',
+        attributeType: 'attack',
+        rate: 0.1,
+        duration: Infinity,
+        trigger,
+        targetingStrategy: targeting,
+        terminationEvent: 'my-end-event',
+      });
+      skill.launch(source, makeContext(source));
+
+      expect(source.removeEventBoundDebuffs('my-end-event')).toHaveLength(1);
+    });
   });
 });

--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -131,6 +131,7 @@ export class AlterationSkill implements Skill {
         this.attributeType,
         this.rate,
         this.duration,
+        this.terminationEvent,
         this.powerId,
       ),
     }));

--- a/src/fight/core/fight-simulator/__tests__/end-event-processor.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/end-event-processor.spec.ts
@@ -71,7 +71,7 @@ describe('EndEventProcessor.processEndEvent()', () => {
         accuracy: 0,
         agility: 0,
       });
-      card.applyDebuff('attack', 0.4, Infinity, undefined, 'lions-end');
+      card.applyDebuff('attack', 0.4, Infinity, 'lions-end');
       const player1 = new Player('P1', [card]);
       const player2 = new Player('P2', [createFightingCard({})]);
       processor = new EndEventProcessor(player1, player2);


### PR DESCRIPTION
## Summary

- Swaps `powerId` and `terminationEvent` optional params in `FightingCard.applyDebuff()` to match the order used by `applyBuff()`: `(type, rate, duration, terminationEvent?, powerId?)`
- Updates `AlterationSkill` debuff path to pass `this.terminationEvent` as the 4th argument so event-bound debuffs are actually removable
- Updates all other callers (`EffectTriggeredDebuff`, tests) to use the corrected argument order
- Adds a regression test in `alteration-skill.spec.ts` verifying that a debuff with `terminationEvent` is removed by `removeEventBoundDebuffs()`

Closes #212

## Test plan

- [ ] `npm test` — all 509 tests pass
- [ ] `npm run build` — clean build
- [ ] New test `sets terminationEvent on applied debuff` in `alteration-skill.spec.ts` covers the regression

https://claude.ai/code/session_017Y5nCBZWGtPhiY2pftenUb

---
_Generated by [Claude Code](https://claude.ai/code/session_017Y5nCBZWGtPhiY2pftenUb)_