### PR TITLE
Implement shield mechanic for fighting cards

### DIFF
--- a/samples/cards.json
+++ b/samples/cards.json
@@ -204,7 +204,12 @@
             "targetingStrategy": "target-all",
             "polarity": "debuff"
           }
-        ]
+        ],
+        "shieldApplication": {
+          "rate": 0.3,
+          "duration": 1,
+          "targetingStrategy": "self"
+        }
       },
       "others": []
     },

--- a/src/fight/core/__tests__/shield.spec.ts
+++ b/src/fight/core/__tests__/shield.spec.ts
@@ -1,0 +1,127 @@
+import { Fight } from '../fight-simulator/fight';
+import { Player } from '../player';
+import { PlayerByPlayerCardSelector } from '../fight-simulator/card-selectors/player-by-player';
+import { createFightingCard } from '../../../../test/helpers/fighting-card';
+import { DamageComposition } from '../cards/@types/damage/damage-composition';
+import { DamageType } from '../cards/@types/damage/damage-type';
+
+describe('Shield mechanic', () => {
+  describe('when special attack applies a shield', () => {
+    const attacker = createFightingCard({
+      attack: 10,
+      criticalChance: 0,
+      health: 500,
+      accuracy: 100,
+      agility: 0,
+      speed: 100,
+      defense: 0,
+      skills: {
+        special: {
+          damages: [new DamageComposition(DamageType.PHYSICAL, 0.1)],
+          energy: 0,
+          kind: 'specialAttack',
+          shieldApplication: {
+            rate: 0.3,
+            duration: 1,
+            targetingStrategy: 'self',
+          },
+        },
+      },
+    });
+    const defender = createFightingCard({
+      attack: 5,
+      defense: 0,
+      health: 1000,
+      speed: 0,
+      agility: 0,
+      accuracy: 0,
+      criticalChance: 0,
+    });
+
+    const player1 = new Player('Player 1', [attacker]);
+    const player2 = new Player('Player 2', [defender]);
+    const fight = new Fight(
+      player1,
+      player2,
+      new PlayerByPlayerCardSelector(player1, player2),
+    );
+
+    const result = fight.start();
+    const steps = Object.values(result);
+
+    it('emits a shield_applied step after the special attack', () => {
+      const shieldApplied = steps.find((s) => s.kind === 'shield_applied');
+
+      expect(shieldApplied).toBeDefined();
+    });
+
+    it('sets shield points to 30% of attacker max health', () => {
+      const shieldApplied = steps.find(
+        (s) => s.kind === 'shield_applied',
+      ) as any;
+
+      expect(shieldApplied.targets[0].points).toBe(150);
+    });
+
+    it('emits a shield_expired step at end of turn if shield was not depleted', () => {
+      const shieldExpired = steps.find((s) => s.kind === 'shield_expired');
+
+      expect(shieldExpired).toBeDefined();
+    });
+  });
+
+  describe('when a shielded card takes damage exceeding shield points', () => {
+    const shieldedCard = createFightingCard({
+      id: 'shielded',
+      attack: 1,
+      criticalChance: 0,
+      health: 400,
+      accuracy: 0,
+      agility: 0,
+      speed: 50,
+      defense: 0,
+      skills: {
+        special: {
+          damages: [new DamageComposition(DamageType.PHYSICAL, 0.01)],
+          energy: 0,
+          kind: 'specialAttack',
+          shieldApplication: { rate: 0.3, duration: 2 },
+        },
+      },
+    });
+    const attacker = createFightingCard({
+      attack: 500,
+      criticalChance: 0,
+      health: 1000,
+      accuracy: 100,
+      agility: 0,
+      speed: 100,
+      defense: 0,
+    });
+
+    shieldedCard.applyShield(0.3, 2);
+
+    const player1 = new Player('Player 1', [attacker]);
+    const player2 = new Player('Player 2', [shieldedCard]);
+    const fight = new Fight(
+      player1,
+      player2,
+      new PlayerByPlayerCardSelector(player1, player2),
+    );
+
+    const result = fight.start();
+    const steps = Object.values(result);
+
+    it('emits a shield_broken step after the attack', () => {
+      const shieldBroken = steps.find((s) => s.kind === 'shield_broken');
+
+      expect(shieldBroken).toBeDefined();
+    });
+
+    it('shield_broken references the shielded card', () => {
+      const shieldBroken = steps.find((s) => s.kind === 'shield_broken') as any;
+
+      expect(shieldBroken.card.id).toBe('shielded');
+    });
+  });
+});

