### PR TITLE
Document Skill.launch() method and targetingStrategy override

### DIFF
--- a/src/fight/core/cards/skills/skill.ts
+++ b/src/fight/core/cards/skills/skill.ts
@@ -59,6 +59,10 @@ export interface Skill {
   id: string;
   name: string;
 
+  /**
+   * Executes the skill. When `targetingStrategy` is provided, it overrides
+   * the skill's own default targeting strategy for this invocation.
+   */
   launch(
     source: FightingCard,
     context: FightingContext,


### PR DESCRIPTION
## Summary
Added JSDoc documentation to the `Skill.launch()` method to clarify its behavior and the purpose of the `targetingStrategy` parameter.

## Key Changes
- Added comprehensive JSDoc comment to the `launch()` method in the `Skill` interface
- Documented that the `targetingStrategy` parameter, when provided, overrides the skill's default targeting strategy for that specific invocation

## Implementation Details
The documentation clarifies the method's contract, making it explicit that `targetingStrategy` acts as an override mechanism rather than a fallback, which is important for developers implementing or using this interface.

https://claude.ai/code/session_01V4sMksk63WKEriyUgVHgtG