### PR TITLE
refactor: remove `as SkillResults` cast in AlterationSkill.launch()

### DIFF
--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -40,10 +40,6 @@ export class AlterationSkill implements Skill {
   private readonly powerId?: string;
   private activationCount = 0;
 
-  private get skillKind() {
-    return this.polarity === 'buff' ? SkillKind.Buff : SkillKind.Debuff;
-  }
-
   constructor({
     name,
     polarity,
@@ -84,12 +80,20 @@ export class AlterationSkill implements Skill {
       this.activationCondition &&
       !this.activationCondition.evaluate(source, context)
     ) {
+      if (this.polarity === 'buff') {
+        return {
+          skillKind: SkillKind.Buff,
+          results: [],
+          name: this.name,
+          powerId: this.powerId,
+        };
+      }
       return {
-        skillKind: this.skillKind,
+        skillKind: SkillKind.Debuff,
         results: [],
         name: this.name,
         powerId: this.powerId,
-      } as SkillResults;
+      };
     }
 
     const targetedCards = this.targetingStrategy.targetedCards(
@@ -129,13 +133,22 @@ export class AlterationSkill implements Skill {
       alteration: applyAlteration(targetedCard),
     }));
 
+    if (this.polarity === 'buff') {
+      return {
+        skillKind: SkillKind.Buff,
+        results,
+        name: this.name,
+        endEvent,
+        powerId: this.powerId,
+      };
+    }
     return {
-      skillKind: this.skillKind,
+      skillKind: SkillKind.Debuff,
       results,
       name: this.name,
       endEvent,
       powerId: this.powerId,
-    } as SkillResults;
+    };
   }
 
   isTriggered(triggerName: string): boolean {

--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -76,64 +76,38 @@ export class AlterationSkill implements Skill {
     context: FightingContext,
     _targetingOverride?: TargetingCardStrategy,
   ): SkillResults {
-    if (
+    const conditionFailed =
       this.activationCondition &&
-      !this.activationCondition.evaluate(source, context)
-    ) {
-      if (this.polarity === 'buff') {
-        return {
-          skillKind: SkillKind.Buff,
-          results: [],
-          name: this.name,
-          powerId: this.powerId,
-        };
-      }
-      return {
-        skillKind: SkillKind.Debuff,
-        results: [],
-        name: this.name,
-        powerId: this.powerId,
-      };
+      !this.activationCondition.evaluate(source, context);
+
+    const targetedCards = conditionFailed
+      ? []
+      : this.targetingStrategy.targetedCards(
+          source,
+          context.sourcePlayer,
+          context.opponentPlayer,
+        );
+
+    if (!conditionFailed) {
+      this.activationCount++;
     }
-
-    const targetedCards = this.targetingStrategy.targetedCards(
-      source,
-      context.sourcePlayer,
-      context.opponentPlayer,
-    );
-
-    this.activationCount++;
 
     const isExhausted =
       this.activationLimit !== undefined &&
       this.activationCount >= this.activationLimit;
     const endEvent = isExhausted ? this.endEvent : undefined;
 
-    const applyAlteration =
-      this.polarity === 'buff'
-        ? (card: FightingCard) =>
-            card.applyBuff(
-              this.attributeType,
-              this.rate,
-              this.duration,
-              this.terminationEvent,
-              this.powerId,
-            )
-        : (card: FightingCard) =>
-            card.applyDebuff(
-              this.attributeType,
-              this.rate,
-              this.duration,
-              this.terminationEvent,
-              this.powerId,
-            );
-
-    const results = targetedCards.map((targetedCard) => ({
-      target: targetedCard.identityInfo,
-      alteration: applyAlteration(targetedCard),
-    }));
-
     if (this.polarity === 'buff') {
+      const results = targetedCards.map((targetedCard) => ({
+        target: targetedCard.identityInfo,
+        alteration: targetedCard.applyBuff(
+          this.attributeType,
+          this.rate,
+          this.duration,
+          this.terminationEvent,
+          this.powerId,
+        ),
+      }));
       return {
         skillKind: SkillKind.Buff,
         results,
@@ -142,6 +116,17 @@ export class AlterationSkill implements Skill {
         powerId: this.powerId,
       };
     }
+
+    const results = targetedCards.map((targetedCard) => ({
+      target: targetedCard.identityInfo,
+      alteration: targetedCard.applyDebuff(
+        this.attributeType,
+        this.rate,
+        this.duration,
+        this.terminationEvent,
+        this.powerId,
+      ),
+    }));
     return {
       skillKind: SkillKind.Debuff,
       results,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Branch explicitly on `polarity` in `AlterationSkill.launch()` to return `BuffSkillResults` or `DebuffSkillResults` directly
- Removes two `as SkillResults` unsafe casts on both early-return and main return paths
- Removes the now-redundant `skillKind` private getter

## Test plan

- [ ] `npm run format` — no changes expected
- [ ] `npm run lint` — no lint errors
- [ ] `npm run test:cov` — all existing tests pass
- [ ] `npm run build` — TypeScript compiles without errors

Closes #272

https://claude.ai/code/session_01BLxMie6AyvnXa8foCeP75U
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLxMie6AyvnXa8foCeP75U)_