### PR TITLE
fix(controller): add missing polarity guard in ALTERATION skill case

### DIFF
--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -362,6 +362,9 @@ export class FightController {
         if (!skillData.buffType) {
           throw new Error('Alteration skill requires buffType');
         }
+        if (!skillData.polarity) {
+          throw new Error('Alteration skill requires polarity');
+        }
         const alterationCondition = skillData.activationCondition
           ? buildAlterationCondition(skillData.activationCondition.type, {
               allyName: skillData.activationCondition.allyName,


### PR DESCRIPTION
## Summary

- Adds a missing `polarity` guard in the `SkillKind.ALTERATION` case of `fight.controller.ts`
- Throws early (`'Alteration skill requires polarity'`) when `polarity` is undefined, preventing silent propagation of `undefined` to the domain constructor
- Follows the project rule: **no silent error, throw early**

## Test plan

- [ ] All 589 existing tests pass (`npx jest`)
- [ ] Manually verify a request without `polarity` on an ALTERATION skill returns a clear 500 error

Closes #318

https://claude.ai/code/session_0141dwqE3JrQBHF67NimjzxC

---
_Generated by [Claude Code](https://claude.ai/code/session_0141dwqE3JrQBHF67NimjzxC)_