### PR TITLE
refactor: inline BuffResult/DebuffResult and remove array aliases

### DIFF
--- a/src/fight/core/cards/@types/action-result/alteration-result.ts
+++ b/src/fight/core/cards/@types/action-result/alteration-result.ts
@@ -1,16 +1,5 @@
 import { CardInfo } from '../card-info';
-import {
-  AlterationDetail,
-  Buff,
-  Debuff,
-} from '../alteration/alteration-detail';
+import { Buff, Debuff } from '../alteration/alteration-detail';
 
-type AlterationResult<T extends AlterationDetail = AlterationDetail> = {
-  target: CardInfo;
-  alteration: T;
-};
-
-export type BuffResult = AlterationResult<Buff>;
-export type DebuffResult = AlterationResult<Debuff>;
-export type BuffResults = BuffResult[];
-export type DebuffResults = DebuffResult[];
+export type BuffResult = { target: CardInfo; alteration: Buff };
+export type DebuffResult = { target: CardInfo; alteration: Debuff };

--- a/src/fight/core/cards/@types/action-result/attack-result.ts
+++ b/src/fight/core/cards/@types/action-result/attack-result.ts
@@ -1,6 +1,6 @@
 import { FightingCard } from '../../fighting-card';
 import { EffectResult } from '../attack/attack-effect';
-import { BuffResults } from './alteration-result';
+import { BuffResult } from './alteration-result';
 import { DamageType } from '../damage/damage-type';
 
 export type AttackResult = {
@@ -10,6 +10,6 @@ export type AttackResult = {
   defender: FightingCard;
   remainingHealth: number;
   effects?: EffectResult[];
-  buffResults?: BuffResults;
+  buffResults?: BuffResult[];
   kind?: DamageType[];
 };

--- a/src/fight/core/cards/@types/action-result/special-result.ts
+++ b/src/fight/core/cards/@types/action-result/special-result.ts
@@ -1,9 +1,9 @@
 import { AttackResult } from './attack-result';
-import { BuffResults } from './alteration-result';
+import { BuffResult } from './alteration-result';
 import { HealingResult } from './healing-result';
 
 export type SpecialResult = {
   name: string;
   actionResults: AttackResult[] | HealingResult[];
-  buffResults: BuffResults;
+  buffResults: BuffResult[];
 };

--- a/src/fight/core/cards/skills/skill.ts
+++ b/src/fight/core/cards/skills/skill.ts
@@ -1,8 +1,8 @@
 import { FightingCard } from '../fighting-card';
 import { HealingResults } from '../@types/action-result/healing-results';
 import {
-  BuffResults,
-  DebuffResults,
+  BuffResult,
+  DebuffResult,
 } from '../@types/action-result/alteration-result';
 import { AttackResult } from '../@types/action-result/attack-result';
 import { FightingContext } from '../@types/fighting-context';
@@ -30,12 +30,12 @@ export type HealingSkillResults = BaseSkillResults & {
 
 export type BuffSkillResults = BaseSkillResults & {
   skillKind: SkillKind.Buff;
-  results: BuffResults;
+  results: BuffResult[];
 };
 
 export type DebuffSkillResults = BaseSkillResults & {
   skillKind: SkillKind.Debuff;
-  results: DebuffResults;
+  results: DebuffResult[];
 };
 
 export type AttackSkillResults = BaseSkillResults & {

--- a/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-attack.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-attack.spec.ts
@@ -50,7 +50,10 @@ describe('skillResultsToSteps: SkillKind.Attack branch', () => {
   });
 
   it('reports snapshot remainingHealth even when defender health changes after calculation', () => {
-    const snapshotDefender = createFightingCard({ id: 'snapshot-defender', health: 1000 });
+    const snapshotDefender = createFightingCard({
+      id: 'snapshot-defender',
+      health: 1000,
+    });
     const snapshotResult: AttackSkillResults = {
       skillKind: SkillKind.Attack,
       name: 'Slash',


### PR DESCRIPTION
## Summary

- Remove the generic `AlterationResult<T>` wrapper — `BuffResult` and `DebuffResult` are now defined directly as `{ target: CardInfo; alteration: Buff/Debuff }` (closes #242)
- Remove the `BuffResults` and `DebuffResults` array type aliases; all 4 call sites now inline `BuffResult[]` / `DebuffResult[]` directly (closes #243)

## Test plan

- [ ] All 551 unit tests pass (`npm run test:cov`)
- [ ] Build succeeds (`npm run build`)
- [ ] No functional change — pure structural refactor

https://claude.ai/code/session_01JM5Ay1ezjfet37c7nRDDk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM5Ay1ezjfet37c7nRDDk7)_