### PR TITLE
fix: use remainingHealth snapshot in healing step report

### DIFF
--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -5,6 +5,7 @@ import { Player } from '../../player';
 import { FightingCard } from '../../cards/fighting-card';
 import { Special } from '../../cards/skills/special';
 import { SpecialAttack } from '../../cards/skills/special-attack';
+import { SpecialHealing } from '../../cards/skills/special-healing';
 import { SimpleAttack } from '../../cards/skills/simple-attack';
 import { SimpleDodge } from '../../cards/behaviors/simple-dodge';
 import { TargetedFromPosition } from '../../targeting-card-strategies/targeted-from-position';
@@ -259,6 +260,41 @@ describe('ActionStage', () => {
         expect(defender.removeEventBoundDebuffs('my-end-event')).toHaveLength(
           1,
         );
+      });
+    });
+
+    describe('remainingHealth snapshot in healing step', () => {
+      let healer: FightingCard;
+      let target: FightingCard;
+      let healStep: import('../../fight-simulator/@types/healing-report').HealingReport;
+
+      beforeEach(() => {
+        const specialHealing = new SpecialHealing('Heal', 1, 0, new Launcher());
+        healer = makeCard(specialHealing);
+        target = makeCard(
+          new SpecialAttack(
+            'special',
+            [new DamageComposition(DamageType.PHYSICAL, 1)],
+            999,
+            POSITION_BASED,
+          ),
+        );
+        const player1 = new Player('Player 1', [healer]);
+        const player2 = new Player('Player 2', [target]);
+        const actionStage = new ActionStage(
+          player1,
+          player2,
+          { onCardDeath: [] },
+          new DeathSkillHandler(player1, player2),
+        );
+        const steps = actionStage.computeNextAction([healer]);
+        healStep = steps.find(
+          (s) => s.kind === StepKind.Healing,
+        ) as import('../../fight-simulator/@types/healing-report').HealingReport;
+      });
+
+      it('sets remainingHealth to the snapshot captured at heal time', () => {
+        expect(healStep.heal[0].remainingHealth).toBe(target.actualHealth);
       });
     });
 

--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -169,7 +169,7 @@ export class ActionStage {
       result.heal.push({
         target: healingResult.target.identityInfo,
         healed: healingResult.healed,
-        remainingHealth: healingResult.target.actualHealth,
+        remainingHealth: healingResult.remainingHealth,
       });
     });
 

--- a/src/fight/core/cards/@types/action-result/healing-result.ts
+++ b/src/fight/core/cards/@types/action-result/healing-result.ts
@@ -3,4 +3,5 @@ import { FightingCard } from '../../fighting-card';
 export type HealingResult = {
   healed: number;
   target: FightingCard;
+  remainingHealth: number;
 };

--- a/src/fight/core/cards/skills/special-healing.ts
+++ b/src/fight/core/cards/skills/special-healing.ts
@@ -31,8 +31,9 @@ export class SpecialHealing implements Special {
 
     const actionResults = targetedCards.map((target) => {
       const healed = target.heal(source.actualAttack * this.rate);
+      const remainingHealth = target.actualHealth;
 
-      return { healed, target };
+      return { healed, target, remainingHealth };
     });
 
     return { name: this.name, actionResults, buffResults: [] };


### PR DESCRIPTION
## Summary

- Adds `remainingHealth: number` to `HealingResult` type to carry the health snapshot at heal time
- Captures `remainingHealth` in `SpecialHealing.launch()` immediately after each `target.heal()` call
- Fixes `action-stage.ts:172` to use `healingResult.remainingHealth` (snapshot) instead of `healingResult.target.actualHealth` (live re-read), consistent with `AttackResult` handling

## Test plan

- [ ] New unit test in `action_stage.spec.ts` verifies `remainingHealth` in the healing step matches the value captured at heal time
- [ ] All 555 existing tests pass
- [ ] Build succeeds

Closes #268

https://claude.ai/code/session_01VYk1z9S14MofHTpkMS8ZNo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYk1z9S14MofHTpkMS8ZNo)_