--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -33,7 +33,7 @@ class UnknownSpecial implements Special {
     return true;
   }
   launch(_source: FightingCard, _context: FightingContext): SpecialResult {
-    return { name: 'unknown', actionResults: [], alterationResults: [] };
+    return { name: 'unknown', actionResults: [], alterationResults: [], shieldResults: [] };
   }
   increaseEnergy(actualEnergy: number): number {
     return actualEnergy;

--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -18,6 +18,8 @@ import {
 } from '../cards/@types/action-result/alteration-result';
 import { AttackSkillResults, SkillKind } from '../cards/skills/skill';
 import { DeathSkillHandler } from '../fight-simulator/death-skill-handler';
+import { ShieldResult } from '../cards/@types/action-result/shield-result';
+import { ShieldAppliedReport } from '../fight-simulator/@types/shield-report';
 
 type SplittedSteps = {
   actionSteps: Step[];
@@ -180,6 +182,14 @@ export class ActionStage {
       result.debuffReport = debuffReport;
     }
 
+    if (specialResults.shieldResults.length > 0) {
+      result.shieldAppliedReport = this.buildShieldAppliedReport(
+        card,
+        specialResults.name,
+        specialResults.shieldResults,
+      );
+    }
+
     return result;
   }
 
@@ -222,6 +232,10 @@ export class ActionStage {
             acc.actionSteps.push(report.debuffReport);
           }
 
+          if (report.shieldAppliedReport) {
+            acc.actionSteps.push(report.shieldAppliedReport);
+          }
+
           report.statusChanges.forEach((statusChange) => {
             acc.statusChangeSteps.push(statusChange);
           });
@@ -256,6 +270,13 @@ export class ActionStage {
         kind: damageDealt.kind,
       });
 
+      if (damageDealt.shieldBroken) {
+        report.statusChanges.push({
+          kind: StepKind.ShieldBroken,
+          card: defensiveCard.identityInfo,
+        });
+      }
+
       if (defensiveCard.isDead() && !reportedDeaths.has(defensiveCard)) {
         reportedDeaths.add(defensiveCard);
         this.notifyDeath(defensiveCard, attackerCard);
@@ -265,28 +286,30 @@ export class ActionStage {
           status: 'dead',
         });
         report.statusChanges.push(...this.deathSkillHandler.drainSteps());
