### PR TITLE
fix: Alteration.apply() respects polarity (buff vs debuff)

### DIFF
--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -33,7 +33,7 @@ class UnknownSpecial implements Special {
     return true;
   }
   launch(_source: FightingCard, _context: FightingContext): SpecialResult {
-    return { name: 'unknown', actionResults: [], buffResults: [] };
+    return { name: 'unknown', actionResults: [], alterationResults: [] };
   }
   increaseEnergy(actualEnergy: number): number {
     return actualEnergy;

--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -8,7 +8,14 @@ import { AttackResult } from '../cards/@types/action-result/attack-result';
 import { HealingReport } from '../fight-simulator/@types/healing-report';
 import { HealingResult } from '../cards/@types/action-result/healing-result';
 import { FightingContext } from '../cards/@types/fighting-context';
-import { BuffReport } from '../fight-simulator/@types/alteration-report';
+import {
+  BuffReport,
+  DebuffReport,
+} from '../fight-simulator/@types/alteration-report';
+import {
+  BuffResult,
+  DebuffResult,
+} from '../cards/@types/action-result/alteration-result';
 import { AttackSkillResults, SkillKind } from '../cards/skills/skill';
 import { DeathSkillHandler } from '../fight-simulator/death-skill-handler';
 
@@ -134,12 +141,19 @@ export class ActionStage {
 
     this.handleAttackResult(actionResults, result, card);
 
-    if (specialResults.buffResults.length > 0) {
+    const buffs = specialResults.alterationResults.filter(
+      (r): r is BuffResult => r.alteration.polarity === 'buff',
+    );
+    const debuffs = specialResults.alterationResults.filter(
+      (r): r is DebuffResult => r.alteration.polarity === 'debuff',
+    );
+
+    if (buffs.length > 0) {
       const buffReport: BuffReport = {
         kind: StepKind.Buff,
         name: specialResults.name,
         source: card.identityInfo,
-        buffs: specialResults.buffResults.map((buffResult) => ({
+        buffs: buffs.map((buffResult) => ({
           target: buffResult.target,
           kind: buffResult.alteration.type,
           value: buffResult.alteration.value,
@@ -147,8 +161,23 @@ export class ActionStage {
         })),
         energy: 0,
       };
-
       result.buffReport = buffReport;
+    }
+
+    if (debuffs.length > 0) {
+      const debuffReport: DebuffReport = {
+        kind: StepKind.Debuff,
+        name: specialResults.name,
+        source: card.identityInfo,
+        debuffs: debuffs.map((debuffResult) => ({
+          target: debuffResult.target,
+          kind: debuffResult.alteration.type,
+          value: debuffResult.alteration.value,
+          remainingTurns: debuffResult.alteration.duration,
+        })),
+        energy: 0,
+      };
+      result.debuffReport = debuffReport;
     }
 
     return result;
@@ -187,6 +216,10 @@ export class ActionStage {
 
           if (report.buffReport) {
             acc.actionSteps.push(report.buffReport);
+          }
+
+          if (report.debuffReport) {
+            acc.actionSteps.push(report.debuffReport);
           }
 
           report.statusChanges.forEach((statusChange) => {

--- a/src/fight/core/cards/@types/action-result/special-result.ts
+++ b/src/fight/core/cards/@types/action-result/special-result.ts
@@ -1,9 +1,9 @@
 import { AttackResult } from './attack-result';
-import { BuffResult } from './alteration-result';
+import { BuffResult, DebuffResult } from './alteration-result';
 import { HealingResult } from './healing-result';
 
 export type SpecialResult = {
   name: string;
   actionResults: AttackResult[] | HealingResult[];
-  buffResults: BuffResult[];
+  alterationResults: (BuffResult | DebuffResult)[];
 };

--- a/src/fight/core/cards/@types/alteration/__tests__/buff-application-with-condition.spec.ts
+++ b/src/fight/core/cards/@types/alteration/__tests__/buff-application-with-condition.spec.ts
@@ -93,4 +93,28 @@ describe('Alteration with condition', () => {
       expect(result.alteration.value).toBe(20);
     });
   });
+
+  describe('when polarity is debuff', () => {
+    let result: ReturnType<Alteration['apply']>[0];
+
+    beforeEach(() => {
+      const source = createFightingCard({ attack: 100 });
+      const debuff = new Alteration(
+        'attack',
+        0.2,
+        1,
+        new Launcher(),
+        undefined,
+        undefined,
+        undefined,
+        'debuff',
+      );
+      const context = makeContext(source);
+      [result] = debuff.apply(source, context);
+    });
+
+    it('applies a debuff polarity', () => {
+      expect(result.alteration.polarity).toBe('debuff');
+    });
+  });
 });

--- a/src/fight/core/cards/@types/alteration/alteration.ts
+++ b/src/fight/core/cards/@types/alteration/alteration.ts
@@ -3,7 +3,7 @@ import { FightingContext } from '../fighting-context';
 import { TargetingCardStrategy } from '../../../targeting-card-strategies/targeting-card-strategy';
 import { AlterationType } from './alteration-type';
 import { AlterationCondition } from './alteration-condition';
-import { BuffResult } from '../action-result/alteration-result';
+import { BuffResult, DebuffResult } from '../action-result/alteration-result';
 
 export class Alteration {
   constructor(
@@ -14,31 +14,47 @@ export class Alteration {
     public readonly condition?: AlterationCondition,
     public readonly conditionMultiplier?: number,
     public readonly terminationEvent?: string,
+    public readonly polarity: 'buff' | 'debuff' = 'buff',
   ) {
     if (condition !== undefined && conditionMultiplier === undefined) {
       throw new Error('conditionMultiplier is required when condition is set');
     }
   }
 
-  public apply(source: FightingCard, context: FightingContext): BuffResult[] {
+  public apply(
+    source: FightingCard,
+    context: FightingContext,
+  ): BuffResult[] | DebuffResult[] {
     const effectiveRate = this.condition?.evaluate(source, context)
       ? this.rate * this.conditionMultiplier
       : this.rate;
 
-    const buffTargets = this.targetingStrategy.targetedCards(
+    const targets = this.targetingStrategy.targetedCards(
       source,
       context.sourcePlayer,
       context.opponentPlayer,
     );
 
-    return buffTargets.map((target) => {
-      const buff = target.applyBuff(
+    if (this.polarity === 'debuff') {
+      return targets.map((target) => ({
+        target: target.identityInfo,
+        alteration: target.applyDebuff(
+          this.type,
+          effectiveRate,
+          this.duration,
+          this.terminationEvent,
+        ),
+      }));
+    }
+
+    return targets.map((target) => ({
+      target: target.identityInfo,
+      alteration: target.applyBuff(
         this.type,
         effectiveRate,
         this.duration,
         this.terminationEvent,
-      );
-      return { target: target.identityInfo, alteration: buff };
-    });
+      ),
+    }));
   }
 }

--- a/src/fight/core/cards/skills/special-attack.ts
+++ b/src/fight/core/cards/skills/special-attack.ts
@@ -7,6 +7,10 @@ import { AttackEffect, EffectResult } from '../@types/attack/attack-effect';
 import { Alteration } from '../@types/alteration/alteration';
 import { DamageComposition } from '../@types/damage/damage-composition';
 import { DamageCalculator } from '../damage/damage-calculator';
+import {
+  BuffResult,
+  DebuffResult,
+} from '../@types/action-result/alteration-result';
 
 const ENERGY_INCREASE_FACTOR = 10;
 const CRITICAL_RATE = 1.3;
@@ -78,12 +82,12 @@ export class SpecialAttack implements Special {
       };
     });
 
-    const buffResults = this.applyBuffs(source, context);
+    const alterationResults = this.applyAlterations(source, context);
 
     return {
       name: this.name,
       actionResults: attackResults,
-      buffResults,
+      alterationResults,
     };
   }
 
@@ -95,13 +99,17 @@ export class SpecialAttack implements Special {
     return 'specialAttack';
   }
 
-  private applyBuffs(source: FightingCard, context: FightingContext) {
+  private applyAlterations(
+    source: FightingCard,
+    context: FightingContext,
+  ): (BuffResult | DebuffResult)[] {
     if (!this.alterations) {
       return [];
     }
 
-    return this.alterations.flatMap((alteration) =>
-      alteration.apply(source, context),
+    return this.alterations.flatMap(
+      (alteration) =>
+        alteration.apply(source, context) as (BuffResult | DebuffResult)[],
     );
   }
 }

--- a/src/fight/core/cards/skills/special-healing.ts
+++ b/src/fight/core/cards/skills/special-healing.ts
@@ -36,7 +36,7 @@ export class SpecialHealing implements Special {
       return { healed, target, remainingHealth };
     });
 
-    return { name: this.name, actionResults, buffResults: [] };
+    return { name: this.name, actionResults, alterationResults: [] };
   }
 
   public increaseEnergy(actualEnergy: number): number {

--- a/src/fight/core/fight-simulator/@types/attack-report.ts
+++ b/src/fight/core/fight-simulator/@types/attack-report.ts
@@ -1,10 +1,11 @@
 import { DamageReport } from './damage-report';
 import { Step, StepKind } from './step';
-import { BuffReport } from './alteration-report';
+import { BuffReport, DebuffReport } from './alteration-report';
 
 export type AttackReport = {
   kind: StepKind.Attack | StepKind.SpecialAttack;
   attack: DamageReport;
   statusChanges: Step[];
   buffReport?: BuffReport;
+  debuffReport?: DebuffReport;
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #271 — `Alteration.apply()` was ignoring polarity and always calling `applyBuff()`, creating a type lie.

- Add `polarity: 'buff' | 'debuff'` field to `Alteration` (defaults to `'buff'` for full backwards compatibility)
- Branch `apply()` on polarity: routes to `applyBuff()` or `applyDebuff()` accordingly
- Update return type to `BuffResult[] | DebuffResult[]`
- Rename `SpecialResult.buffResults` → `alterationResults: (BuffResult | DebuffResult)[]` to reflect mixed polarity support
- Update `ActionStage` to split alteration results by polarity and emit `BuffReport` and/or `DebuffReport`
- Add `debuffReport?` to `AttackReport`
- Add test covering debuff-polarity `Alteration`

## Test plan

- [x] All 556 existing tests pass
- [x] New test: debuff-polarity `Alteration.apply()` returns `alteration.polarity === 'debuff'`
- [x] Lint passes

https://claude.ai/code/session_01SEhEjYTFjANwy818payKYH
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEhEjYTFjANwy818payKYH)_