### PR TITLE
types: add polarity discriminator to AlterationDetail

### DIFF
--- a/src/fight/core/cards/@types/action-result/buff-results.ts
+++ b/src/fight/core/cards/@types/action-result/buff-results.ts
@@ -1,9 +1,9 @@
 import { CardInfo } from '../card-info';
-import { AlterationDetail } from '../alteration/alteration-detail';
+import { Buff } from '../alteration/alteration-detail';
 
 export type BuffResult = {
   target: CardInfo;
-  alteration: AlterationDetail;
+  alteration: Buff;
 };
 
 export type BuffResults = BuffResult[];

--- a/src/fight/core/cards/@types/action-result/debuff-results.ts
+++ b/src/fight/core/cards/@types/action-result/debuff-results.ts
@@ -1,9 +1,9 @@
 import { CardInfo } from '../card-info';
-import { AlterationDetail } from '../alteration/alteration-detail';
+import { Debuff } from '../alteration/alteration-detail';
 
 export type DebuffResult = {
   target: CardInfo;
-  debuff: AlterationDetail;
+  debuff: Debuff;
 };
 
 export type DebuffResults = DebuffResult[];

--- a/src/fight/core/cards/@types/alteration/alteration-detail.ts
+++ b/src/fight/core/cards/@types/alteration/alteration-detail.ts
@@ -1,9 +1,13 @@
 import { AlterationType } from './alteration-type';
 
 export type AlterationDetail = {
+  polarity: 'buff' | 'debuff';
   type: AlterationType;
   value: number;
   duration: number;
   terminationEvent?: string;
   powerId?: string;
 };
+
+export type Buff = AlterationDetail & { polarity: 'buff' };
+export type Debuff = AlterationDetail & { polarity: 'debuff' };

--- a/src/fight/core/cards/@types/alteration/alteration.ts
+++ b/src/fight/core/cards/@types/alteration/alteration.ts
@@ -1,14 +1,14 @@
 import { FightingCard } from '../../fighting-card';
 import { FightingContext } from '../fighting-context';
 import { TargetingCardStrategy } from '../../../targeting-card-strategies/targeting-card-strategy';
