### PR TITLE
types: replace redundant AlterationResult with BuffResult in alteration.ts

### DIFF
--- a/src/fight/core/cards/@types/alteration/alteration.ts
+++ b/src/fight/core/cards/@types/alteration/alteration.ts
@@ -1,15 +1,9 @@
 import { FightingCard } from '../../fighting-card';
 import { FightingContext } from '../fighting-context';
 import { TargetingCardStrategy } from '../../../targeting-card-strategies/targeting-card-strategy';
-import { Buff } from './alteration-detail';
 import { AlterationType } from './alteration-type';
-import { CardInfo } from '../card-info';
 import { AlterationCondition } from './alteration-condition';
-
-export type AlterationResult = {
-  target: CardInfo;
-  alteration: Buff;
-};
+import { BuffResult } from '../action-result/alteration-result';
 
 export class Alteration {
   constructor(
@@ -26,10 +20,7 @@ export class Alteration {
     }
   }
 
-  public apply(
-    source: FightingCard,
-    context: FightingContext,
-  ): AlterationResult[] {
+  public apply(source: FightingCard, context: FightingContext): BuffResult[] {
     const effectiveRate = this.condition?.evaluate(source, context)
       ? this.rate * this.conditionMultiplier
       : this.rate;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes the duplicate `AlterationResult` type from `alteration.ts` — it was structurally identical to `BuffResult<Buff>` from `alteration-result.ts`
- Imports and uses `BuffResult` directly in `Alteration.apply()` return type
- Drops now-unused `Buff` and `CardInfo` imports from `alteration.ts`

Closes #230

## Test plan

- [ ] `npm run build` passes — no type errors in `alteration.ts` or any consumer
- [ ] `npm run test` passes — no behavioral change, pure type consolidation

https://claude.ai/code/session_015gwxecHfs1L5e3cJy86Tw1
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015gwxecHfs1L5e3cJy86Tw1)_