### PR TITLE
test: add debuff + activationCondition coverage to AlterationSkill

### DIFF
--- a/src/fight/core/cards/skills/__tests__/conditional-alteration-skill.spec.ts
+++ b/src/fight/core/cards/skills/__tests__/conditional-alteration-skill.spec.ts
@@ -17,79 +17,184 @@ describe('AlterationSkill with activationCondition', () => {
     };
   }
 
-  describe('when activation condition is met', () => {
-    let results;
+  describe('buff polarity', () => {
+    describe('when activation condition is met', () => {
+      let results;
 
-    beforeEach(() => {
-      const condition = new HealthThresholdCondition(0.5, 'above');
-      const skill = new AlterationSkill({
-        name: 'skill',
-        polarity: 'buff',
-        attributeType: 'attack',
-        rate: 0.1,
-        duration: 2,
-        trigger,
-        targetingStrategy,
-        activationCondition: condition,
+      beforeEach(() => {
+        const condition = new HealthThresholdCondition(0.5, 'above');
+        const skill = new AlterationSkill({
+          name: 'skill',
+          polarity: 'buff',
+          attributeType: 'attack',
+          rate: 0.1,
+          duration: 2,
+          trigger,
+          targetingStrategy,
+          activationCondition: condition,
+        });
+        const source = createFightingCard({ health: 100 });
+        results = skill.launch(source, makeContext(source));
       });
-      const source = createFightingCard({ health: 100 });
-      results = skill.launch(source, makeContext(source));
+
+      it('returns buff results', () => {
+        expect(results.results.length).toBe(1);
+      });
     });
 
-    it('returns buff results', () => {
-      expect(results.results.length).toBe(1);
+    describe('when activation condition is not met', () => {
+      let results;
+
+      beforeEach(() => {
+        const condition = new HealthThresholdCondition(0.5, 'above');
+        const skill = new AlterationSkill({
+          name: 'skill',
+          polarity: 'buff',
+          attributeType: 'attack',
+          rate: 0.1,
+          duration: 2,
+          trigger,
+          targetingStrategy,
+          activationCondition: condition,
+        });
+        const source = createFightingCard({ health: 100 });
+        source.addRealDamage(60);
+        results = skill.launch(source, makeContext(source));
+      });
+
+      it('returns empty results', () => {
+        expect(results.results.length).toBe(0);
+      });
+
+      it('returns Buff skillKind', () => {
+        expect(results.skillKind).toBe(SkillKind.Buff);
+      });
+    });
+
+    describe('when no activation condition is set', () => {
+      let results;
+
+      beforeEach(() => {
+        const skill = new AlterationSkill({
+          name: 'skill',
+          polarity: 'buff',
+          attributeType: 'attack',
+          rate: 0.1,
+          duration: 2,
+          trigger,
+          targetingStrategy,
+        });
+        const source = createFightingCard({ health: 100 });
+        source.addRealDamage(99);
+        results = skill.launch(source, makeContext(source));
+      });
+
+      it('always applies buff', () => {
+        expect(results.results.length).toBe(1);
+      });
     });
   });
 
-  describe('when activation condition is not met', () => {
-    let results;
+  describe('debuff polarity', () => {
+    describe('when activation condition is met', () => {
+      let results;
 
-    beforeEach(() => {
-      const condition = new HealthThresholdCondition(0.5, 'above');
-      const skill = new AlterationSkill({
-        name: 'skill',
-        polarity: 'buff',
-        attributeType: 'attack',
-        rate: 0.1,
-        duration: 2,
-        trigger,
-        targetingStrategy,
-        activationCondition: condition,
+      beforeEach(() => {
+        const condition = new HealthThresholdCondition(0.5, 'above');
+        const skill = new AlterationSkill({
+          name: 'skill',
+          polarity: 'debuff',
+          attributeType: 'attack',
+          rate: 0.1,
+          duration: 2,
+          trigger,
+          targetingStrategy,
+          activationCondition: condition,
+        });
+        const source = createFightingCard({ health: 100 });
+        results = skill.launch(source, makeContext(source));
       });
-      const source = createFightingCard({ health: 100 });
-      source.addRealDamage(60);
-      results = skill.launch(source, makeContext(source));
-    });
 
-    it('returns empty results', () => {
-      expect(results.results.length).toBe(0);
-    });
-
-    it('returns Buff skillKind', () => {
-      expect(results.skillKind).toBe(SkillKind.Buff);
-    });
-  });
-
-  describe('when no activation condition is set', () => {
-    let results;
-
-    beforeEach(() => {
-      const skill = new AlterationSkill({
-        name: 'skill',
-        polarity: 'buff',
-        attributeType: 'attack',
-        rate: 0.1,
-        duration: 2,
-        trigger,
-        targetingStrategy,
+      it('returns debuff results', () => {
+        expect(results.results.length).toBe(1);
       });
-      const source = createFightingCard({ health: 100 });
-      source.addRealDamage(99);
-      results = skill.launch(source, makeContext(source));
+
+      it('returns Debuff skillKind', () => {
+        expect(results.skillKind).toBe(SkillKind.Debuff);
+      });
     });
 
-    it('always applies buff', () => {
-      expect(results.results.length).toBe(1);
+    describe('when activation condition is not met', () => {
+      let results;
+
+      beforeEach(() => {
+        const condition = new HealthThresholdCondition(0.5, 'above');
+        const skill = new AlterationSkill({
+          name: 'skill',
+          polarity: 'debuff',
+          attributeType: 'attack',
+          rate: 0.1,
+          duration: 2,
+          trigger,
+          targetingStrategy,
+          activationCondition: condition,
+        });
+        const source = createFightingCard({ health: 100 });
+        source.addRealDamage(60);
+        results = skill.launch(source, makeContext(source));
+      });
+
+      it('returns empty results', () => {
+        expect(results.results.length).toBe(0);
+      });
+
+      it('returns Debuff skillKind', () => {
+        expect(results.skillKind).toBe(SkillKind.Debuff);
+      });
+    });
+
+    describe('when no activation condition is set', () => {
+      let results;
+
+      beforeEach(() => {
+        const skill = new AlterationSkill({
+          name: 'skill',
+          polarity: 'debuff',
+          attributeType: 'attack',
+          rate: 0.1,
+          duration: 2,
+          trigger,
+          targetingStrategy,
+        });
+        const source = createFightingCard({ health: 100 });
+        source.addRealDamage(99);
+        results = skill.launch(source, makeContext(source));
+      });
+
+      it('always applies debuff', () => {
+        expect(results.results.length).toBe(1);
+      });
+    });
+
+    describe('with terminationEvent', () => {
+      it('stores terminationEvent on applied debuff when condition is met', () => {
+        const condition = new HealthThresholdCondition(0.5, 'above');
+        const source = createFightingCard({ health: 100 });
+        const skill = new AlterationSkill({
+          name: 'skill',
+          polarity: 'debuff',
+          attributeType: 'attack',
+          rate: 0.1,
+          duration: Infinity,
+          trigger,
+          targetingStrategy,
+          activationCondition: condition,
+          terminationEvent: 'my-end-event',
+        });
+        skill.launch(source, makeContext(source));
+
+        expect(source.removeEventBoundDebuffs('my-end-event')).toHaveLength(1);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Reorganizes existing buff polarity tests under a `buff polarity` describe block for clarity
- Adds mirror test coverage for the `debuff` polarity path with `activationCondition`:
  - Condition evaluates to **true** → debuff is applied (1 result, `SkillKind.Debuff`)
  - Condition evaluates to **false** → returns empty results (`SkillKind.Debuff`)
  - No condition set → debuff always applies
- Adds a `terminationEvent` test for the debuff + activationCondition path: verifies the event-bound debuff is correctly stored and removable

Closes #216

## Test plan

- [ ] `npm test` passes (523 tests, 0 failures)
- [ ] New tests in `conditional-alteration-skill.spec.ts` cover all 3 debuff + condition scenarios plus the `terminationEvent` case

https://claude.ai/code/session_019HS4hHES9JkuhL2HUMqbsw

---
_Generated by [Claude Code](https://claude.ai/code/session_019HS4hHES9JkuhL2HUMqbsw)_