-      } else if (!defensiveCard.isDead() && damageDealt.effects?.length) {
-        for (const effect of damageDealt.effects) {
-          report.statusChanges.push({
-            kind: StepKind.StatusChange,
-            status: effect.type,
-            card: effect.card.identityInfo,
-          });
-          if (effect.triggeredDebuff) {
-            const { card: debuffTarget, debuff } = effect.triggeredDebuff;
+      } else if (!defensiveCard.isDead()) {
+        if (damageDealt.effects?.length) {
+          for (const effect of damageDealt.effects) {
             report.statusChanges.push({
-              kind: StepKind.Debuff,
-              source: attackerCard.identityInfo,
-              alterations: [
-                {
-                  target: debuffTarget.identityInfo,
-                  kind: debuff.type,
-                  value: debuff.value,
-                  remainingTurns: debuff.duration,
-                },
-              ],
-              energy: attackerCard.actualEnergy,
+              kind: StepKind.StatusChange,
+              status: effect.type,
+              card: effect.card.identityInfo,
             });
+            if (effect.triggeredDebuff) {
+              const { card: debuffTarget, debuff } = effect.triggeredDebuff;
+              report.statusChanges.push({
+                kind: StepKind.Debuff,
+                source: attackerCard.identityInfo,
+                alterations: [
+                  {
+                    target: debuffTarget.identityInfo,
+                    kind: debuff.type,
+                    value: debuff.value,
+                    remainingTurns: debuff.duration,
+                  },
+                ],
+                energy: attackerCard.actualEnergy,
+              });
+            }
           }
         }
       }
@@ -305,5 +328,21 @@ export class ActionStage {
     this.eventBroker.onCardDeath.forEach((subscriber) =>
       subscriber.notifyDeath(card, killerCard),
     );
+  }
+
+  private buildShieldAppliedReport(
+    source: FightingCard,
+    name: string,
+    shieldResults: ShieldResult[],
+  ): ShieldAppliedReport {
+    return {
+      kind: StepKind.ShieldApplied,
+      name,
+      source: source.identityInfo,
+      targets: shieldResults.map((r) => ({
+        target: r.target,
+        points: r.shield.points,
+      })),
+    };
   }
 }

--- a/src/fight/core/cards/@types/action-result/attack-result.ts
+++ b/src/fight/core/cards/@types/action-result/attack-result.ts
@@ -5,6 +5,8 @@ import { DamageType } from '../damage/damage-type';
 
 export type AttackResult = {
   damage: number;
+  shieldAbsorbed?: number;
+  shieldBroken?: boolean;
   isCritical: boolean;
   dodge: boolean;
   defender: FightingCard;

--- a/src/fight/core/cards/@types/action-result/shield-result.ts
+++ b/src/fight/core/cards/@types/action-result/shield-result.ts
@@ -1,0 +1,7 @@
+import { CardInfo } from '../card-info';
+import { Shield } from '../shield/shield';
+
+export type ShieldResult = {
+  target: CardInfo;
+  shield: Shield;
+};

--- a/src/fight/core/cards/@types/action-result/special-result.ts
+++ b/src/fight/core/cards/@types/action-result/special-result.ts
@@ -1,9 +1,11 @@
 import { AttackResult } from './attack-result';
 import { BuffResult, DebuffResult } from './alteration-result';
 import { HealingResult } from './healing-result';
+import { ShieldResult } from './shield-result';
 
 export type SpecialResult = {
   name: string;
   actionResults: AttackResult[] | HealingResult[];
   alterationResults: (BuffResult | DebuffResult)[];
+  shieldResults: ShieldResult[];
 };

--- a/src/fight/core/cards/@types/shield/shield-application.ts
+++ b/src/fight/core/cards/@types/shield/shield-application.ts
@@ -1,0 +1,25 @@
+import { FightingCard } from '../../fighting-card';
+import { FightingContext } from '../fighting-context';
+import { TargetingCardStrategy } from '../../../targeting-card-strategies/targeting-card-strategy';
+import { ShieldResult } from '../action-result/shield-result';
+
+export class ShieldApplication {
+  constructor(
+    public readonly rate: number,
+    public readonly duration: number,
+    public readonly targetingStrategy: TargetingCardStrategy,
+  ) {}
+
+  public apply(source: FightingCard, context: FightingContext): ShieldResult[] {
+    const targets = this.targetingStrategy.targetedCards(
+      source,
+      context.sourcePlayer,
+      context.opponentPlayer,
+    );
+
+    return targets.map((target) => ({
+      target: target.identityInfo,
+      shield: target.applyShield(this.rate, this.duration),
+    }));
+  }
+}

--- a/src/fight/core/cards/@types/shield/shield.ts
+++ b/src/fight/core/cards/@types/shield/shield.ts
@@ -1,0 +1,4 @@
+export type Shield = {
+  points: number;
+  duration: number;
+};

--- a/src/fight/core/cards/__tests__/fighting-card-shield.spec.ts
+++ b/src/fight/core/cards/__tests__/fighting-card-shield.spec.ts
@@ -1,0 +1,122 @@
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+
+describe('FightingCard shield', () => {
+  describe('applyShield()', () => {
+    it('sets shield points to 30% of maxHealth', () => {
+      const card = createFightingCard({ health: 400 });
+
+      const shield = card.applyShield(0.3, 1);
+
+      expect(shield.points).toBe(120);
+    });
+
+    it('sets shield duration', () => {
+      const card = createFightingCard({ health: 400 });
+
+      const shield = card.applyShield(0.3, 2);
+
+      expect(shield.duration).toBe(2);
+    });
+
+    it('exposes the shield via getter', () => {
+      const card = createFightingCard({ health: 400 });
+      card.applyShield(0.3, 1);
+
+      expect(card.shield).not.toBeNull();
+    });
+  });
+
+  describe('applyFinalDamage() with shield', () => {
+    it('absorbs damage into the shield before health', () => {
+      const card = createFightingCard({ health: 400, defense: 0 });
+      card.applyShield(0.3, 1);
+
+      const { damageToHealth, shieldAbsorbed } = card.applyFinalDamage(50);
+
+      expect(shieldAbsorbed).toBe(50);
+      expect(damageToHealth).toBe(0);
+    });
+
+    it('reduces health only for damage exceeding shield points', () => {
+      const card = createFightingCard({ health: 400, defense: 0 });
+      card.applyShield(0.3, 1);
+
+      const { damageToHealth, shieldAbsorbed } = card.applyFinalDamage(150);
+
+      expect(shieldAbsorbed).toBe(120);
+      expect(damageToHealth).toBe(30);
+    });
+
+    it('removes shield when fully depleted', () => {
+      const card = createFightingCard({ health: 400, defense: 0 });
+      card.applyShield(0.3, 1);
+
+      card.applyFinalDamage(120);
+
+      expect(card.shield).toBeNull();
+    });
+
+    it('sets shieldBroken flag when shield is depleted by hit', () => {
+      const card = createFightingCard({ health: 400, defense: 0 });
+      card.applyShield(0.3, 1);
+
+      const { shieldAbsorbed } = card.applyFinalDamage(120);
+
+      expect(shieldAbsorbed).toBe(120);
+      expect(card.shield).toBeNull();
+    });
+
+    it('keeps partial shield when damage is below shield points', () => {
+      const card = createFightingCard({ health: 400, defense: 0 });
+      card.applyShield(0.3, 1);
+
+      card.applyFinalDamage(50);
+
+      expect(card.shield!.points).toBe(70);
+    });
+  });
+
+  describe('decreaseShieldDuration()', () => {
+    it('returns null when no shield is active', () => {
+      const card = createFightingCard({ health: 400 });
+
+      expect(card.decreaseShieldDuration()).toBeNull();
+    });
+
+    it('returns null when shield still has duration remaining', () => {
+      const card = createFightingCard({ health: 400 });
+      card.applyShield(0.3, 2);
+
+      expect(card.decreaseShieldDuration()).toBeNull();
+    });
+
+    it('returns expired shield when duration reaches 0', () => {
+      const card = createFightingCard({ health: 400 });
+      card.applyShield(0.3, 1);
+
+      const expired = card.decreaseShieldDuration();
+
+      expect(expired).not.toBeNull();
+    });
+
+    it('nullifies shield after expiry', () => {
+      const card = createFightingCard({ health: 400 });
+      card.applyShield(0.3, 1);
+
+      card.decreaseShieldDuration();
+
+      expect(card.shield).toBeNull();
+    });
+  });
+
+  describe('applyFinalDamage() without shield', () => {
+    it('returns shieldAbsorbed of 0 when no shield', () => {
+      const card = createFightingCard({ health: 400, defense: 0 });
+
+      const { shieldAbsorbed, damageToHealth } = card.applyFinalDamage(100);
+
+      expect(shieldAbsorbed).toBe(0);
+      expect(damageToHealth).toBe(100);
+    });
+  });
+});

--- a/src/fight/core/cards/__tests__/fighting-card-shield.spec.ts
+++ b/src/fight/core/cards/__tests__/fighting-card-shield.spec.ts
@@ -18,11 +18,11 @@ describe('FightingCard shield', () => {
       expect(shield.duration).toBe(2);
     });
 
-    it('exposes the shield via getter', () => {
+    it('activates the shield', () => {
       const card = createFightingCard({ health: 400 });
       card.applyShield(0.3, 1);
 
-      expect(card.shield).not.toBeNull();
+      expect(card.shielded).toBe(true);
     });
   });
 
@@ -53,17 +53,7 @@ describe('FightingCard shield', () => {
 
       card.applyFinalDamage(120);
 
-      expect(card.shield).toBeNull();
-    });
-
-    it('sets shieldBroken flag when shield is depleted by hit', () => {
-      const card = createFightingCard({ health: 400, defense: 0 });
-      card.applyShield(0.3, 1);
-
-      const { shieldAbsorbed } = card.applyFinalDamage(120);
-
-      expect(shieldAbsorbed).toBe(120);
-      expect(card.shield).toBeNull();
+      expect(card.shielded).toBe(false);
     });
 
     it('keeps partial shield when damage is below shield points', () => {
@@ -71,8 +61,9 @@ describe('FightingCard shield', () => {
       card.applyShield(0.3, 1);
 
       card.applyFinalDamage(50);
+      const { shieldAbsorbed } = card.applyFinalDamage(80);
 
-      expect(card.shield!.points).toBe(70);
+      expect(shieldAbsorbed).toBe(70);
     });
   });
 
@@ -99,13 +90,13 @@ describe('FightingCard shield', () => {
       expect(expired).not.toBeNull();
     });
 
-    it('nullifies shield after expiry', () => {
+    it('deactivates shield after expiry', () => {
       const card = createFightingCard({ health: 400 });
       card.applyShield(0.3, 1);
 
       card.decreaseShieldDuration();
 
-      expect(card.shield).toBeNull();
+      expect(card.shielded).toBe(false);
     });
   });
 

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -66,7 +66,7 @@ export class FightingCard {
   private dodgeBehavior: DodgeBehavior;
 
   // Shield
-  private _shield: Shield | null = null;
+  private shield: Shield | null = null;
 
   // Targeting overrides
   private targetingOverrides: TargetingOverrideEntry[] = [];
@@ -186,8 +186,8 @@ export class FightingCard {
     return this.burned?.level ?? 0;
   }
 
-  public get shield(): Shield | null {
-    return this._shield;
+  public get shielded(): boolean {
+    return this.shield !== null;
   }
 
   public setOwnerInfo(ownerName: string, cardPositionInDeck: number): void {
@@ -365,29 +365,29 @@ export class FightingCard {
 
   public applyShield(rate: number, duration: number): Shield {
     const points = Math.round(rate * this.maxHealth);
-    this._shield = { points, duration };
-    return this._shield;
+    this.shield = { points, duration };
+    return this.shield;
   }
 
   public decreaseShieldDuration(): Shield | null {
-    if (!this._shield) return null;
+    if (!this.shield) return null;
 
-    this._shield = { ...this._shield, duration: this._shield.duration - 1 };
-    if (this._shield.duration <= 0) {
-      const expired = this._shield;
-      this._shield = null;
+    this.shield = { ...this.shield, duration: this.shield.duration - 1 };
+    if (this.shield.duration <= 0) {
+      const expired = this.shield;
+      this.shield = null;
       return expired;
     }
     return null;
   }
 
   private absorbWithShield(damage: number): number {
-    if (!this._shield) return 0;
+    if (!this.shield) return 0;
 
-    const absorbed = Math.min(this._shield.points, damage);
-    this._shield = { ...this._shield, points: this._shield.points - absorbed };
-    if (this._shield.points <= 0) {
-      this._shield = null;
+    const absorbed = Math.min(this.shield.points, damage);
+    this.shield = { ...this.shield, points: this.shield.points - absorbed };
+    if (this.shield.points <= 0) {
+      this.shield = null;
     }
     return absorbed;
   }

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -17,6 +17,12 @@ import { Element } from './@types/damage/element';
 import { TargetingCardStrategy } from '../targeting-card-strategies/targeting-card-strategy';
 import { NamedAttackResult } from './@types/action-result/named-attack-result';
 import { round2 } from '../../tools/round';
+import { Shield } from './@types/shield/shield';
+
+export type FinalDamageResult = {
+  damageToHealth: number;
+  shieldAbsorbed: number;
+};
 
 export type TargetingOverrideEntry = {
   strategy: TargetingCardStrategy;
@@ -58,6 +64,9 @@ export class FightingCard {
 
   // Behaviors
   private dodgeBehavior: DodgeBehavior;
+
+  // Shield
+  private _shield: Shield | null = null;
 
   // Targeting overrides
   private targetingOverrides: TargetingOverrideEntry[] = [];
@@ -175,6 +184,10 @@ export class FightingCard {
 
   public get burnLevel(): EffectLevel {
     return this.burned?.level ?? 0;
+  }
+
+  public get shield(): Shield | null {
+    return this._shield;
   }
 
   public setOwnerInfo(ownerName: string, cardPositionInDeck: number): void {
@@ -330,7 +343,7 @@ export class FightingCard {
     return this.special.getSpecialKind();
   }
 
-  public applyFinalDamage(damage: number): number {
+  public applyFinalDamage(damage: number): FinalDamageResult {
     let causedDamages = damage;
     if (this.frozen) {
       causedDamages = (this.frozen as CardStateFrozen).applyDamageRate(
@@ -342,9 +355,41 @@ export class FightingCard {
         causedDamages,
       );
     }
-    this.receivedDamages += causedDamages;
 
-    return causedDamages;
+    const shieldAbsorbed = this.absorbWithShield(causedDamages);
+    const damageToHealth = causedDamages - shieldAbsorbed;
+    this.receivedDamages += damageToHealth;
+
+    return { damageToHealth, shieldAbsorbed };
+  }
+
+  public applyShield(rate: number, duration: number): Shield {
+    const points = Math.round(rate * this.maxHealth);
+    this._shield = { points, duration };
+    return this._shield;
+  }
+
+  public decreaseShieldDuration(): Shield | null {
+    if (!this._shield) return null;
+
+    this._shield = { ...this._shield, duration: this._shield.duration - 1 };
+    if (this._shield.duration <= 0) {
+      const expired = this._shield;
+      this._shield = null;
+      return expired;
+    }
+    return null;
+  }
+
+  private absorbWithShield(damage: number): number {
+    if (!this._shield) return 0;
+
+    const absorbed = Math.min(this._shield.points, damage);
+    this._shield = { ...this._shield, points: this._shield.points - absorbed };
+    if (this._shield.points <= 0) {
+      this._shield = null;
+    }
+    return absorbed;
   }
 
   public addRealDamage(damage: number): number {

--- a/src/fight/core/cards/skills/multiple-attack.ts
+++ b/src/fight/core/cards/skills/multiple-attack.ts
@@ -92,7 +92,7 @@ export class MultipleAttack implements AttackSkill {
           damage: damageToHealth + shieldAbsorbed,
           shieldAbsorbed: shieldAbsorbed > 0 ? shieldAbsorbed : undefined,
           shieldBroken:
-            shieldAbsorbed > 0 && !defender.shield ? true : undefined,
+            shieldAbsorbed > 0 && !defender.shielded ? true : undefined,
           isCritical,
           dodge: false,
           defender,
@@ -119,7 +119,7 @@ export class MultipleAttack implements AttackSkill {
           damage: damageToHealth + shieldAbsorbed,
           shieldAbsorbed: shieldAbsorbed > 0 ? shieldAbsorbed : undefined,
           shieldBroken:
-            shieldAbsorbed > 0 && !defender.shield ? true : undefined,
+            shieldAbsorbed > 0 && !defender.shielded ? true : undefined,
           isCritical: false,
           dodge: false,
           defender,

--- a/src/fight/core/cards/skills/multiple-attack.ts
+++ b/src/fight/core/cards/skills/multiple-attack.ts
@@ -81,14 +81,18 @@ export class MultipleAttack implements AttackSkill {
           attackPower * damageMultiplier,
           defender,
         );
-        const collectedDamage = defender.applyFinalDamage(total);
+        const { damageToHealth, shieldAbsorbed } =
+          defender.applyFinalDamage(total);
 
         const effects = this.effects
           ?.map((e) => e.applyEffect(defender, card, context))
           .filter((r): r is EffectResult => r != null);
 
         results.results.push({
-          damage: collectedDamage,
+          damage: damageToHealth + shieldAbsorbed,
+          shieldAbsorbed: shieldAbsorbed > 0 ? shieldAbsorbed : undefined,
+          shieldBroken:
+            shieldAbsorbed > 0 && !defender.shield ? true : undefined,
           isCritical,
           dodge: false,
           defender,
@@ -109,9 +113,13 @@ export class MultipleAttack implements AttackSkill {
           card.actualAttack,
           defender,
         );
-        const collectedDamage = defender.applyFinalDamage(total);
+        const { damageToHealth, shieldAbsorbed } =
+          defender.applyFinalDamage(total);
         results.results.push({
-          damage: collectedDamage,
+          damage: damageToHealth + shieldAbsorbed,
+          shieldAbsorbed: shieldAbsorbed > 0 ? shieldAbsorbed : undefined,
+          shieldBroken:
+            shieldAbsorbed > 0 && !defender.shield ? true : undefined,
           isCritical: false,
           dodge: false,
           defender,

--- a/src/fight/core/cards/skills/simple-attack.ts
+++ b/src/fight/core/cards/skills/simple-attack.ts
@@ -75,7 +75,7 @@ export class SimpleAttack implements AttackSkill {
           damage: damageToHealth + shieldAbsorbed,
           shieldAbsorbed: shieldAbsorbed > 0 ? shieldAbsorbed : undefined,
           shieldBroken:
-            shieldAbsorbed > 0 && !defender.shield ? true : undefined,
+            shieldAbsorbed > 0 && !defender.shielded ? true : undefined,
           isCritical,
           dodge: false,
           defender,

--- a/src/fight/core/cards/skills/simple-attack.ts
+++ b/src/fight/core/cards/skills/simple-attack.ts
@@ -64,14 +64,18 @@ export class SimpleAttack implements AttackSkill {
           card.actualAttack * damageMultiplier,
           defender,
         );
-        const collectedDamage = defender.applyFinalDamage(total);
+        const { damageToHealth, shieldAbsorbed } =
+          defender.applyFinalDamage(total);
 
         const effects = this.effects
           ?.map((e) => e.applyEffect(defender, card, context))
           .filter((r): r is EffectResult => r != null);
 
         return {
-          damage: collectedDamage,
+          damage: damageToHealth + shieldAbsorbed,
+          shieldAbsorbed: shieldAbsorbed > 0 ? shieldAbsorbed : undefined,
+          shieldBroken:
+            shieldAbsorbed > 0 && !defender.shield ? true : undefined,
           isCritical,
           dodge: false,
           defender,

--- a/src/fight/core/cards/skills/special-attack.ts
+++ b/src/fight/core/cards/skills/special-attack.ts
@@ -77,7 +77,7 @@ export class SpecialAttack implements Special {
       return {
         damage: damageToHealth + shieldAbsorbed,
         shieldAbsorbed: shieldAbsorbed > 0 ? shieldAbsorbed : undefined,
-        shieldBroken: shieldAbsorbed > 0 && !target.shield ? true : undefined,
+        shieldBroken: shieldAbsorbed > 0 && !target.shielded ? true : undefined,
         isCritical,
         dodge: false,
         defender: target,

--- a/src/fight/core/cards/skills/special-attack.ts
+++ b/src/fight/core/cards/skills/special-attack.ts
@@ -11,6 +11,8 @@ import {
   BuffResult,
   DebuffResult,
 } from '../@types/action-result/alteration-result';
+import { ShieldApplication } from '../@types/shield/shield-application';
+import { ShieldResult } from '../@types/action-result/shield-result';
 
 const ENERGY_INCREASE_FACTOR = 10;
 const CRITICAL_RATE = 1.3;
@@ -23,6 +25,7 @@ export class SpecialAttack implements Special {
     private readonly targetingStrategy: TargetingCardStrategy,
     private readonly effect?: AttackEffect,
     private readonly alterations?: Alteration[],
+    private readonly shieldApplication?: ShieldApplication,
   ) {}
 
   public ready(actualEnergy: number): boolean {
@@ -64,7 +67,7 @@ export class SpecialAttack implements Special {
         source.actualAttack * damageMultiplier,
         target,
       );
-      const damage = target.applyFinalDamage(total);
+      const { damageToHealth, shieldAbsorbed } = target.applyFinalDamage(total);
 
       let effectResult: EffectResult;
       if (this.effect) {
@@ -72,7 +75,9 @@ export class SpecialAttack implements Special {
       }
 
       return {
-        damage,
+        damage: damageToHealth + shieldAbsorbed,
+        shieldAbsorbed: shieldAbsorbed > 0 ? shieldAbsorbed : undefined,
+        shieldBroken: shieldAbsorbed > 0 && !target.shield ? true : undefined,
         isCritical,
         dodge: false,
         defender: target,
@@ -83,11 +88,13 @@ export class SpecialAttack implements Special {
     });
 
     const alterationResults = this.applyAlterations(source, context);
+    const shieldResults = this.applyShield(source, context);
 
     return {
       name: this.name,
       actionResults: attackResults,
       alterationResults,
+      shieldResults,
     };
   }
 
@@ -111,5 +118,15 @@ export class SpecialAttack implements Special {
       (alteration) =>
         alteration.apply(source, context) as (BuffResult | DebuffResult)[],
     );
+  }
+
+  private applyShield(
+    source: FightingCard,
+    context: FightingContext,
+  ): ShieldResult[] {
+    if (!this.shieldApplication) {
+      return [];
+    }
+    return this.shieldApplication.apply(source, context);
   }
 }

--- a/src/fight/core/cards/skills/special-healing.ts
+++ b/src/fight/core/cards/skills/special-healing.ts
@@ -36,7 +36,12 @@ export class SpecialHealing implements Special {
       return { healed, target, remainingHealth };
     });
 
-    return { name: this.name, actionResults, alterationResults: [] };
+    return {
+      name: this.name,
+      actionResults,
+      alterationResults: [],
+      shieldResults: [],
+    };
   }
 
   public increaseEnergy(actualEnergy: number): number {

--- a/src/fight/core/fight-simulator/@types/attack-report.ts
+++ b/src/fight/core/fight-simulator/@types/attack-report.ts
@@ -1,6 +1,7 @@
 import { DamageReport } from './damage-report';
 import { Step, StepKind } from './step';
 import { BuffReport, DebuffReport } from './alteration-report';
+import { ShieldAppliedReport } from './shield-report';
 
 export type AttackReport = {
   kind: StepKind.Attack | StepKind.SpecialAttack;
@@ -8,4 +9,5 @@ export type AttackReport = {
   statusChanges: Step[];
   buffReport?: BuffReport;
   debuffReport?: DebuffReport;
+  shieldAppliedReport?: ShieldAppliedReport;
 };

--- a/src/fight/core/fight-simulator/@types/shield-report.ts
+++ b/src/fight/core/fight-simulator/@types/shield-report.ts
@@ -1,0 +1,19 @@
+import { CardInfo } from '../../cards/@types/card-info';
+import { StepKind } from './step';
+
+export type ShieldAppliedReport = {
+  kind: StepKind.ShieldApplied;
+  name?: string;
+  source: CardInfo;
+  targets: { target: CardInfo; points: number }[];
+};
+
+export type ShieldBrokenReport = {
+  kind: StepKind.ShieldBroken;
+  card: CardInfo;
+};
+
+export type ShieldExpiredReport = {
+  kind: StepKind.ShieldExpired;
+  card: CardInfo;
+};

--- a/src/fight/core/fight-simulator/@types/step.ts
+++ b/src/fight/core/fight-simulator/@types/step.ts
@@ -17,6 +17,11 @@ import {
   TargetingRevertedReport,
 } from './targeting-override-report';
 import { EffectRemovedReport } from './effect-removed-report';
+import {
+  ShieldAppliedReport,
+  ShieldBrokenReport,
+  ShieldExpiredReport,
+} from './shield-report';
 
 export enum StepKind {
   FightEnd = 'fight_end',
@@ -34,6 +39,9 @@ export enum StepKind {
   TargetingOverride = 'targeting_override',
   TargetingReverted = 'targeting_reverted',
   EffectRemoved = 'effect_removed',
+  ShieldApplied = 'shield_applied',
+  ShieldBroken = 'shield_broken',
+  ShieldExpired = 'shield_expired',
 }
 
 export type Step =
@@ -51,4 +59,7 @@ export type Step =
   | DebuffExpiredReport
   | TargetingOverrideReport
   | TargetingRevertedReport
-  | EffectRemovedReport;
+  | EffectRemovedReport
+  | ShieldAppliedReport
+  | ShieldBrokenReport
+  | ShieldExpiredReport;

--- a/src/fight/core/fight-simulator/turn-manager.ts
+++ b/src/fight/core/fight-simulator/turn-manager.ts
@@ -56,6 +56,10 @@ export class TurnManager {
           })),
         });
       }
+      const expiredShield = card.decreaseShieldDuration();
+      if (expiredShield) {
+        steps.push({ kind: StepKind.ShieldExpired, card: card.identityInfo });
+      }
       this.processCardSkill(card, steps);
       this.processCardEffectStates(card, steps);
     });

--- a/src/fight/http-api/dto/fight-data.dto.ts
+++ b/src/fight/http-api/dto/fight-data.dto.ts
@@ -190,6 +190,21 @@ class StatAlterationDto {
   terminationEvent?: string;
 }
 
+class ShieldApplicationDto {
+  @IsNumber()
+  rate: number;
+
+  @IsNumber()
+  duration: number;
+
+  @IsEnum(TargetingStrategy)
+  @IsNotIn([TargetingStrategy.TARGETED_CARD], {
+    message:
+      'targeted-card strategy can only be used with targeting override skills',
+  })
+  targetingStrategy: TargetingStrategy;
+}
+
 class SpecialDto {
   @IsEnum(SpecialKind)
   kind: SpecialKind;
@@ -228,6 +243,11 @@ class SpecialDto {
   @ValidateNested({ each: true })
   @Type(/* istanbul ignore next */ () => StatAlterationDto)
   statAlterations?: StatAlterationDto[];
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(/* istanbul ignore next */ () => ShieldApplicationDto)
+  shieldApplication?: ShieldApplicationDto;
 }
 
 class DamageCompositionDto {

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -56,6 +56,7 @@ import { MultipleAttack } from '../core/cards/skills/multiple-attack';
 import { AttackSkill } from '../core/cards/skills/attack-skill';
 import { TargetedCard } from '../core/targeting-card-strategies/targeted-card';
 import { validatePowerIdConsistency } from '../core/cards/skills/power-id-consistency';
+import { ShieldApplication } from '../core/cards/@types/shield/shield-application';
 
 @Controller()
 @UsePipes(
@@ -138,6 +139,15 @@ export class FightController {
       const specialDamages = rawDamages.map(
         (d) => new DamageComposition(d.type, d.rate),
       );
+      const shieldDto = cardData.skills.special.shieldApplication;
+      const shieldApplication = shieldDto
+        ? new ShieldApplication(
+            shieldDto.rate,
+            shieldDto.duration,
+            buildTargetingStrategy(shieldDto.targetingStrategy),
+          )
+        : undefined;
+
       special = new SpecialAttack(
         cardData.skills.special.name,
         specialDamages,
@@ -145,6 +155,7 @@ export class FightController {
         buildTargetingStrategy(cardData.skills.special.targetingStrategy),
         specialEffect,
         alterations.length > 0 ? alterations : undefined,
+        shieldApplication,
       );
     } else if (cardData.skills.special.kind === SpecialKind.HEALING) {
       special = new SpecialHealing(

--- a/test/helpers/fighting-card.ts
+++ b/test/helpers/fighting-card.ts
@@ -28,6 +28,7 @@ import { AlterationCondition } from '../../src/fight/core/cards/@types/alteratio
 import { Element } from '../../src/fight/core/cards/@types/damage/element';
 import { DamageComposition } from '../../src/fight/core/cards/@types/damage/damage-composition';
 import { DamageType } from '../../src/fight/core/cards/@types/damage/damage-type';
+import { ShieldApplication } from '../../src/fight/core/cards/@types/shield/shield-application';
 
 type effect = {
   type: string;
@@ -73,6 +74,7 @@ type FightingCardParams = {
         debuffDuration: number;
         debuffTargetingStrategy: string;
       }[];
+      shieldApplication?: { rate: number; duration: number; targetingStrategy?: string };
     };
     others?: (
       | {
@@ -244,6 +246,11 @@ function createSpecialAttack(params: {
     debuffDuration: number;
     debuffTargetingStrategy: string;
   }[];
+  shieldApplication?: {
+    rate: number;
+    duration: number;
+    targetingStrategy?: string;
+  };
 }): SpecialAttack {
   const damages = params.damages ?? [
     new DamageComposition(
@@ -279,6 +286,16 @@ function createSpecialAttack(params: {
   );
   const alterations = [...buffs, ...debuffs];
 
+  const shieldApplication = params.shieldApplication
+    ? new ShieldApplication(
+        params.shieldApplication.rate,
+        params.shieldApplication.duration,
+        createTargetingStrategy(
+          params.shieldApplication.targetingStrategy ?? 'self',
+        ),
+      )
+    : undefined;
+
   return new SpecialAttack(
     params.name ?? faker.word.noun(),
     damages,
@@ -286,6 +303,7 @@ function createSpecialAttack(params: {
     createTargetingStrategy(targetingStrategy),
     effect,
     alterations.length > 0 ? alterations : undefined,
+    shieldApplication,
   );
 }
 


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive shield system to the fighting card game mechanics. Shields are temporary protective barriers that absorb damage before affecting a card's health, and can be applied through special attack skills.

## Key Changes

### Core Shield Mechanics
- Added `Shield` type with `points` and `duration` properties
- Implemented `applyShield(rate, duration)` method on `FightingCard` to create shields based on a percentage of max health
- Implemented `decreaseShieldDuration()` method to handle shield expiration at turn end
- Modified `applyFinalDamage()` to return `FinalDamageResult` with separate `damageToHealth` and `shieldAbsorbed` values
- Added `absorbWithShield()` private method to handle damage absorption logic

### Shield Application System
- Created `ShieldApplication` class to manage shield application targeting and parameters
- Integrated shield application into `SpecialAttack` skill with optional `shieldApplication` configuration
- Added `ShieldResult` type to track shield application outcomes

### Game Flow Integration
- Updated `ActionStage` to build and emit `ShieldAppliedReport` when shields are applied
- Added shield break detection: emits `ShieldBrokenReport` when damage exceeds shield points
- Integrated `TurnManager` to emit `ShieldExpiredReport` when shield duration expires
- Updated all attack skills (`SimpleAttack`, `MultipleAttack`, `SpecialAttack`) to track shield absorption separately

### API & Configuration
- Added `ShieldApplicationDto` validation class for HTTP API
- Extended `SpecialDto` to support optional `shieldApplication` configuration
- Updated sample cards configuration with shield application example

### Step Types
- Added three new `StepKind` enum values: `ShieldApplied`, `ShieldBroken`, `ShieldExpired`
- Created corresponding report types in `shield-report.ts`

### Testing
- Added comprehensive test suite for shield mechanics in `shield.spec.ts`
- Added unit tests for `FightingCard` shield methods in `fighting-card-shield.spec.ts`
- Updated test helpers to support shield application configuration

## Implementation Details
- Shields use immutable updates to maintain state consistency
- Shield absorption is calculated before health damage, with overflow damage applied to health
- Shield duration decreases at the end of each turn, with expiration triggering a report
- Shield breaking (when fully depleted by a single hit) is tracked separately from normal shield absorption

https://claude.ai/code/session_01Ur5EQrwcR11zowcdDr1qw4