### PR TITLE
fix: add default throw in skill-results-to-steps switch

### DIFF
--- a/src/fight/core/fight-simulator/skill-results-to-steps.ts
+++ b/src/fight/core/fight-simulator/skill-results-to-steps.ts
@@ -109,6 +109,8 @@ export function skillResultsToSteps(
           }),
         );
         break;
+      default:
+        throw new Error(`Unknown SkillKind: ${(skillResult as any).skillKind}`);
     }
 
     if (skillResult.endEvent && endEventProcessor) {


### PR DESCRIPTION
## Summary

- Adds a `default` case to the `switch (skillResult.skillKind)` in `skill-results-to-steps.ts`
- Throws `Error(\`Unknown SkillKind: ...\`)` on any unhandled enum value
- Prevents silent failures when a new `SkillKind` is added without updating this switch

Closes #232

## Test plan

- [ ] All 524 existing unit tests pass
- [ ] Verify no regression in fight simulation behaviour

https://claude.ai/code/session_01EL9gVEnFqJSioWwDfxAsWE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EL9gVEnFqJSioWwDfxAsWE)_