### PR TITLE
fix: propagate powerId through EffectTriggeredDebuff

### DIFF
--- a/src/fight/core/cards/@types/attack/__tests__/effect-triggered-debuff.spec.ts
+++ b/src/fight/core/cards/@types/attack/__tests__/effect-triggered-debuff.spec.ts
@@ -82,6 +82,36 @@ describe('EffectTriggeredDebuff', () => {
     });
   });
 
+  describe('when a powerId is provided', () => {
+    let result: ReturnType<EffectTriggeredDebuff['tryApply']>;
+
+    beforeEach(() => {
+      randomizer.setNextRandomValue(0);
+      const target = createFightingCard({ defense: 200 });
+      const triggered = new EffectTriggeredDebuff(
+        1.0,
+        'defense',
+        0.1,
+        2,
+        randomizer,
+        undefined,
+        'my-power-id',
+      );
+      result = triggered.tryApply(target);
+    });
+
+    it('returns the applied debuff with the powerId', () => {
+      expect(result).toEqual({
+        polarity: 'debuff',
+        type: 'defense',
+        value: 20,
+        duration: 2,
+        terminationEvent: undefined,
+        powerId: 'my-power-id',
+      });
+    });
+  });
+
   describe('when the random roll fails', () => {
     let result: ReturnType<EffectTriggeredDebuff['tryApply']>;
 

--- a/src/fight/core/cards/@types/attack/effect-triggered-debuff.ts
+++ b/src/fight/core/cards/@types/attack/effect-triggered-debuff.ts
@@ -9,6 +9,7 @@ export class EffectTriggeredDebuff {
   public readonly debuffRate: number;
   public readonly duration: number;
   public readonly terminationEvent?: string;
+  public readonly powerId?: string;
   private readonly randomizer: Randomizer;
 
   constructor(
@@ -18,6 +19,7 @@ export class EffectTriggeredDebuff {
     duration: number,
     randomizer: Randomizer,
     terminationEvent?: string,
+    powerId?: string,
   ) {
     if (probability < 0 || probability > 1) {
       throw new Error(`probability must be in [0, 1], got: ${probability}`);
@@ -27,6 +29,7 @@ export class EffectTriggeredDebuff {
     this.debuffRate = debuffRate;
     this.duration = duration;
     this.terminationEvent = terminationEvent;
+    this.powerId = powerId;
     this.randomizer = randomizer;
   }
 
@@ -39,6 +42,7 @@ export class EffectTriggeredDebuff {
       this.debuffRate,
       this.duration,
       this.terminationEvent,
+      this.powerId,
     );
   }
 }

--- a/src/fight/http-api/dto/fight-data.dto.ts
+++ b/src/fight/http-api/dto/fight-data.dto.ts
@@ -127,6 +127,11 @@ class EffectTriggeredDebuffDto {
   @IsString()
   @IsNotEmpty()
   terminationEvent?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  powerId?: string;
 }
 
 class EffectDto {

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -238,6 +238,7 @@ export class FightController {
         duration: number;
         probability: number;
         terminationEvent?: string;
+        powerId?: string;
       };
       terminationEvent?: string;
       probability?: number;
@@ -257,6 +258,7 @@ export class FightController {
       duration: number;
       probability: number;
       terminationEvent?: string;
+      powerId?: string;
     };
     terminationEvent?: string;
     probability?: number;
@@ -269,6 +271,7 @@ export class FightController {
           effectDto.triggeredDebuff.duration,
           new MathRandomizer(),
           effectDto.triggeredDebuff.terminationEvent,
+          effectDto.triggeredDebuff.powerId,
         )
       : undefined;
 


### PR DESCRIPTION
## Summary

- Add optional `powerId` field to `EffectTriggeredDebuff` and pass it as the 5th argument to `target.applyDebuff()`
- Add `powerId?` to `EffectTriggeredDebuffDto` with proper `class-validator` decorators
- Update the inline type annotations and constructor call in `fight.controller.ts` to propagate `powerId` from the DTO

## Test plan

- [ ] New test case `when a powerId is provided` in `effect-triggered-debuff.spec.ts` asserts the debuff carries the correct `powerId`
- [ ] All 556 existing tests still pass
- [ ] Build succeeds with no TypeScript errors

Closes #275

https://claude.ai/code/session_01HisRjGf7udTj4NxJrzyBRU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HisRjGf7udTj4NxJrzyBRU)_