### PR TITLE
refactor: unify BuffReport/DebuffReport with generic template

### DIFF
--- a/src/fight/core/__tests__/buffing-skill.spec.ts
+++ b/src/fight/core/__tests__/buffing-skill.spec.ts
@@ -80,7 +80,7 @@ describe('Buffing-skill', () => {
       2: {
         kind: 'buff',
         source: card1.identityInfo,
-        buffs: [
+        alterations: [
           {
             target: card1.identityInfo,
             kind: 'attack',
@@ -126,7 +126,7 @@ describe('Buffing-skill', () => {
       6: {
         kind: 'buff',
         source: card1.identityInfo,
-        buffs: [
+        alterations: [
           {
             target: card1.identityInfo,
             kind: 'attack',

--- a/src/fight/core/__tests__/debuffing-skill.spec.ts
+++ b/src/fight/core/__tests__/debuffing-skill.spec.ts
@@ -79,7 +79,7 @@ describe('Debuffing-skill', () => {
         2: expect.objectContaining({
           kind: 'debuff',
           source: card1.identityInfo,
-          debuffs: [
+          alterations: [
             {
               target: card2.identityInfo,
               kind: 'attack',

--- a/src/fight/core/__tests__/special-attack.spec.ts
+++ b/src/fight/core/__tests__/special-attack.spec.ts
@@ -368,7 +368,7 @@ describe('Trigger card special attack with buff', () => {
     expect(result[2]).toMatchObject({
       kind: 'buff',
       source: attacker.identityInfo,
-      buffs: [
+      alterations: [
         {
           target: attacker.identityInfo,
           kind: 'attack',

--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -121,14 +121,14 @@ describe('ActionStage', () => {
         const debuffStep = steps.find(
           (s) => s.kind === StepKind.Debuff,
         ) as DebuffReport;
-        expect(debuffStep.debuffs[0].kind).toBe('defense');
+        expect(debuffStep.alterations[0].kind).toBe('defense');
       });
 
       it('debuff step has correct remainingTurns', () => {
         const debuffStep = steps.find(
           (s) => s.kind === StepKind.Debuff,
         ) as DebuffReport;
-        expect(debuffStep.debuffs[0].remainingTurns).toBe(2);
+        expect(debuffStep.alterations[0].remainingTurns).toBe(2);
       });
 
       it('debuff step has source card info', () => {

--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -153,7 +153,7 @@ export class ActionStage {
         kind: StepKind.Buff,
         name: specialResults.name,
         source: card.identityInfo,
-        buffs: buffs.map((buffResult) => ({
+        alterations: buffs.map((buffResult) => ({
           target: buffResult.target,
           kind: buffResult.alteration.type,
           value: buffResult.alteration.value,
@@ -169,7 +169,7 @@ export class ActionStage {
         kind: StepKind.Debuff,
         name: specialResults.name,
         source: card.identityInfo,
-        debuffs: debuffs.map((debuffResult) => ({
+        alterations: debuffs.map((debuffResult) => ({
           target: debuffResult.target,
           kind: debuffResult.alteration.type,
           value: debuffResult.alteration.value,
@@ -277,7 +277,7 @@ export class ActionStage {
             report.statusChanges.push({
               kind: StepKind.Debuff,
               source: attackerCard.identityInfo,
-              debuffs: [
+              alterations: [
                 {
                   target: debuffTarget.identityInfo,
                   kind: debuff.type,

--- a/src/fight/core/fight-simulator/@types/alteration-report.ts
+++ b/src/fight/core/fight-simulator/@types/alteration-report.ts
@@ -2,11 +2,11 @@ import { AlterationType } from '../../cards/@types/alteration/alteration-type';
 import { CardInfo } from '../../cards/@types/card-info';
 import { StepKind } from './step';
 
-export type BuffReport = {
-  kind: StepKind.Buff;
+type AlterationReport<K extends StepKind> = {
+  kind: K;
   name?: string;
   source: CardInfo;
-  buffs: {
+  alterations: {
     target: CardInfo;
     kind: AlterationType;
     value: number;
@@ -16,16 +16,5 @@ export type BuffReport = {
   powerId?: string;
 };
 
-export type DebuffReport = {
-  kind: StepKind.Debuff;
-  name?: string;
-  source: CardInfo;
-  debuffs: {
-    target: CardInfo;
-    kind: AlterationType;
-    value: number;
-    remainingTurns: number;
-  }[];
-  energy: number;
-  powerId?: string;
-};
+export type BuffReport = AlterationReport<StepKind.Buff>;
+export type DebuffReport = AlterationReport<StepKind.Debuff>;

--- a/src/fight/core/fight-simulator/skill-results-to-steps.ts
+++ b/src/fight/core/fight-simulator/skill-results-to-steps.ts
@@ -28,29 +28,16 @@ export function skillResultsToSteps(
         });
         break;
       case SkillKind.Buff:
-        if (skillResult.results.length > 0) {
-          steps.push({
-            kind: StepKind.Buff,
-            name: skillResult.name,
-            source: card.identityInfo,
-            buffs: skillResult.results.map((result) => ({
-              target: result.target,
-              kind: result.alteration.type,
-              value: result.alteration.value,
-              remainingTurns: result.alteration.duration,
-            })),
-            energy: card.actualEnergy,
-            powerId: skillResult.powerId,
-          });
-        }
-        break;
       case SkillKind.Debuff:
         if (skillResult.results.length > 0) {
           steps.push({
-            kind: StepKind.Debuff,
+            kind:
+              skillResult.skillKind === SkillKind.Buff
+                ? StepKind.Buff
+                : StepKind.Debuff,
             name: skillResult.name,
             source: card.identityInfo,
-            debuffs: skillResult.results.map((result) => ({
+            alterations: skillResult.results.map((result) => ({
               target: result.target,
               kind: result.alteration.type,
               value: result.alteration.value,

--- a/test/fight/simulate-buffs.e2e-spec.ts
+++ b/test/fight/simulate-buffs.e2e-spec.ts
@@ -187,7 +187,7 @@ describe('Simulate fight with buffs', () => {
         expect(res.body[Object.keys(res.body).length].kind).toBe('fight_end');
 
         expect(res.body[3]).toEqual({
-          buffs: [
+          alterations: [
             {
               kind: 'attack',
               remainingTurns: 4,

--- a/test/fight/special-attack-buffs.e2e-spec.ts
+++ b/test/fight/special-attack-buffs.e2e-spec.ts
@@ -134,7 +134,7 @@ describe('Special Attack with Buffs (e2e)', () => {
             name: 'Attacker with Buff',
             deckIdentity: 'Player 1-0',
           },
-          buffs: [
+          alterations: [
             {
               target: {
                 name: 'Attacker with Buff',
@@ -274,7 +274,7 @@ describe('Special Attack with Buffs (e2e)', () => {
         expect(result['2']).toMatchObject({
           kind: 'buff',
           source: { name: 'Dual Buffer' },
-          buffs: expect.arrayContaining([
+          alterations: expect.arrayContaining([
             expect.objectContaining({ kind: 'attack', value: 20 }),
             expect.objectContaining({ kind: 'defense', value: 30 }),
           ]),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Apply `AlterationReport<K extends StepKind>` generic template to `BuffReport` and `DebuffReport` in `alteration-report.ts`, replacing the duplicate `buffs`/`debuffs` field with a unified `alterations` field — consistent with how `AlterationExpiredReport` and `AlterationRemovedReport` are already structured
- Collapse the two near-identical `SkillKind.Buff` / `SkillKind.Debuff` cases in `skill-results-to-steps.ts` into a single branch
- Update all call sites in `action-stage.ts` and test files to use `alterations`

## Test plan

- [ ] All 559 unit tests pass (`npm run test`)
- [ ] Build succeeds (`npm run build`)

Closes #274

https://claude.ai/code/session_01KvFYzjuLTgD2AMEbyyyzey
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvFYzjuLTgD2AMEbyyyzey)_