### PR TITLE
test: exercise terminationEvent parameter in EffectTriggeredDebuff

### DIFF
--- a/src/fight/core/cards/@types/attack/__tests__/effect-triggered-debuff.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/effect-triggered-debuff.spec.ts
@@ -37,6 +37,35 @@ describe('EffectTriggeredDebuff', () => {
     });
   });
 
+  describe('when a terminationEvent is provided', () => {
+    let result: ReturnType<EffectTriggeredDebuff['tryApply']>;
+
+    beforeEach(() => {
+      randomizer.setNextRandomValue(0);
+      const target = createFightingCard({ defense: 200 });
+      const triggered = new EffectTriggeredDebuff(
+        1.0,
+        'defense',
+        0.1,
+        2,
+        randomizer,
+        'my-end-event',
+      );
+      result = triggered.tryApply(target);
+    });
+
+    it('returns the applied debuff with the terminationEvent', () => {
+      expect(result).toEqual({
+        polarity: 'debuff',
+        type: 'defense',
+        value: 20,
+        duration: 2,
+        terminationEvent: 'my-end-event',
+        powerId: undefined,
+      });
+    });
+  });
+
   describe('when the random roll fails', () => {
     let result: ReturnType<EffectTriggeredDebuff['tryApply']>;
 


### PR DESCRIPTION
## Summary

- Adds a test case in `effect-triggered-debuff.spec.ts` that constructs `EffectTriggeredDebuff` with a `terminationEvent` argument
- Verifies the returned debuff object carries the `terminationEvent` value through `applyDebuff`

Closes #235

https://claude.ai/code/session_017AJjLfLBrfCt4qGyKZD8uq

---
_Generated by [Claude Code](https://claude.ai/code/session_017AJjLfLBrfCt4qGyKZD8uq)_