### PR TITLE
fix: make attackerCard required in handleAttackResult

### DIFF
--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -207,7 +207,7 @@ export class ActionStage {
   private handleAttackResult(
     attackResults: AttackResult[],
     report: AttackReport,
-    attackerCard?: FightingCard,
+    attackerCard: FightingCard,
   ): void {
     const reportedDeaths = new Set<FightingCard>();
 


### PR DESCRIPTION
## Summary

- Removes the false `?` optional marker on the `attackerCard` parameter of `handleAttackResult` in `action-stage.ts`
- All three call sites (lines 80, 104, 135) always pass a concrete `FightingCard` — the optional type was a latent `TypeError` waiting to happen at lines 247 and 256 where the parameter is unconditionally dereferenced

## Test plan

- [ ] Run `npm test` — existing tests should pass unchanged (no behaviour change, type-only fix)
- [ ] Run `npm run build` — TypeScript compilation should succeed

Closes #231

https://claude.ai/code/session_0112BCqfVYCkunL8GQpNwSTY

---
_Generated by [Claude Code](https://claude.ai/code/session_0112BCqfVYCkunL8GQpNwSTY)_