-import { AlterationDetail } from './alteration-detail';
+import { Buff } from './alteration-detail';
 import { AlterationType } from './alteration-type';
 import { CardInfo } from '../card-info';
 import { AlterationCondition } from './alteration-condition';
 
 export type AlterationResult = {
   target: CardInfo;
-  alteration: AlterationDetail;
+  alteration: Buff;
 };
 
 export class Alteration {

--- a/src/fight/core/cards/@types/attack/__tests__/effect-triggered-debuff.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/effect-triggered-debuff.spec.ts
@@ -27,9 +27,12 @@ describe('EffectTriggeredDebuff', () => {
 
     it('returns the applied debuff', () => {
       expect(result).toEqual({
+        polarity: 'debuff',
         type: 'defense',
         value: 20,
         duration: 2,
+        terminationEvent: undefined,
+        powerId: undefined,
       });
     });
   });

--- a/src/fight/core/cards/@types/attack/attack-effect.ts
+++ b/src/fight/core/cards/@types/attack/attack-effect.ts
@@ -1,14 +1,14 @@
 import { FightingCard } from '../../fighting-card';
 import { EffectLevel } from './effect-level';
 import { FightingContext } from '../fighting-context';
-import { AlterationDetail } from '../alteration/alteration-detail';
+import { Debuff } from '../alteration/alteration-detail';
 import { EffectTriggeredDebuff } from './effect-triggered-debuff';
 import { StateEffectType } from '../state/state-effect-type';
 
 export type EffectResult = {
   type: StateEffectType;
   card: FightingCard;
-  triggeredDebuff?: { card: FightingCard; debuff: AlterationDetail };
+  triggeredDebuff?: { card: FightingCard; debuff: Debuff };
 };
 
 export interface AttackEffect {

--- a/src/fight/core/cards/@types/attack/effect-triggered-debuff.ts
+++ b/src/fight/core/cards/@types/attack/effect-triggered-debuff.ts
@@ -1,5 +1,5 @@
 import { FightingCard } from '../../fighting-card';
-import { AlterationDetail } from '../alteration/alteration-detail';
+import { Debuff } from '../alteration/alteration-detail';
 import { AlterationType } from '../alteration/alteration-type';
 import { Randomizer } from '../../../../core/randomizer';
 
@@ -27,7 +27,7 @@ export class EffectTriggeredDebuff {
     this.randomizer = randomizer;
   }
 
-  public tryApply(target: FightingCard): AlterationDetail | undefined {
+  public tryApply(target: FightingCard): Debuff | undefined {
     if (this.randomizer.random_int_between(0, 100) >= this.probability * 100)
       return undefined;
 

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -10,11 +10,7 @@ import { StateResult } from './@types/action-result/state-result';
 import { CardStateFrozen } from './@types/state/card-state-frozen';
 import { CardStateStunted } from './@types/state/card-state-stunted';
 import { EffectLevel } from './@types/attack/effect-level';
-import {
-  AlterationDetail,
-  Buff,
-  Debuff,
-} from './@types/alteration/alteration-detail';
+import { Buff, Debuff } from './@types/alteration/alteration-detail';
 import { Skill, SkillResults } from './skills/skill';
 import { AlterationType } from './@types/alteration/alteration-type';
 import { Element } from './@types/damage/element';

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -10,7 +10,11 @@ import { StateResult } from './@types/action-result/state-result';
 import { CardStateFrozen } from './@types/state/card-state-frozen';
 import { CardStateStunted } from './@types/state/card-state-stunted';
 import { EffectLevel } from './@types/attack/effect-level';
-import { AlterationDetail } from './@types/alteration/alteration-detail';
+import {
+  AlterationDetail,
+  Buff,
+  Debuff,
+} from './@types/alteration/alteration-detail';
 import { Skill, SkillResults } from './skills/skill';
 import { AlterationType } from './@types/alteration/alteration-type';
 import { Element } from './@types/damage/element';
@@ -46,10 +50,10 @@ export class FightingCard {
   private receivedHeal: number = 0;
 
   // Buffs
-  private buffs: AlterationDetail[] = [];
+  private buffs: Buff[] = [];
 
   // Debuffs
-  private debuffs: AlterationDetail[] = [];
+  private debuffs: Debuff[] = [];
 
   // Skills
   private simpleAttack: AttackSkill;
@@ -376,9 +380,10 @@ export class FightingCard {
     duration: number,
     terminationEvent?: string,
     powerId?: string,
-  ): AlterationDetail {
+  ): Buff {
     const value = this.computeAttributeModifierValue(buffType, buffRate);
-    const buff: AlterationDetail = {
+    const buff: Buff = {
+      polarity: 'buff',
       type: buffType,
       value,
       duration,
@@ -449,8 +454,8 @@ export class FightingCard {
   }
 
   public decreaseBuffAndDebuffDuration(): {
-    expiredBuffs: AlterationDetail[];
-    expiredDebuffs: AlterationDetail[];
+    expiredBuffs: Buff[];
+    expiredDebuffs: Debuff[];
   } {
     const decremented = this.buffs.map((b) => ({
       ...b,
@@ -475,8 +480,9 @@ export class FightingCard {
     duration: number,
     terminationEvent?: string,
     powerId?: string,
-  ): AlterationDetail {
-    const debuff: AlterationDetail = {
+  ): Debuff {
+    const debuff: Debuff = {
+      polarity: 'debuff',
       type: debuffType,
       value: this.computeAttributeModifierValue(debuffType, debuffRate),
       duration: duration,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #215

- Added `polarity: 'buff' | 'debuff'` required field to `AlterationDetail`
- Exported two narrowed subtypes `Buff` and `Debuff` from `alteration-detail.ts`
- Narrowed `FightingCard.buffs` to `Buff[]` and `FightingCard.debuffs` to `Debuff[]`
- `applyBuff()` now returns `Buff`, `applyDebuff()` returns `Debuff`
- `decreaseBuffAndDebuffDuration()` returns `{ expiredBuffs: Buff[], expiredDebuffs: Debuff[] }`
- Updated `BuffResult.alteration`, `AlterationResult.alteration` to `Buff`
- Updated `DebuffResult.debuff`, `EffectResult.triggeredDebuff.debuff`, `EffectTriggeredDebuff.tryApply()` return to `Debuff`

TypeScript now statically prevents a `Debuff` being pushed into `buffs[]` and vice-versa, eliminating the silent stat corruption described in the issue.

## Test plan

- [ ] All 517 existing unit tests pass (`npm run test:cov`)
- [ ] Updated `effect-triggered-debuff.spec.ts` assertion to include `polarity: 'debuff'`
- [ ] Build succeeds (`npm run build`)

https://claude.ai/code/session_013X6j7bjHNSCKqD984WFGqH
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013X6j7bjHNSCKqD984WFGqH)_