### PR TITLE
enhancement: add constructor guards for polarity and probability validation

### DIFF
--- a/src/fight/core/cards/@types/attack/__tests__/effect-triggered-debuff.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/effect-triggered-debuff.spec.ts
@@ -2,6 +2,22 @@ import { EffectTriggeredDebuff } from '../effect-triggered-debuff';
 import { RandomizerFake } from '../../../../../../../test/helpers/randomizer-fake';
 import { createFightingCard } from '../../../../../../../test/helpers/fighting-card';
 
+describe('EffectTriggeredDebuff constructor validation', () => {
+  const randomizer = new RandomizerFake();
+
+  it('throws when probability is below 0', () => {
+    expect(
+      () => new EffectTriggeredDebuff(-0.1, 'defense', 0.1, 2, randomizer),
+    ).toThrow('probability must be in [0, 1], got: -0.1');
+  });
+
+  it('throws when probability is above 1', () => {
+    expect(
+      () => new EffectTriggeredDebuff(1.5, 'defense', 0.1, 2, randomizer),
+    ).toThrow('probability must be in [0, 1], got: 1.5');
+  });
+});
+
 describe('EffectTriggeredDebuff', () => {
   const randomizer = new RandomizerFake();
 

--- a/src/fight/core/cards/@types/attack/effect-triggered-debuff.ts
+++ b/src/fight/core/cards/@types/attack/effect-triggered-debuff.ts
@@ -19,6 +19,9 @@ export class EffectTriggeredDebuff {
     randomizer: Randomizer,
     terminationEvent?: string,
   ) {
+    if (probability < 0 || probability > 1) {
+      throw new Error(`probability must be in [0, 1], got: ${probability}`);
+    }
     this.probability = probability;
     this.debuffType = debuffType;
     this.debuffRate = debuffRate;

--- a/src/fight/core/cards/skills/__tests__/alteration-skill.spec.ts
+++ b/src/fight/core/cards/skills/__tests__/alteration-skill.spec.ts
@@ -5,6 +5,26 @@ import { Player } from '../../../player';
 import { TurnEnd } from '../../../trigger/turn-end';
 import { Launcher } from '../../../targeting-card-strategies/launcher';
 
+describe('AlterationSkill constructor validation', () => {
+  const trigger = new TurnEnd();
+  const targeting = new Launcher();
+
+  it('throws when polarity is invalid', () => {
+    expect(
+      () =>
+        new AlterationSkill({
+          name: 'skill',
+          polarity: 'invalid' as any,
+          attributeType: 'attack',
+          rate: 0.1,
+          duration: 2,
+          trigger,
+          targetingStrategy: targeting,
+        }),
+    ).toThrow('Invalid polarity: invalid');
+  });
+});
+
 describe('AlterationSkill lifecycle', () => {
   const trigger = new TurnEnd();
   const targeting = new Launcher();

--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -58,6 +58,9 @@ export class AlterationSkill implements Skill {
     terminationEvent,
     powerId,
   }: AlterationSkillOptions) {
+    if (polarity !== 'buff' && polarity !== 'debuff') {
+      throw new Error(`Invalid polarity: ${polarity}`);
+    }
     this.name = name;
     this.polarity = polarity;
     this.attributeType = attributeType;


### PR DESCRIPTION
## Summary

- Add constructor guard in `AlterationSkill` to throw on invalid `polarity` value (must be `'buff'` or `'debuff'`) — closes #247
- Add constructor guard in `EffectTriggeredDebuff` to throw when `probability` is outside `[0, 1]` — closes #248

Both guards are consistent with the project's "throw early, no silent errors" rule.

## Test plan

- [ ] `AlterationSkill` constructor throws `'Invalid polarity: <value>'` when given an invalid polarity
- [ ] `EffectTriggeredDebuff` constructor throws `'probability must be in [0, 1], got: <value>'` for values < 0 or > 1
- [ ] All 554 existing tests still pass

https://claude.ai/code/session_01626HezhoPKfxuApB2Hinr1

---
_Generated by [Claude Code](https://claude.ai/code/session_01626HezhoPKfxuApB2Hinr1)_