### PR TITLE
feat(frontend): update fight-replayer for alterations refactor and Kaelion stunt/shield

### DIFF
--- a/frontend/fight-replayer/js/demo-data.js
+++ b/frontend/fight-replayer/js/demo-data.js
@@ -44,7 +44,7 @@ export const DEMO_DATA = {
     kind: 'buff',
     name: 'Fierté du lion',
     source: { id: 'arionis', name: 'Arionis', deckIdentity: 'Héros-1' },
-    buffs: [
+    alterations: [
       {
         target: { id: 'arionis', name: 'Arionis', deckIdentity: 'Héros-1' },
         kind: 'attack',
@@ -87,7 +87,7 @@ export const DEMO_DATA = {
       name: 'Seigneur des Cendres',
       deckIdentity: 'Boss-0',
     },
-    buffs: [
+    alterations: [
       {
         target: {
           id: 'boss',
@@ -145,7 +145,7 @@ export const DEMO_DATA = {
     kind: 'buff',
     name: 'Fierté du lion',
     source: { id: 'arionis', name: 'Arionis', deckIdentity: 'Héros-1' },
-    buffs: [
+    alterations: [
       {
         target: { id: 'arionis', name: 'Arionis', deckIdentity: 'Héros-1' },
         kind: 'attack',
@@ -213,7 +213,7 @@ export const DEMO_DATA = {
     kind: 'buff',
     name: 'Rugissement solaire',
     source: { id: 'arionis', name: 'Arionis', deckIdentity: 'Héros-1' },
-    buffs: [
+    alterations: [
       {
         target: { id: 'kaelion', name: 'Kaelion', deckIdentity: 'Héros-0' },
         kind: 'attack',
@@ -311,7 +311,7 @@ export const DEMO_DATA = {
     kind: 'buff',
     name: 'Buff Héroïque',
     source: { id: 'arionis', name: 'Arionis', deckIdentity: 'Héros-1' },
-    buffs: [
+    alterations: [
       {
         target: { id: 'arionis', name: 'Arionis', deckIdentity: 'Héros-1' },
         kind: 'attack',

--- a/frontend/fight-replayer/js/icons.js
+++ b/frontend/fight-replayer/js/icons.js
@@ -21,9 +21,14 @@ export const ICON = {
   burn:              '🔥',
   poison:            '☠️',
   freeze:            '❄️',
+  stunt:             '💫',
   dead:              '💀',
   status_change:     '⚡',
   state_effect:      '💢',
+  /* Shield */
+  shield_applied:    '🛡️',
+  shield_broken:     '💥',
+  shield_expired:    '🔻',
   /* Targeting */
   targeting_override: '🎯',
   targeting_reverted: '🔄',
@@ -41,6 +46,7 @@ export const STATUS_ICON = {
   burn:   ICON.burn,
   poison: ICON.poison,
   freeze: ICON.freeze,
+  stunt:  ICON.stunt,
 };
 
 /** Primary colour per event kind */
@@ -61,6 +67,9 @@ export const EVENT_COLOR = {
   targeting_override: '#c084fc',
   targeting_reverted: '#c084fc',
   effect_removed:    '#94a3b8',
+  shield_applied:    '#60a5fa',
+  shield_broken:     '#f87171',
+  shield_expired:    '#94a3b8',
   fight_end:         '#22c55e',
 };
 

--- a/frontend/fight-replayer/js/parser.js
+++ b/frontend/fight-replayer/js/parser.js
@@ -33,9 +33,9 @@ function discoverCards(events) {
       trackFirstHP(firstHP, d.defender, d.remainingHealth, d.damage);
     });
     ev.heal?.forEach(h => registerCard(meta, h.target));
-    ev.buffs?.forEach(b => registerCard(meta, b.target));
-    ev.debuffs?.forEach(b => registerCard(meta, b.target));
+    ev.alterations?.forEach(b => registerCard(meta, b.target));
     ev.removed?.forEach(r => registerCard(meta, r.target));
+    ev.targets?.forEach(t => registerCard(meta, t.target));
     if (ev.kind === 'state_effect') {
       trackFirstHP(firstHP, ev.card, ev.remainingHealth, ev.damage);
     }
@@ -123,10 +123,11 @@ function buildInitialState(cardsMeta, firstHP) {
       deckIdentity: c.deckIdentity,
       maxHP,
       hp: maxHP,
-      statuses: [],     // active status names: ['burn', 'poison', ...]
+      statuses: [],     // active status names: ['burn', 'poison', 'stunt', ...]
       stateEffects: {}, // { [type]: remainingTurns }
       buffs: [],        // { kind, value, turns, name, powerId }
       debuffs: [],      // { kind, value, turns, name, powerId }
+      shield: null,     // null | { points: number }
       dead: false,
     };
   });
@@ -182,7 +183,7 @@ function applyEvent(state, ev) {
     }
 
     case 'buff':
-      ev.buffs?.forEach(b => {
+      ev.alterations?.forEach(b => {
         const c = get(b.target?.id);
         if (!c) return;
         c.buffs = [...c.buffs, {
@@ -196,7 +197,7 @@ function applyEvent(state, ev) {
       break;
 
     case 'debuff':
-      ev.debuffs?.forEach(b => {
+      ev.alterations?.forEach(b => {
         const c = get(b.target?.id);
         if (!c) return;
         c.debuffs = [...c.debuffs, {
@@ -265,6 +266,26 @@ function applyEvent(state, ev) {
         });
       }
       break;
+
+    case 'shield_applied':
+      ev.targets?.forEach(t => {
+        const c = get(t.target?.id);
+        if (!c) return;
+        c.shield = { points: t.points };
+      });
+      break;
+
+    case 'shield_broken': {
+      const c = get(ev.card?.id);
+      if (c) c.shield = null;
+      break;
+    }
+
+    case 'shield_expired': {
+      const c = get(ev.card?.id);
+      if (c) c.shield = null;
+      break;
+    }
 
     // targeting_override / targeting_reverted don't mutate card stats
     default: break;

--- a/frontend/fight-replayer/js/renderers.js
+++ b/frontend/fight-replayer/js/renderers.js
@@ -62,6 +62,10 @@ export function buildCardPanel(card, isTeamA, isActive) {
       </div>`
     : '';
 
+  const shieldHtml = card.shield
+    ? `<div class="card-panel__shield">${ICON.shield_applied} ${card.shield.points} shield</div>`
+    : '';
+
   const hpHtml = !card.dead
     ? `
     <div class="hp-bar">
@@ -82,6 +86,7 @@ export function buildCardPanel(card, isTeamA, isActive) {
       <div class="card-panel__name" style="color:${nameColor}">${esc(card.name)}</div>
       ${card.deckIdentity ? `<div class="card-panel__identity">${esc(card.deckIdentity)}</div>` : ''}
       ${hpHtml}
+      ${shieldHtml}
       ${statusesHtml}
       ${buffsHtml}
       ${debuffsHtml}
@@ -103,11 +108,13 @@ export function buildEventCard(ev, teamBName) {
   if (ev.kind === 'attack' || ev.kind === 'special_attack') {
     contentHtml = buildAttackDetail(ev);
   } else if (ev.kind === 'buff') {
-    contentHtml = buildBuffDebuffDetail(ev, 'buff');
+    contentHtml = buildAlterationDetail(ev, 'buff');
   } else if (ev.kind === 'debuff') {
-    contentHtml = buildBuffDebuffDetail(ev, 'debuff');
+    contentHtml = buildAlterationDetail(ev, 'debuff');
   } else if (ev.kind === 'healing') {
     contentHtml = buildHealDetail(ev);
+  } else if (ev.kind === 'shield_applied') {
+    contentHtml = buildShieldAppliedDetail(ev);
   } else {
     const detail = buildGenericDetail(ev);
     if (detail)
@@ -227,14 +234,13 @@ function buildAttackDetail(ev) {
   return `<div class="attack-targets">${rows}</div>`;
 }
 
-function buildBuffDebuffDetail(ev, type) {
-  const items = type === 'buff' ? ev.buffs : ev.debuffs;
-  if (!items?.length) return '';
+function buildAlterationDetail(ev, type) {
+  if (!ev.alterations?.length) return '';
 
   const cssClass = `detail-row--${type}`;
   const sign = type === 'buff' ? '+' : '−';
 
-  const rows = items
+  const rows = ev.alterations
     .map((b) => {
       const turns = b.remainingTurns != null ? `(${b.remainingTurns}T)` : '(∞)';
       return `
@@ -243,6 +249,20 @@ function buildBuffDebuffDetail(ev, type) {
         <span>${sign}${b.value} ${turns}</span>
       </div>`;
     })
+    .join('');
+
+  return `<div class="detail-rows">${rows}</div>`;
+}
+
+function buildShieldAppliedDetail(ev) {
+  if (!ev.targets?.length) return '';
+
+  const rows = ev.targets
+    .map((t) => `
+      <div class="detail-row detail-row--buff">
+        <span>${esc(t.target?.name)}</span>
+        <span>${ICON.shield_applied} ${t.points} pts</span>
+      </div>`)
     .join('');
 
   return `<div class="detail-rows">${rows}</div>`;
@@ -286,6 +306,9 @@ function buildGenericDetail(ev) {
       return `${esc(ev.previousStrategy)} → ${esc(ev.newStrategy)}`;
     case 'targeting_reverted':
       return `${esc(ev.revertedStrategy)} → ${esc(ev.restoredStrategy)}`;
+    case 'shield_broken':
+    case 'shield_expired':
+      return esc(ev.card?.name);
     case 'fight_end':
       return ev.winner ? `Winner: ${esc(ev.winner)}` : 'Draw';
     default:
@@ -400,6 +423,24 @@ export function describeEvent(ev, teamBName) {
         icon: ICON.effect_removed,
         text: `Effects removed — ${ev.eventName ?? ''}`,
         color: EVENT_COLOR.effect_removed,
+      };
+    case 'shield_applied':
+      return {
+        icon: ICON.shield_applied,
+        text: `${ev.source?.name} — ${ev.name ?? 'Shield'}`,
+        color: EVENT_COLOR.shield_applied,
+      };
+    case 'shield_broken':
+      return {
+        icon: ICON.shield_broken,
+        text: `${ev.card?.name} — Shield broken`,
+        color: EVENT_COLOR.shield_broken,
+      };
+    case 'shield_expired':
+      return {
+        icon: ICON.shield_expired,
+        text: `${ev.card?.name} — Shield expired`,
+        color: EVENT_COLOR.shield_expired,
       };
     case 'fight_end': {
       const bossWins = ev.winner && ev.winner === teamBName;

--- a/samples/cards.json
+++ b/samples/cards.json
@@ -61,17 +61,19 @@
           { "type": "FIRE", "rate": 0.4 }
         ],
         "targetingStrategy": "position-based",
-        "effect": {
-          "type": "BURN",
-          "rate": 0.1,
-          "level": 2,
-          "triggeredDebuff": {
-            "debuffType": "defense",
-            "debuffRate": 0.08,
-            "probability": 0.3,
-            "duration": 2
+        "effects": [
+          {
+            "type": "BURN",
+            "rate": 0.1,
+            "level": 2,
+            "triggeredDebuff": {
+              "debuffType": "defense",
+              "debuffRate": 0.08,
+              "probability": 0.3,
+              "duration": 2
+            }
           }
-        }
+        ]
       },
       "others": [
         {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Alteration refactor**: update buff/debuff parsing to use the unified `alterations` field (replaces deprecated `buffs`/`debuffs` fields from `AlterationReport` refactor in #290)
- **Stunt support**: add stunt icon (`💫`) and color token so the new Kaelion status displays correctly in the event log and card panel
- **Shield mechanic**: full support for `shield_applied`, `shield_broken`, `shield_expired` events — tracks shield state per card, shows shield points on card panel, and renders rich event details in the event card

## Test plan

- [ ] Load a fight result containing buff/debuff steps — verify they render with correct values (no empty rows)
- [ ] Load a fight result with a card that receives a stunt status — verify `💫 stunt` badge appears in the card panel
- [ ] Load a fight result with Kaelion's shield special — verify shield points show on the card panel after `shield_applied`, disappear on `shield_broken` or `shield_expired`
- [ ] Verify `shield_applied` event card shows targets and point values
- [ ] Verify `shield_broken` / `shield_expired` event cards render correctly

Closes #293

https://claude.ai/code/session_01JjCLBCjpHDTSnoNZangJkE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjCLBCjpHDTSnoNZangJkE)_