### PR TITLE
test: verify remainingHealth snapshot is used instead of live state

### DIFF
--- a/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-attack.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-attack.spec.ts
@@ -45,6 +45,28 @@ describe('skillResultsToSteps: SkillKind.Attack branch', () => {
     expect((steps[0] as any).damages[0].remainingHealth).toBe(950);
   });
 
+  it('reports snapshot remainingHealth even when defender health changes after calculation', () => {
+    const snapshotDefender = createFightingCard({ id: 'snapshot-defender', health: 1000 });
+    const snapshotResult: AttackSkillResults = {
+      skillKind: SkillKind.Attack,
+      name: 'Slash',
+      results: [
+        {
+          damage: 200,
+          isCritical: false,
+          dodge: false,
+          defender: snapshotDefender,
+          remainingHealth: 800,
+        },
+      ],
+    };
+    snapshotDefender.addRealDamage(500);
+
+    const steps = skillResultsToSteps(card, [snapshotResult]);
+
+    expect((steps[0] as any).damages[0].remainingHealth).toBe(800);
+  });
+
   it('emits a status_change dead step when defender is dead', () => {
     const deadDefender = createFightingCard({ id: 'dead', health: 1 });
     deadDefender.addRealDamage(9999);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The code fix for #245 was already applied in #257 (`r.defender.actualHealth` → `r.remainingHealth` in `skill-results-to-steps.ts`)
- This PR adds the missing regression test that explicitly proves the snapshot value is reported even when the defender's health changes after the `AttackResult` is built
- Test name: `'reports snapshot remainingHealth even when defender health changes after calculation'`

## Test plan

- [ ] `skill-results-to-steps-attack.spec.ts` passes (9 tests)
- [ ] New test creates an `AttackResult` with `remainingHealth: 800`, then applies additional damage to the defender (live health → 500), and asserts the step still reports `800`

Closes #245

https://claude.ai/code/session_01DWN4LJ4EQ4C39PvF7JLhdB
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWN4LJ4EQ4C39PvF7JLhdB)_