### PR TITLE
refactor: extract skillKind getter in AlterationSkill

### DIFF
--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -256,7 +256,9 @@ describe('ActionStage', () => {
       });
 
       it('stores terminationEvent on the applied debuff so it can be removed by event', () => {
-        expect(defender.removeEventBoundDebuffs('my-end-event')).toHaveLength(1);
+        expect(defender.removeEventBoundDebuffs('my-end-event')).toHaveLength(
+          1,
+        );
       });
     });
 

--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -40,6 +40,10 @@ export class AlterationSkill implements Skill {
   private readonly powerId?: string;
   private activationCount = 0;
 
+  private get skillKind() {
+    return this.polarity === 'buff' ? SkillKind.Buff : SkillKind.Debuff;
+  }
+
   constructor({
     name,
     polarity,
@@ -77,19 +81,12 @@ export class AlterationSkill implements Skill {
       this.activationCondition &&
       !this.activationCondition.evaluate(source, context)
     ) {
-      return this.polarity === 'buff'
-        ? {
-            skillKind: SkillKind.Buff,
-            results: [],
-            name: this.name,
-            powerId: this.powerId,
-          }
-        : {
-            skillKind: SkillKind.Debuff,
-            results: [],
-            name: this.name,
-            powerId: this.powerId,
-          };
+      return {
+        skillKind: this.skillKind,
+        results: [],
+        name: this.name,
+        powerId: this.powerId,
+      } as SkillResults;
     }
 
     const targetedCards = this.targetingStrategy.targetedCards(
@@ -105,43 +102,37 @@ export class AlterationSkill implements Skill {
       this.activationCount >= this.activationLimit;
     const endEvent = isExhausted ? this.endEvent : undefined;
 
-    if (this.polarity === 'buff') {
-      const results = targetedCards.map((targetedCard) => ({
-        target: targetedCard.identityInfo,
-        alteration: targetedCard.applyBuff(
-          this.attributeType,
-          this.rate,
-          this.duration,
-          this.terminationEvent,
-          this.powerId,
-        ),
-      }));
-      return {
-        skillKind: SkillKind.Buff,
-        results,
-        name: this.name,
-        endEvent,
-        powerId: this.powerId,
-      };
-    }
+    const applyAlteration =
+      this.polarity === 'buff'
+        ? (card: FightingCard) =>
+            card.applyBuff(
+              this.attributeType,
+              this.rate,
+              this.duration,
+              this.terminationEvent,
+              this.powerId,
+            )
+        : (card: FightingCard) =>
+            card.applyDebuff(
+              this.attributeType,
+              this.rate,
+              this.duration,
+              this.terminationEvent,
+              this.powerId,
+            );
 
     const results = targetedCards.map((targetedCard) => ({
       target: targetedCard.identityInfo,
-      alteration: targetedCard.applyDebuff(
-        this.attributeType,
-        this.rate,
-        this.duration,
-        this.terminationEvent,
-        this.powerId,
-      ),
+      alteration: applyAlteration(targetedCard),
     }));
+
     return {
-      skillKind: SkillKind.Debuff,
+      skillKind: this.skillKind,
       results,
       name: this.name,
       endEvent,
       powerId: this.powerId,
-    };
+    } as SkillResults;
   }
 
   isTriggered(triggerName: string): boolean {

--- a/src/fight/core/fight-simulator/__tests__/end-event-processor-composite.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/end-event-processor-composite.spec.ts
@@ -51,27 +51,43 @@ describe('EndEventProcessor composite power', () => {
     });
 
     it('emits a DebuffRemoved step', () => {
-      const steps = processor.processEndEvent('curse-end', source, 'curse-power');
+      const steps = processor.processEndEvent(
+        'curse-end',
+        source,
+        'curse-power',
+      );
 
       expect(steps[0].kind).toBe(StepKind.DebuffRemoved);
     });
 
     it('includes powerId in the DebuffRemoved step', () => {
-      const steps = processor.processEndEvent('curse-end', source, 'curse-power');
+      const steps = processor.processEndEvent(
+        'curse-end',
+        source,
+        'curse-power',
+      );
       const step = steps[0] as DebuffRemovedReport;
 
       expect(step.powerId).toBe('curse-power');
     });
 
     it('includes the correct source card in the DebuffRemoved step', () => {
-      const steps = processor.processEndEvent('curse-end', source, 'curse-power');
+      const steps = processor.processEndEvent(
+        'curse-end',
+        source,
+        'curse-power',
+      );
       const step = steps[0] as DebuffRemovedReport;
 
       expect(step.source.id).toBe(source.id);
     });
 
     it('includes the removed debuff in the step', () => {
-      const steps = processor.processEndEvent('curse-end', source, 'curse-power');
+      const steps = processor.processEndEvent(
+        'curse-end',
+        source,
+        'curse-power',
+      );
       const step = steps[0] as DebuffRemovedReport;
 
       expect(step.removed).toHaveLength(1);

--- a/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-attack.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-attack.spec.ts
@@ -1,5 +1,9 @@
 import { skillResultsToSteps } from '../skill-results-to-steps';
-import { SkillKind, AttackSkillResults, BuffSkillResults } from '../../cards/skills/skill';
+import {
+  SkillKind,
+  AttackSkillResults,
+  BuffSkillResults,
+} from '../../cards/skills/skill';
 import { StepKind } from '../@types/step';
 import { createFightingCard } from '../../../../../test/helpers/fighting-card';
 
@@ -106,7 +110,9 @@ describe('skillResultsToSteps: absent endEventProcessor with endEvent', () => {
   };
 
   it('does not throw when endEventProcessor is absent', () => {
-    expect(() => skillResultsToSteps(card, [buffResultWithEndEvent])).not.toThrow();
+    expect(() =>
+      skillResultsToSteps(card, [buffResultWithEndEvent]),
+    ).not.toThrow();
   });
 
   it('silently skips the endEvent when endEventProcessor is absent', () => {


### PR DESCRIPTION
## Summary

- Extracts a private `skillKind` getter in `AlterationSkill` that returns `SkillKind.Buff` or `SkillKind.Debuff` based on `this.polarity`
- Removes the three duplicated `this.polarity === 'buff' ? SkillKind.Buff : SkillKind.Debuff` expressions
- Consolidates the duplicated early-return branches (condition not met) into a single return
- Merges the two main branches into one, with the `applyBuff`/`applyDebuff` selection handled via a local function variable

Closes #241

https://claude.ai/code/session_014dEACDzmEZ9YrS2PLwR6L6

---
_Generated by [Claude Code](https://claude.ai/code/session_014dEACDzmEZ9YrS2PLwR6L6)_