### PR TITLE
test: close all test: issues (#236, #237, #238, #239, #249, #250, #251)

### DIFF
--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -71,36 +71,40 @@ function makeCard(
 describe('ActionStage', () => {
   describe('handleAttackResult with triggeredDebuff', () => {
     describe('when a simple attack applies a burn effect with triggered debuff', () => {
-      const randomizer = new RandomizerFake().setNextRandomValue(0);
-      const burnEffect = new BurnAttackEffect(
-        0.1,
-        1,
-        new MathRandomizer(),
-        new EffectTriggeredDebuff(1.0, 'defense', 0.1, 2, randomizer),
-      );
-      const attackWithBurn = new SimpleAttack(
-        'attack',
-        [new DamageComposition(DamageType.PHYSICAL, 1)],
-        POSITION_BASED,
-        [burnEffect],
-      );
-      const HIGH_ENERGY_SPECIAL = new SpecialAttack(
-        'special',
-        [new DamageComposition(DamageType.PHYSICAL, 1)],
-        999,
-        POSITION_BASED,
-      );
-      const attacker = makeCard(HIGH_ENERGY_SPECIAL, attackWithBurn);
-      const defender = makeCard(HIGH_ENERGY_SPECIAL);
-      const player1 = new Player('Player 1', [attacker]);
-      const player2 = new Player('Player 2', [defender]);
-      const actionStage = new ActionStage(
-        player1,
-        player2,
-        { onCardDeath: [] },
-        new DeathSkillHandler(player1, player2),
-      );
-      const steps = actionStage.computeNextAction([attacker]);
+      let steps: ReturnType<ActionStage['computeNextAction']>;
+
+      beforeEach(() => {
+        const randomizer = new RandomizerFake().setNextRandomValue(0);
+        const burnEffect = new BurnAttackEffect(
+          0.1,
+          1,
+          new MathRandomizer(),
+          new EffectTriggeredDebuff(1.0, 'defense', 0.1, 2, randomizer),
+        );
+        const attackWithBurn = new SimpleAttack(
+          'attack',
+          [new DamageComposition(DamageType.PHYSICAL, 1)],
+          POSITION_BASED,
+          [burnEffect],
+        );
+        const HIGH_ENERGY_SPECIAL = new SpecialAttack(
+          'special',
+          [new DamageComposition(DamageType.PHYSICAL, 1)],
+          999,
+          POSITION_BASED,
+        );
+        const attacker = makeCard(HIGH_ENERGY_SPECIAL, attackWithBurn);
+        const defender = makeCard(HIGH_ENERGY_SPECIAL);
+        const player1 = new Player('Player 1', [attacker]);
+        const player2 = new Player('Player 2', [defender]);
+        const actionStage = new ActionStage(
+          player1,
+          player2,
+          { onCardDeath: [] },
+          new DeathSkillHandler(player1, player2),
+        );
+        steps = actionStage.computeNextAction([attacker]);
+      });
 
       it('emits a debuff step after the status_change step', () => {
         expect(steps.find((s) => s.kind === StepKind.Debuff)).toBeDefined();
@@ -111,35 +115,37 @@ describe('ActionStage', () => {
   describe('launchSpecial', () => {
     describe('when special attack applies a buff', () => {
       const skillName = 'Power Surge';
-      const specialWithBuff = new SpecialAttack(
-        skillName,
-        [new DamageComposition(DamageType.PHYSICAL, 1)],
-        0,
-        POSITION_BASED,
-        undefined,
-        [new Alteration('attack', 1.2, 2, new Launcher())],
-      );
-      const attacker = makeCard(specialWithBuff);
-      const defender = makeCard(
-        new SpecialAttack(
-          'special',
+      let buffStep: BuffReport;
+
+      beforeEach(() => {
+        const specialWithBuff = new SpecialAttack(
+          skillName,
           [new DamageComposition(DamageType.PHYSICAL, 1)],
-          999,
+          0,
           POSITION_BASED,
-        ),
-      );
-      const player1 = new Player('Player 1', [attacker]);
-      const player2 = new Player('Player 2', [defender]);
-      const actionStage = new ActionStage(
-        player1,
-        player2,
-        { onCardDeath: [] },
-        new DeathSkillHandler(player1, player2),
-      );
-      const steps = actionStage.computeNextAction([attacker]);
-      const buffStep = steps.find(
-        (s) => s.kind === StepKind.Buff,
-      ) as BuffReport;
+          undefined,
+          [new Alteration('attack', 1.2, 2, new Launcher())],
+        );
+        const attacker = makeCard(specialWithBuff);
+        const defender = makeCard(
+          new SpecialAttack(
+            'special',
+            [new DamageComposition(DamageType.PHYSICAL, 1)],
+            999,
+            POSITION_BASED,
+          ),
+        );
+        const player1 = new Player('Player 1', [attacker]);
+        const player2 = new Player('Player 2', [defender]);
+        const actionStage = new ActionStage(
+          player1,
+          player2,
+          { onCardDeath: [] },
+          new DeathSkillHandler(player1, player2),
+        );
+        const steps = actionStage.computeNextAction([attacker]);
+        buffStep = steps.find((s) => s.kind === StepKind.Buff) as BuffReport;
+      });
 
       it('emits a buff step with the skill name', () => {
         expect(buffStep?.name).toBe(skillName);

--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -21,7 +21,10 @@ import { RandomizerFake } from '../../../../../test/helpers/randomizer-fake';
 import { MathRandomizer } from '../../../tools/math-randomizer';
 import { StepKind } from '../../fight-simulator/@types/step';
 import { Alteration } from '../../cards/@types/alteration/alteration';
-import { BuffReport } from '../../fight-simulator/@types/alteration-report';
+import {
+  BuffReport,
+  DebuffReport,
+} from '../../fight-simulator/@types/alteration-report';
 
 class UnknownSpecial implements Special {
   name = 'unknown';
@@ -106,8 +109,32 @@ describe('ActionStage', () => {
         steps = actionStage.computeNextAction([attacker]);
       });
 
-      it('emits a debuff step after the status_change step', () => {
-        expect(steps.find((s) => s.kind === StepKind.Debuff)).toBeDefined();
+      it('emits the debuff step immediately after the status_change step', () => {
+        const statusChangeIndex = steps.findIndex(
+          (s) => s.kind === StepKind.StatusChange,
+        );
+        expect(steps[statusChangeIndex + 1].kind).toBe(StepKind.Debuff);
+      });
+
+      it('debuff step has correct kind and value', () => {
+        const debuffStep = steps.find(
+          (s) => s.kind === StepKind.Debuff,
+        ) as DebuffReport;
+        expect(debuffStep.debuffs[0].kind).toBe('defense');
+      });
+
+      it('debuff step has correct remainingTurns', () => {
+        const debuffStep = steps.find(
+          (s) => s.kind === StepKind.Debuff,
+        ) as DebuffReport;
+        expect(debuffStep.debuffs[0].remainingTurns).toBe(2);
+      });
+
+      it('debuff step has source card info', () => {
+        const debuffStep = steps.find(
+          (s) => s.kind === StepKind.Debuff,
+        ) as DebuffReport;
+        expect(debuffStep.source).toBeDefined();
       });
     });
   });

--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -207,6 +207,59 @@ describe('ActionStage', () => {
       });
     });
 
+    describe('EffectTriggeredDebuff with terminationEvent roundtrip', () => {
+      let defender: FightingCard;
+      let steps: ReturnType<ActionStage['computeNextAction']>;
+
+      beforeEach(() => {
+        const randomizer = new RandomizerFake().setNextRandomValue(0);
+        const burnEffect = new BurnAttackEffect(
+          0.1,
+          1,
+          new MathRandomizer(),
+          new EffectTriggeredDebuff(
+            1.0,
+            'defense',
+            0.1,
+            2,
+            randomizer,
+            'my-end-event',
+          ),
+        );
+        const attackWithBurn = new SimpleAttack(
+          'attack',
+          [new DamageComposition(DamageType.PHYSICAL, 1)],
+          POSITION_BASED,
+          [burnEffect],
+        );
+        const HIGH_ENERGY_SPECIAL = new SpecialAttack(
+          'special',
+          [new DamageComposition(DamageType.PHYSICAL, 1)],
+          999,
+          POSITION_BASED,
+        );
+        const attacker = makeCard(HIGH_ENERGY_SPECIAL, attackWithBurn);
+        defender = makeCard(HIGH_ENERGY_SPECIAL);
+        const player1 = new Player('Player 1', [attacker]);
+        const player2 = new Player('Player 2', [defender]);
+        const actionStage = new ActionStage(
+          player1,
+          player2,
+          { onCardDeath: [] },
+          new DeathSkillHandler(player1, player2),
+        );
+        steps = actionStage.computeNextAction([attacker]);
+      });
+
+      it('emits a debuff step', () => {
+        expect(steps.find((s) => s.kind === StepKind.Debuff)).toBeDefined();
+      });
+
+      it('stores terminationEvent on the applied debuff so it can be removed by event', () => {
+        expect(defender.removeEventBoundDebuffs('my-end-event')).toHaveLength(1);
+      });
+    });
+
     describe('when launching an unknown special kind', () => {
       const attacker = makeCard(new UnknownSpecial());
       const defender = makeCard(

--- a/src/fight/core/cards/skills/__tests__/conditional-alteration-skill.spec.ts
+++ b/src/fight/core/cards/skills/__tests__/conditional-alteration-skill.spec.ts
@@ -40,6 +40,10 @@ describe('AlterationSkill with activationCondition', () => {
       it('returns buff results', () => {
         expect(results.results.length).toBe(1);
       });
+
+      it('returns Buff skillKind', () => {
+        expect(results.skillKind).toBe(SkillKind.Buff);
+      });
     });
 
     describe('when activation condition is not met', () => {

--- a/src/fight/core/fight-simulator/__tests__/end-event-processor-composite.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/end-event-processor-composite.spec.ts
@@ -1,7 +1,11 @@
 import { EndEventProcessor } from '../end-event-processor';
 import { Player } from '../../player';
 import { createFightingCard } from '../../../../../test/helpers/fighting-card';
-import { BuffRemovedReport } from '../@types/alteration-removed-report';
+import {
+  BuffRemovedReport,
+  DebuffRemovedReport,
+} from '../@types/alteration-removed-report';
+import { StepKind } from '../@types/step';
 
 const source = { id: 'src', name: 'Source', deckIdentity: '' };
 
@@ -31,6 +35,46 @@ describe('EndEventProcessor composite power', () => {
       const step = steps[0] as BuffRemovedReport;
 
       expect(step.removed).toHaveLength(2);
+    });
+  });
+
+  describe('removes composite debuff power with powerId', () => {
+    let card: ReturnType<typeof createFightingCard>;
+    let processor: EndEventProcessor;
+
+    beforeEach(() => {
+      card = createFightingCard({ attack: 100 });
+      card.applyDebuff('attack', 0.2, Infinity, 'curse-end', 'curse-power');
+      const player1 = new Player('P1', [card]);
+      const player2 = new Player('P2', [createFightingCard()]);
+      processor = new EndEventProcessor(player1, player2);
+    });
+
+    it('emits a DebuffRemoved step', () => {
+      const steps = processor.processEndEvent('curse-end', source, 'curse-power');
+
+      expect(steps[0].kind).toBe(StepKind.DebuffRemoved);
+    });
+
+    it('includes powerId in the DebuffRemoved step', () => {
+      const steps = processor.processEndEvent('curse-end', source, 'curse-power');
+      const step = steps[0] as DebuffRemovedReport;
+
+      expect(step.powerId).toBe('curse-power');
+    });
+
+    it('includes the correct source card in the DebuffRemoved step', () => {
+      const steps = processor.processEndEvent('curse-end', source, 'curse-power');
+      const step = steps[0] as DebuffRemovedReport;
+
+      expect(step.source.id).toBe(source.id);
+    });
+
+    it('includes the removed debuff in the step', () => {
+      const steps = processor.processEndEvent('curse-end', source, 'curse-power');
+      const step = steps[0] as DebuffRemovedReport;
+
+      expect(step.removed).toHaveLength(1);
     });
   });
 

--- a/src/fight/core/fight-simulator/__tests__/end-event-processor-composite.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/end-event-processor-composite.spec.ts
@@ -3,18 +3,23 @@ import { Player } from '../../player';
 import { createFightingCard } from '../../../../../test/helpers/fighting-card';
 import { BuffRemovedReport } from '../@types/alteration-removed-report';
 
-describe('EndEventProcessor composite power', () => {
-  const source = { id: 'src', name: 'Source', deckIdentity: '' };
+const source = { id: 'src', name: 'Source', deckIdentity: '' };
 
+describe('EndEventProcessor composite power', () => {
   describe('removes all buffs with matching terminationEvent and propagates powerId', () => {
-    it('includes powerId in the BuffRemoved step', () => {
-      const card = createFightingCard({ attack: 100 });
+    let card: ReturnType<typeof createFightingCard>;
+    let processor: EndEventProcessor;
+
+    beforeEach(() => {
+      card = createFightingCard({ attack: 100, defense: 100 });
       card.applyBuff('attack', 0.3, Infinity, 'rage-end', 'rage-power');
       card.applyBuff('defense', 0.2, Infinity, 'rage-end', 'rage-power');
       const player1 = new Player('P1', [card]);
       const player2 = new Player('P2', [createFightingCard()]);
-      const processor = new EndEventProcessor(player1, player2);
+      processor = new EndEventProcessor(player1, player2);
+    });
 
+    it('includes powerId in the BuffRemoved step', () => {
       const steps = processor.processEndEvent('rage-end', source, 'rage-power');
       const step = steps[0] as BuffRemovedReport;
 
@@ -22,13 +27,6 @@ describe('EndEventProcessor composite power', () => {
     });
 
     it('removes both buffs in a single step', () => {
-      const card = createFightingCard({ attack: 100, defense: 100 });
-      card.applyBuff('attack', 0.3, Infinity, 'rage-end', 'rage-power');
-      card.applyBuff('defense', 0.2, Infinity, 'rage-end', 'rage-power');
-      const player1 = new Player('P1', [card]);
-      const player2 = new Player('P2', [createFightingCard()]);
-      const processor = new EndEventProcessor(player1, player2);
-
       const steps = processor.processEndEvent('rage-end', source, 'rage-power');
       const step = steps[0] as BuffRemovedReport;
 
@@ -37,14 +35,19 @@ describe('EndEventProcessor composite power', () => {
   });
 
   describe('two composite powers on same card', () => {
-    it('expiring one does not affect the other', () => {
-      const card = createFightingCard({ attack: 100, defense: 100 });
+    let card: ReturnType<typeof createFightingCard>;
+    let processor: EndEventProcessor;
+
+    beforeEach(() => {
+      card = createFightingCard({ attack: 100, defense: 100 });
       card.applyBuff('attack', 0.3, Infinity, 'rage-end', 'rage-power');
       card.applyBuff('defense', 0.2, Infinity, 'shield-end', 'shield-power');
       const player1 = new Player('P1', [card]);
       const player2 = new Player('P2', [createFightingCard()]);
-      const processor = new EndEventProcessor(player1, player2);
+      processor = new EndEventProcessor(player1, player2);
+    });
 
+    it('expiring one does not affect the other', () => {
       processor.processEndEvent('rage-end', source, 'rage-power');
       const steps = processor.processEndEvent(
         'shield-end',
@@ -57,13 +60,6 @@ describe('EndEventProcessor composite power', () => {
     });
 
     it('the remaining power buff is still active after the first expires', () => {
-      const card = createFightingCard({ attack: 100, defense: 100 });
-      card.applyBuff('attack', 0.3, Infinity, 'rage-end', 'rage-power');
-      card.applyBuff('defense', 0.2, Infinity, 'shield-end', 'shield-power');
-      const player1 = new Player('P1', [card]);
-      const player2 = new Player('P2', [createFightingCard()]);
-      const processor = new EndEventProcessor(player1, player2);
-
       processor.processEndEvent('rage-end', source, 'rage-power');
 
       expect(card.actualDefense).toBeGreaterThan(100);

--- a/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-attack.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-attack.spec.ts
@@ -1,0 +1,117 @@
+import { skillResultsToSteps } from '../skill-results-to-steps';
+import { SkillKind, AttackSkillResults, BuffSkillResults } from '../../cards/skills/skill';
+import { StepKind } from '../@types/step';
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+
+describe('skillResultsToSteps: SkillKind.Attack branch', () => {
+  const card = createFightingCard({ id: 'attacker' });
+  const defender = createFightingCard({ id: 'defender' });
+
+  const attackResult: AttackSkillResults = {
+    skillKind: SkillKind.Attack,
+    name: 'Slash',
+    results: [
+      {
+        damage: 50,
+        isCritical: false,
+        dodge: false,
+        defender,
+        remainingHealth: 950,
+      },
+    ],
+  };
+
+  it('emits an Attack step', () => {
+    const steps = skillResultsToSteps(card, [attackResult]);
+
+    expect(steps[0].kind).toBe(StepKind.Attack);
+  });
+
+  it('includes the skill name in the Attack step', () => {
+    const steps = skillResultsToSteps(card, [attackResult]);
+
+    expect((steps[0] as any).name).toBe('Slash');
+  });
+
+  it('includes damage in the Attack step', () => {
+    const steps = skillResultsToSteps(card, [attackResult]);
+
+    expect((steps[0] as any).damages[0].damage).toBe(50);
+  });
+
+  it('includes remainingHealth snapshot from AttackResult', () => {
+    const steps = skillResultsToSteps(card, [attackResult]);
+
+    expect((steps[0] as any).damages[0].remainingHealth).toBe(950);
+  });
+
+  it('emits a status_change dead step when defender is dead', () => {
+    const deadDefender = createFightingCard({ id: 'dead', health: 1 });
+    deadDefender.addRealDamage(9999);
+    const resultWithDead: AttackSkillResults = {
+      skillKind: SkillKind.Attack,
+      results: [
+        {
+          damage: 9999,
+          isCritical: false,
+          dodge: false,
+          defender: deadDefender,
+          remainingHealth: 0,
+        },
+      ],
+    };
+    const steps = skillResultsToSteps(card, [resultWithDead]);
+
+    expect(steps[1].kind).toBe(StepKind.StatusChange);
+  });
+
+  it('emits a status_change step for applied effect', () => {
+    const defenderWithEffect = createFightingCard({ id: 'burned' });
+    const resultWithEffect: AttackSkillResults = {
+      skillKind: SkillKind.Attack,
+      results: [
+        {
+          damage: 10,
+          isCritical: false,
+          dodge: false,
+          defender: defenderWithEffect,
+          remainingHealth: 990,
+          effects: [{ type: 'burn', card: defenderWithEffect }],
+        },
+      ],
+    };
+    const steps = skillResultsToSteps(card, [resultWithEffect]);
+
+    expect(steps[1].kind).toBe(StepKind.StatusChange);
+  });
+});
+
+describe('skillResultsToSteps: absent endEventProcessor with endEvent', () => {
+  const card = createFightingCard({ id: 'source' });
+
+  const buffResultWithEndEvent: BuffSkillResults = {
+    skillKind: SkillKind.Buff,
+    endEvent: 'rage-end',
+    results: [
+      {
+        target: card.identityInfo,
+        alteration: {
+          polarity: 'buff',
+          type: 'attack',
+          value: 10,
+          duration: 2,
+        },
+      },
+    ],
+  };
+
+  it('does not throw when endEventProcessor is absent', () => {
+    expect(() => skillResultsToSteps(card, [buffResultWithEndEvent])).not.toThrow();
+  });
+
+  it('silently skips the endEvent when endEventProcessor is absent', () => {
+    const steps = skillResultsToSteps(card, [buffResultWithEndEvent]);
+
+    expect(steps).toHaveLength(1);
+  });
+});

--- a/src/fight/core/fight-simulator/__tests__/turn-manager-composite-power.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/turn-manager-composite-power.spec.ts
@@ -4,7 +4,7 @@ import { TurnManager } from '../turn-manager';
 import { DeathSkillHandler } from '../death-skill-handler';
 import { EndEventProcessor } from '../end-event-processor';
 import { StepKind } from '../@types/step';
-import { BuffReport } from '../@types/alteration-report';
+import { BuffReport, DebuffReport } from '../@types/alteration-report';
 import { HealingReport } from '../@types/healing-report';
 
 describe('TurnManager composite power', () => {
@@ -70,6 +70,55 @@ describe('TurnManager composite power', () => {
       ) as HealingReport;
 
       expect(healingStep?.powerId).toBe('rage');
+    });
+  });
+
+  describe('debuff skill with powerId', () => {
+    let card: ReturnType<typeof createFightingCard>;
+    let turnManager: TurnManager;
+
+    beforeEach(() => {
+      card = createFightingCard({
+        id: 'card-1',
+        attack: 100,
+        health: 5000,
+        skills: {
+          others: [
+            {
+              debuffType: 'attack',
+              debuffRate: 0.2,
+              duration: 3,
+              trigger: 'turn-end',
+              targetingStrategy: 'self',
+              powerId: 'curse',
+            },
+          ],
+        },
+      });
+      const player1 = new Player('p1', [card]);
+      const player2 = new Player('p2', [createFightingCard()]);
+      const endEventProcessor = new EndEventProcessor(player1, player2);
+      const deathSkillHandler = new DeathSkillHandler(
+        player1,
+        player2,
+        endEventProcessor,
+      );
+      turnManager = new TurnManager(
+        player1,
+        player2,
+        { onCardDeath: [deathSkillHandler] },
+        deathSkillHandler,
+        endEventProcessor,
+      );
+    });
+
+    it('produces a debuff step with powerId', () => {
+      const steps = turnManager.endTurn([card]);
+      const debuffStep = steps.find(
+        (s) => s.kind === StepKind.Debuff,
+      ) as DebuffReport;
+
+      expect(debuffStep?.powerId).toBe('curse');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Move describe-scope test setup into `beforeEach` in `action_stage.spec.ts` and `end-event-processor-composite.spec.ts` (closes #239)
- Assert debuff step order and content (immediately after `status_change`) in `ActionStage` (closes #236)
- Add `EffectTriggeredDebuff` + `terminationEvent` roundtrip test through `ActionStage` (closes #251)
- Add missing `skillKind` assertion for buff condition-met case in `conditional-alteration-skill.spec.ts` (closes #250)
- Add `DebuffRemoved` composite path test with `powerId` and `source` in `end-event-processor-composite.spec.ts` (closes #237)
- Add debuff skill with `powerId` through `TurnManager` coverage (closes #238)
- Add unit tests for `SkillKind.Attack` branch and silent no-op when `endEventProcessor` is absent in `skill-results-to-steps` (closes #249)

## Test plan

- [ ] All 550 tests pass (`npm test`)
- [ ] Each commit closes exactly one issue
- [ ] No production code was changed — test files only

https://claude.ai/code/session_01QUzNErPse5Tw7i26TGeSBC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUzNErPse5Tw7i26TGeSBC)_