### PR TITLE
refactor: AlterationDetail discriminated union + AlterationSkill.launch() simplification

### DIFF
--- a/src/fight/core/cards/@types/alteration/alteration-detail.ts
+++ b/src/fight/core/cards/@types/alteration/alteration-detail.ts
@@ -1,7 +1,6 @@
 import { AlterationType } from './alteration-type';
 
-export type AlterationDetail = {
-  polarity: 'buff' | 'debuff';
+type AlterationDetailBase = {
   type: AlterationType;
   value: number;
   duration: number;
@@ -9,5 +8,7 @@ export type AlterationDetail = {
   powerId?: string;
 };
 
-export type Buff = AlterationDetail & { polarity: 'buff' };
-export type Debuff = AlterationDetail & { polarity: 'debuff' };
+export type Buff = AlterationDetailBase & { polarity: 'buff' };
+export type Debuff = AlterationDetailBase & { polarity: 'debuff' };
+
+export type AlterationDetail = Buff | Debuff;

--- a/src/fight/core/cards/skills/alteration-skill.ts
+++ b/src/fight/core/cards/skills/alteration-skill.ts
@@ -4,7 +4,7 @@ import { Trigger } from '../../trigger/trigger';
 import { ActivatableTrigger } from '../../trigger/activatable-trigger';
 import { FightingContext } from '../@types/fighting-context';
 import { AlterationType } from '../@types/alteration/alteration-type';
-import { Skill, SkillKind, SkillResults } from './skill';
+import { BuffSkillResults, DebuffSkillResults, Skill, SkillKind, SkillResults } from './skill';
 import { AlterationCondition } from '../@types/alteration/alteration-condition';
 
 export interface AlterationSkillOptions {
@@ -97,43 +97,32 @@ export class AlterationSkill implements Skill {
       this.activationCount >= this.activationLimit;
     const endEvent = isExhausted ? this.endEvent : undefined;
 
-    if (this.polarity === 'buff') {
-      const results = targetedCards.map((targetedCard) => ({
-        target: targetedCard.identityInfo,
-        alteration: targetedCard.applyBuff(
-          this.attributeType,
-          this.rate,
-          this.duration,
-          this.terminationEvent,
-          this.powerId,
-        ),
-      }));
-      return {
-        skillKind: SkillKind.Buff,
-        results,
-        name: this.name,
-        endEvent,
-        powerId: this.powerId,
-      };
-    }
-
     const results = targetedCards.map((targetedCard) => ({
       target: targetedCard.identityInfo,
-      alteration: targetedCard.applyDebuff(
-        this.attributeType,
-        this.rate,
-        this.duration,
-        this.terminationEvent,
-        this.powerId,
-      ),
+      alteration:
+        this.polarity === 'buff'
+          ? targetedCard.applyBuff(
+              this.attributeType,
+              this.rate,
+              this.duration,
+              this.terminationEvent,
+              this.powerId,
+            )
+          : targetedCard.applyDebuff(
+              this.attributeType,
+              this.rate,
+              this.duration,
+              this.terminationEvent,
+              this.powerId,
+            ),
     }));
     return {
-      skillKind: SkillKind.Debuff,
+      skillKind: this.polarity === 'buff' ? SkillKind.Buff : SkillKind.Debuff,
       results,
       name: this.name,
       endEvent,
       powerId: this.powerId,
-    };
+    } as BuffSkillResults | DebuffSkillResults;
   }
 
   isTriggered(triggerName: string): boolean {


### PR DESCRIPTION
## Summary

- **#273** — `AlterationDetailBase` is now a private (non-exported) type. `Buff` and `Debuff` are standalone discriminated types extending it. The public `AlterationDetail` is re-exported as `Buff | Debuff`, forcing consumers to always work with the narrowed discriminated variant rather than the weaker base type.

- **#278** — `AlterationSkill.launch()` no longer duplicates the `results` map and `return` statement in two separate `if/else` branches. A single `map()` with an inline polarity ternary replaces both, and the return uses `as BuffSkillResults | DebuffSkillResults` to satisfy the discriminated union constraint while keeping the logic DRY.

## Test plan

- [ ] `npm run format` — no changes
- [ ] `npm run test:cov` — 71 suites, 559 tests pass
- [ ] `npm run build` — clean build

Closes #273
Closes #278

https://claude.ai/code/session_01JG2tDfhL19iGPHRS66Ta1x

---
_Generated by [Claude Code](https://claude.ai/code/session_01JG2tDfhL19iGPHRS66Ta1x)_