### PR TITLE
fix: throw on unknown BuffConditionType and invalid operator in buff-condition-factory

### DIFF
--- a/src/fight/http-api/__test__/buff-condition-factory.spec.ts
+++ b/src/fight/http-api/__test__/buff-condition-factory.spec.ts
@@ -1,0 +1,73 @@
+import 'reflect-metadata';
+
+import { BuffConditionType } from '../dto/fight-data.dto';
+import { buildBuffCondition } from '../buff-condition-factory';
+import { AllyPresenceCondition } from '../../core/cards/@types/alteration/conditions/ally-presence-condition';
+import { HealthThresholdCondition } from '../../core/cards/@types/alteration/conditions/health-threshold-condition';
+
+describe('buildBuffCondition', () => {
+  describe('ALLY_PRESENCE', () => {
+    it('returns AllyPresenceCondition when allyName is provided', () => {
+      const condition = buildBuffCondition(BuffConditionType.ALLY_PRESENCE, {
+        allyName: 'Hero',
+      });
+      expect(condition).toBeInstanceOf(AllyPresenceCondition);
+    });
+
+    it('throws when allyName is missing', () => {
+      expect(() =>
+        buildBuffCondition(BuffConditionType.ALLY_PRESENCE, {}),
+      ).toThrow('AllyPresenceCondition requires allyName');
+    });
+  });
+
+  describe('HEALTH_THRESHOLD', () => {
+    it('returns HealthThresholdCondition with defaults when no params provided', () => {
+      const condition = buildBuffCondition(
+        BuffConditionType.HEALTH_THRESHOLD,
+        {},
+      );
+      expect(condition).toBeInstanceOf(HealthThresholdCondition);
+    });
+
+    it('returns HealthThresholdCondition with valid above operator', () => {
+      const condition = buildBuffCondition(BuffConditionType.HEALTH_THRESHOLD, {
+        threshold: 0.3,
+        operator: 'above',
+      });
+      expect(condition).toBeInstanceOf(HealthThresholdCondition);
+    });
+
+    it('returns HealthThresholdCondition with valid below operator', () => {
+      const condition = buildBuffCondition(BuffConditionType.HEALTH_THRESHOLD, {
+        threshold: 0.5,
+        operator: 'below',
+      });
+      expect(condition).toBeInstanceOf(HealthThresholdCondition);
+    });
+
+    it('throws for an invalid operator', () => {
+      expect(() =>
+        buildBuffCondition(BuffConditionType.HEALTH_THRESHOLD, {
+          operator: 'greater',
+        }),
+      ).toThrow('Invalid operator: greater');
+    });
+
+    it('throws for an empty string operator', () => {
+      expect(() =>
+        buildBuffCondition(BuffConditionType.HEALTH_THRESHOLD, {
+          operator: '',
+        }),
+      ).toThrow('Invalid operator: ');
+    });
+  });
+
+  describe('unknown type', () => {
+    it('throws for an unknown BuffConditionType', () => {
+      expect(() =>
+        buildBuffCondition('UNKNOWN_TYPE' as BuffConditionType, {}),
+      ).toThrow('Unknown BuffConditionType: UNKNOWN_TYPE');
+    });
+  });
+});

--- a/src/fight/http-api/__test__/buff-condition-factory.spec.ts
+++ b/src/fight/http-api/__test__/buff-condition-factory.spec.ts
@@ -1,16 +1,22 @@
 import 'reflect-metadata';
 
-import { BuffConditionType } from '../dto/fight-data.dto';
-import { buildBuffCondition } from '../buff-condition-factory';
+import { AlterationCondition } from '../../core/cards/@types/alteration/alteration-condition';
 import { AllyPresenceCondition } from '../../core/cards/@types/alteration/conditions/ally-presence-condition';
 import { HealthThresholdCondition } from '../../core/cards/@types/alteration/conditions/health-threshold-condition';
