### PR TITLE
docs: remove redundant JSDoc from Skill.launch() and Skill.isTriggered()

### DIFF
--- a/src/fight/core/cards/skills/skill.ts
+++ b/src/fight/core/cards/skills/skill.ts
@@ -59,26 +59,12 @@ export interface Skill {
   id: string;
   name: string;
 
-  /**
-   * Launches the skill.
-   *
-   * @param source - The card that is using the skill.
-   * @param context - The fighting context.
-   * @param targetingStrategy - The override strategy to use instead of the skill's default strategy, if applicable
-   * @returns The result of the skill.
-   */
   launch(
     source: FightingCard,
     context: FightingContext,
     targetingStrategy?: TargetingCardStrategy,
   ): SkillResults;
 
-  /**
-   * Checks if the skill is triggered.
-   *
-   * @param triggerName - The name of the trigger to check.
-   * @returns True if the skill is triggered, false otherwise
-   */
   isTriggered(triggerName: string): boolean;
 
   /**


### PR DESCRIPTION
## Summary

- Remove the `@param`/`@returns` JSDoc blocks on `launch()` and `isTriggered()` in `src/fight/core/cards/skills/skill.ts`
- These blocks only restated what the parameter names already conveyed — pure noise per project guidelines

Closes #240

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdFRydAbbh1dGchUhFSzyA)_