### PR TITLE
fix(alteration): throw early when condition is set without conditionMultiplier

### DIFF
--- a/src/fight/core/cards/@types/alteration/__tests__/buff-application-with-condition.spec.ts
+++ b/src/fight/core/cards/@types/alteration/__tests__/buff-application-with-condition.spec.ts
@@ -64,6 +64,14 @@ describe('Alteration with condition', () => {
     });
   });
 
+  describe('when condition is provided without conditionMultiplier', () => {
+    it('throws in the constructor', () => {
+      expect(
+        () => new Alteration('attack', 0.2, 1, new Launcher(), trueCondition),
+      ).toThrow();
+    });
+  });
+
   describe('when condition evaluates to false', () => {
     let result: ReturnType<Alteration['apply']>[0];
 

--- a/src/fight/core/cards/@types/alteration/alteration.ts
+++ b/src/fight/core/cards/@types/alteration/alteration.ts
@@ -20,7 +20,11 @@ export class Alteration {
     public readonly condition?: AlterationCondition,
     public readonly conditionMultiplier?: number,
     public readonly terminationEvent?: string,
-  ) {}
+  ) {
+    if (condition !== undefined && conditionMultiplier === undefined) {
+      throw new Error('conditionMultiplier is required when condition is set');
+    }
+  }
 
   public apply(
     source: FightingCard,


### PR DESCRIPTION
## ✅ Type of PR

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Constructing an `Alteration` with a `condition` but no `conditionMultiplier` silently
produced `NaN` via `rate * undefined`, corrupting all subsequent stat calculations
with no error raised.

## 🚶‍➡️ Behavior

- `Alteration` constructor now throws immediately when `condition` is set without `conditionMultiplier`
- Prevents silent NaN propagation through buff/stat calculation chain
- No change to existing valid usages (condition + multiplier, or neither)

## 🧪 Steps to test

- [ ] Construct `Alteration` with a `condition` and no `conditionMultiplier` → expect an `Error` to be thrown
- [ ] Construct `Alteration` with both `condition` and `conditionMultiplier` → expect normal buff application
- [ ] Run `npm run test:cov` → all 524 tests pass

Closes #228