+import { BuffConditionType } from '../dto/fight-data.dto';
+import { buildBuffCondition } from '../buff-condition-factory';
 
 describe('buildBuffCondition', () => {
   describe('ALLY_PRESENCE', () => {
-    it('returns AllyPresenceCondition when allyName is provided', () => {
-      const condition = buildBuffCondition(BuffConditionType.ALLY_PRESENCE, {
+    let condition: AlterationCondition;
+
+    beforeEach(() => {
+      condition = buildBuffCondition(BuffConditionType.ALLY_PRESENCE, {
         allyName: 'Hero',
       });
+    });
+
+    it('returns AllyPresenceCondition when allyName is provided', () => {
       expect(condition).toBeInstanceOf(AllyPresenceCondition);
     });
 
@@ -22,28 +28,46 @@ describe('buildBuffCondition', () => {
   });
 
   describe('HEALTH_THRESHOLD', () => {
-    it('returns HealthThresholdCondition with defaults when no params provided', () => {
-      const condition = buildBuffCondition(
-        BuffConditionType.HEALTH_THRESHOLD,
-        {},
-      );
-      expect(condition).toBeInstanceOf(HealthThresholdCondition);
+    describe('with default params', () => {
+      let condition: AlterationCondition;
+
+      beforeEach(() => {
+        condition = buildBuffCondition(BuffConditionType.HEALTH_THRESHOLD, {});
+      });
+
+      it('returns HealthThresholdCondition', () => {
+        expect(condition).toBeInstanceOf(HealthThresholdCondition);
+      });
     });
 
-    it('returns HealthThresholdCondition with valid above operator', () => {
-      const condition = buildBuffCondition(BuffConditionType.HEALTH_THRESHOLD, {
-        threshold: 0.3,
-        operator: 'above',
+    describe('with above operator', () => {
+      let condition: AlterationCondition;
+
+      beforeEach(() => {
+        condition = buildBuffCondition(BuffConditionType.HEALTH_THRESHOLD, {
+          threshold: 0.3,
+          operator: 'above',
+        });
       });
-      expect(condition).toBeInstanceOf(HealthThresholdCondition);
+
+      it('returns HealthThresholdCondition', () => {
+        expect(condition).toBeInstanceOf(HealthThresholdCondition);
+      });
     });
 
-    it('returns HealthThresholdCondition with valid below operator', () => {
-      const condition = buildBuffCondition(BuffConditionType.HEALTH_THRESHOLD, {
-        threshold: 0.5,
-        operator: 'below',
+    describe('with below operator', () => {
+      let condition: AlterationCondition;
+
+      beforeEach(() => {
+        condition = buildBuffCondition(BuffConditionType.HEALTH_THRESHOLD, {
+          threshold: 0.5,
+          operator: 'below',
+        });
       });
-      expect(condition).toBeInstanceOf(HealthThresholdCondition);
+
+      it('returns HealthThresholdCondition', () => {
+        expect(condition).toBeInstanceOf(HealthThresholdCondition);
+      });
     });
 
     it('throws for an invalid operator', () => {

--- a/src/fight/http-api/buff-condition-factory.ts
+++ b/src/fight/http-api/buff-condition-factory.ts
@@ -3,6 +3,9 @@ import { AlterationCondition } from '../core/cards/@types/alteration/alteration-
 import { AllyPresenceCondition } from '../core/cards/@types/alteration/conditions/ally-presence-condition';
 import { HealthThresholdCondition } from '../core/cards/@types/alteration/conditions/health-threshold-condition';
 
+type ConditionOperator = 'above' | 'below';
+const VALID_OPERATORS: ConditionOperator[] = ['above', 'below'];
+
 export function buildBuffCondition(
   type: BuffConditionType,
   params: { allyName?: string; threshold?: number; operator?: string },
@@ -14,16 +17,15 @@ export function buildBuffCondition(
       }
       return new AllyPresenceCondition(params.allyName);
     case BuffConditionType.HEALTH_THRESHOLD: {
-      const validOperators = ['above', 'below'] as const;
       if (
         params.operator !== undefined &&
-        !validOperators.includes(params.operator as 'above' | 'below')
+        !VALID_OPERATORS.includes(params.operator as ConditionOperator)
       ) {
         throw new Error(`Invalid operator: ${params.operator}`);
       }
       return new HealthThresholdCondition(
         params.threshold ?? 0.5,
-        (params.operator as 'above' | 'below') ?? 'above',
+        (params.operator as ConditionOperator) ?? 'above',
       );
     }
     default:

--- a/src/fight/http-api/buff-condition-factory.ts
+++ b/src/fight/http-api/buff-condition-factory.ts
@@ -13,10 +13,20 @@ export function buildBuffCondition(
         throw new Error('AllyPresenceCondition requires allyName');
       }
       return new AllyPresenceCondition(params.allyName);
-    case BuffConditionType.HEALTH_THRESHOLD:
+    case BuffConditionType.HEALTH_THRESHOLD: {
+      const validOperators = ['above', 'below'] as const;
+      if (
+        params.operator !== undefined &&
+        !validOperators.includes(params.operator as 'above' | 'below')
+      ) {
+        throw new Error(`Invalid operator: ${params.operator}`);
+      }
       return new HealthThresholdCondition(
         params.threshold ?? 0.5,
         (params.operator as 'above' | 'below') ?? 'above',
       );
+    }
+    default:
+      throw new Error(`Unknown BuffConditionType: ${type}`);
   }
 }


### PR DESCRIPTION
## Summary

- Add `default` branch to `buildBuffCondition()` switch that throws `Error('Unknown BuffConditionType: ${type}')` instead of silently returning `undefined`
- Validate `params.operator` against `['above', 'below']` before casting, throwing `Error('Invalid operator: ${params.operator}')` for any other value (including empty string)
- Add `buff-condition-factory.spec.ts` with 8 tests covering all cases (100% coverage)

## Test plan

- [x] All 517 existing tests pass (`npm run test:cov`)
- [x] New spec covers: ALLY_PRESENCE happy path, missing allyName, HEALTH_THRESHOLD defaults, valid operators (`above`/`below`), invalid operator (`greater`), empty string operator, unknown type
- [x] `npm run lint` passes
- [x] `npm run build` passes

Closes #213

https://claude.ai/code/session_016XN6ztyWxzzFRX5Y8EvW8W

---
_Generated by [Claude Code](https://claude.ai/code/session_016XN6ztyWxzzFRX5Y8EvW8W)_