### PR TITLE
test: add coverage for skillResultsToSteps unknown SkillKind guard

### DIFF
--- a/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-attack.spec.ts
+++ b/src/fight/core/fight-simulator/__tests__/skill-results-to-steps-attack.spec.ts
@@ -115,6 +115,18 @@ describe('skillResultsToSteps: SkillKind.Attack branch', () => {
   });
 });
 
+describe('skillResultsToSteps: unknown SkillKind guard', () => {
+  const card = createFightingCard({ id: 'source' });
+
+  it('throws for unknown SkillKind', () => {
+    const unknownResult = { skillKind: 'unknown' as any, results: [] };
+
+    expect(() => skillResultsToSteps(card, [unknownResult])).toThrow(
+      'Unknown SkillKind: unknown',
+    );
+  });
+});
+
 describe('skillResultsToSteps: absent endEventProcessor with endEvent', () => {
   const card = createFightingCard({ id: 'source' });
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a test for the `default: throw new Error('Unknown SkillKind: ...')` guard in `skill-results-to-steps.ts`
- Ensures any future `SkillKind` added without a matching case will be caught immediately
- Test is placed in the existing `skill-results-to-steps-attack.spec.ts` file in a dedicated `describe` block

Closes #276

## Test plan

- [x] New test `throws for unknown SkillKind` passes
- [x] All 10 tests in `skill-results-to-steps-attack.spec.ts` pass

https://claude.ai/code/session_01UxT5m9imgLUFksZeqJpkgW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxT5m9imgLUFksZeqJpkgW)_