### PR TITLE
fix: rename BuffConditionType to AlterationConditionType for consistency

### DIFF
--- a/src/fight/http-api/__test__/buff-condition-factory.spec.ts
+++ b/src/fight/http-api/__test__/buff-condition-factory.spec.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata';
 import { AlterationCondition } from '../../core/cards/@types/alteration/alteration-condition';
 import { AllyPresenceCondition } from '../../core/cards/@types/alteration/conditions/ally-presence-condition';
 import { HealthThresholdCondition } from '../../core/cards/@types/alteration/conditions/health-threshold-condition';
-import { BuffConditionType } from '../dto/fight-data.dto';
+import { AlterationConditionType } from '../dto/fight-data.dto';
 import { buildAlterationCondition } from '../buff-condition-factory';
 
 describe('buildAlterationCondition', () => {
@@ -11,9 +11,12 @@ describe('buildAlterationCondition', () => {
     let condition: AlterationCondition;
 
     beforeEach(() => {
-      condition = buildAlterationCondition(BuffConditionType.ALLY_PRESENCE, {
-        allyName: 'Hero',
-      });
+      condition = buildAlterationCondition(
+        AlterationConditionType.ALLY_PRESENCE,
+        {
+          allyName: 'Hero',
+        },
+      );
     });
 
     it('returns AllyPresenceCondition when allyName is provided', () => {
@@ -22,7 +25,7 @@ describe('buildAlterationCondition', () => {
 
     it('throws when allyName is missing', () => {
       expect(() =>
-        buildAlterationCondition(BuffConditionType.ALLY_PRESENCE, {}),
+        buildAlterationCondition(AlterationConditionType.ALLY_PRESENCE, {}),
       ).toThrow('AllyPresenceCondition requires allyName');
     });
   });
@@ -33,7 +36,7 @@ describe('buildAlterationCondition', () => {
 
       beforeEach(() => {
         condition = buildAlterationCondition(
-          BuffConditionType.HEALTH_THRESHOLD,
+          AlterationConditionType.HEALTH_THRESHOLD,
           {},
         );
       });
@@ -48,7 +51,7 @@ describe('buildAlterationCondition', () => {
 
       beforeEach(() => {
         condition = buildAlterationCondition(
-          BuffConditionType.HEALTH_THRESHOLD,
+          AlterationConditionType.HEALTH_THRESHOLD,
           {
             threshold: 0.3,
             operator: 'above',
@@ -66,7 +69,7 @@ describe('buildAlterationCondition', () => {
 
       beforeEach(() => {
         condition = buildAlterationCondition(
-          BuffConditionType.HEALTH_THRESHOLD,
+          AlterationConditionType.HEALTH_THRESHOLD,
           {
             threshold: 0.5,
             operator: 'below',
@@ -81,7 +84,7 @@ describe('buildAlterationCondition', () => {
 
     it('throws for an invalid operator', () => {
       expect(() =>
-        buildAlterationCondition(BuffConditionType.HEALTH_THRESHOLD, {
+        buildAlterationCondition(AlterationConditionType.HEALTH_THRESHOLD, {
           operator: 'greater',
         }),
       ).toThrow('Invalid operator: greater');
@@ -89,7 +92,7 @@ describe('buildAlterationCondition', () => {
 
     it('throws for an empty string operator', () => {
       expect(() =>
-        buildAlterationCondition(BuffConditionType.HEALTH_THRESHOLD, {
+        buildAlterationCondition(AlterationConditionType.HEALTH_THRESHOLD, {
           operator: '',
         }),
       ).toThrow('Invalid operator: ');
@@ -97,10 +100,10 @@ describe('buildAlterationCondition', () => {
   });
 
   describe('unknown type', () => {
-    it('throws for an unknown BuffConditionType', () => {
+    it('throws for an unknown AlterationConditionType', () => {
       expect(() =>
-        buildAlterationCondition('UNKNOWN_TYPE' as BuffConditionType, {}),
-      ).toThrow('Unknown BuffConditionType: UNKNOWN_TYPE');
+        buildAlterationCondition('UNKNOWN_TYPE' as AlterationConditionType, {}),
+      ).toThrow('Unknown AlterationConditionType: UNKNOWN_TYPE');
     });
   });
 });

--- a/src/fight/http-api/buff-condition-factory.ts
+++ b/src/fight/http-api/buff-condition-factory.ts
@@ -1,4 +1,4 @@
-import { BuffConditionType } from './dto/fight-data.dto';
+import { AlterationConditionType } from './dto/fight-data.dto';
 import { AlterationCondition } from '../core/cards/@types/alteration/alteration-condition';
 import { AllyPresenceCondition } from '../core/cards/@types/alteration/conditions/ally-presence-condition';
 import { HealthThresholdCondition } from '../core/cards/@types/alteration/conditions/health-threshold-condition';
@@ -7,16 +7,16 @@ type ConditionOperator = 'above' | 'below';
 const VALID_OPERATORS: ConditionOperator[] = ['above', 'below'];
 
 export function buildAlterationCondition(
-  type: BuffConditionType,
+  type: AlterationConditionType,
   params: { allyName?: string; threshold?: number; operator?: string },
 ): AlterationCondition {
   switch (type) {
-    case BuffConditionType.ALLY_PRESENCE:
+    case AlterationConditionType.ALLY_PRESENCE:
       if (!params.allyName) {
         throw new Error('AllyPresenceCondition requires allyName');
       }
       return new AllyPresenceCondition(params.allyName);
-    case BuffConditionType.HEALTH_THRESHOLD: {
+    case AlterationConditionType.HEALTH_THRESHOLD: {
       if (
         params.operator !== undefined &&
         !VALID_OPERATORS.includes(params.operator as ConditionOperator)
@@ -29,6 +29,6 @@ export function buildAlterationCondition(
       );
     }
     default:
-      throw new Error(`Unknown BuffConditionType: ${type}`);
+      throw new Error(`Unknown AlterationConditionType: ${type}`);
   }
 }

--- a/src/fight/http-api/dto/fight-data.dto.ts
+++ b/src/fight/http-api/dto/fight-data.dto.ts
@@ -19,14 +19,14 @@ import {
   Validate,
 } from 'class-validator';
 
-export enum BuffConditionType {
+export enum AlterationConditionType {
   ALLY_PRESENCE = 'ally-presence',
   HEALTH_THRESHOLD = 'health-threshold',
 }
 
 class BuffConditionDto {
-  @IsEnum(BuffConditionType)
-  type: BuffConditionType;
+  @IsEnum(AlterationConditionType)
+  type: AlterationConditionType;
 
   @IsOptional()
   @IsString()


### PR DESCRIPTION
## Summary

- Renames `BuffConditionType` → `AlterationConditionType` in `fight-data.dto.ts` to align the public DTO enum with the internal `alteration` vocabulary
- Updates all references in `buff-condition-factory.ts` (import, parameter type, switch cases, error message)
- Updates all references in `buff-condition-factory.spec.ts` (import, usages, error assertion)

## Test plan

- [ ] All 555 existing unit tests pass (`npm test`)
- [ ] No compilation errors (`npm run build`)

Closes #270

https://claude.ai/code/session_01L4mGWETCuvhQfKoWUQJbH4

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4mGWETCuvhQfKoWUQJbH4)_