### PR TITLE
fix(dto): replace @IsEnum with @IsIn for polarity field validation

### DIFF
--- a/src/fight/http-api/dto/fight-data.dto.ts
+++ b/src/fight/http-api/dto/fight-data.dto.ts
@@ -13,6 +13,7 @@ import {
   ValidateIf,
   Min,
   IsNotIn,
+  IsIn,
   ValidatorConstraint,
   ValidatorConstraintInterface,
   ValidationArguments,
@@ -176,7 +177,7 @@ class StatAlterationDto {
   })
   targetingStrategy: TargetingStrategy;
 
-  @IsEnum(['buff', 'debuff'])
+  @IsIn(['buff', 'debuff'])
   polarity: 'buff' | 'debuff';
 
   @IsOptional()
@@ -376,7 +377,7 @@ export class OtherSkillDto {
 
   @ValidateIf((o) => o.kind === SkillKind.ALTERATION)
   @IsDefined()
-  @IsEnum(['buff', 'debuff'])
+  @IsIn(['buff', 'debuff'])
   polarity?: 'buff' | 'debuff';
 
   @IsOptional()

--- a/test/fight/simulate-buffs.e2e-spec.ts
+++ b/test/fight/simulate-buffs.e2e-spec.ts
@@ -320,7 +320,9 @@ describe('Simulate fight with buffs', () => {
       .expect(200)
       .then((res) => {
         const steps = Object.values(res.body);
-        const expiredStep = steps.find((s: any) => s.kind === 'debuff_expired') as any;
+        const expiredStep = steps.find(
+          (s: any) => s.kind === 'debuff_expired',
+        ) as any;
         expect(expiredStep).toMatchObject({
           kind: 'debuff_expired',
           expired: [{ kind: 'defense', value: 30 }],


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `@IsEnum(['buff', 'debuff'])` was incorrectly used — `@IsEnum()` expects a TypeScript enum object, not an array
- When passed an array, class-validator treats it as `{ 0: 'buff', 1: 'debuff' }` and silently accepts `'0'`, `'1'`, `0`, `1` as valid values
- Replaced both occurrences in `fight-data.dto.ts` with `@IsIn(['buff', 'debuff'])` which correctly validates against a plain array
- Added `IsIn` to the `class-validator` imports

Closes #317

## Test plan

- [ ] Verify the API rejects `polarity: '0'` and `polarity: 1` with a 400 error
- [ ] Verify the API still accepts `polarity: 'buff'` and `polarity: 'debuff'`
- [ ] Run `npm run test:e2e` to confirm no regression

https://claude.ai/code/session_01QVjAzrhaJ6YBRgbRMkL4Sf
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVjAzrhaJ6YBRgbRMkL4Sf)_