### PR TITLE
fix: correct misleading JSDoc on AlterationSkillOptions.duration

### DIFF
--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -12,7 +12,7 @@ export interface AlterationSkillOptions {
   polarity: 'buff' | 'debuff';
   attributeType: AlterationType;
   rate: number;
-  /** Number of turns the alteration lasts. Use Infinity for event-bound or permanent buffs. */
+  /** Number of turns the alteration lasts. Use 0 for permanent or event-bound alterations (combined with an optional terminationEvent). */
   duration: number;
   trigger: Trigger;
   targetingStrategy: TargetingCardStrategy;


### PR DESCRIPTION
## Summary

- Corrects the JSDoc comment on `AlterationSkillOptions.duration` in `alteration-skill.ts:15`
- Replaces the incorrect `Infinity` sentinel hint with the real contract: `duration: 0` = permanent / event-bound (combined with optional `terminationEvent`)

Closes #229

## Test plan

- [ ] No logic changed — comment-only fix
- [ ] Lint passes (`npm run lint`)

https://claude.ai/code/session_01EkBzd6BnCGo3DQiCHJjxkL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkBzd6BnCGo3DQiCHJjxkL)_