### PR TITLE
refactor: inline AlterationEntry into BuffReport and DebuffReport

### DIFF
--- a/src/fight/core/fight-simulator/@types/alteration-report.ts
+++ b/src/fight/core/fight-simulator/@types/alteration-report.ts
@@ -2,18 +2,16 @@ import { AlterationType } from '../../cards/@types/alteration/alteration-type';
 import { CardInfo } from '../../cards/@types/card-info';
 import { StepKind } from './step';
 
-type AlterationEntry = {
-  target: CardInfo;
-  kind: AlterationType;
-  value: number;
-  remainingTurns: number;
-};
-
 export type BuffReport = {
   kind: StepKind.Buff;
   name?: string;
   source: CardInfo;
-  buffs: AlterationEntry[];
+  buffs: {
+    target: CardInfo;
+    kind: AlterationType;
+    value: number;
+    remainingTurns: number;
+  }[];
   energy: number;
   powerId?: string;
 };
@@ -22,7 +20,12 @@ export type DebuffReport = {
   kind: StepKind.Debuff;
   name?: string;
   source: CardInfo;
-  debuffs: AlterationEntry[];
+  debuffs: {
+    target: CardInfo;
+    kind: AlterationType;
+    value: number;
+    remainingTurns: number;
+  }[];
   energy: number;
   powerId?: string;
 };


### PR DESCRIPTION
## Summary

- `AlterationEntry` was a private (unexported) type used only within `alteration-report.ts` to type `BuffReport.buffs` and `DebuffReport.debuffs`
- Inlined the type directly into both report types, removing the unnecessary named intermediate
- No behavioral change — pure type-level simplification

Closes #244

## Test plan

- [ ] No logic changed — type-only refactor
- [ ] Verify TypeScript compilation passes (`npm run build`)
- [ ] Verify tests pass (`npm test`)

https://claude.ai/code/session_01XjG8iMfvj7i6btWJQ6vNPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjG8iMfvj7i6btWJQ6vNPJ)_