### PR TITLE
feat(007): Kaelion Link Skill — Salamander Tears

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
 # card-game Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-16
+Auto-generated from all feature plans. Last updated: 2026-05-18
 
 ## Active Technologies
+
 - N/A — stateless in-memory simulator (007-survive-skill)
 
 - N/A (stateless in-memory simulator) (003-composite-power)
@@ -26,6 +27,9 @@ npm test && npm run lint
 TypeScript on Node.js 26: Follow standard conventions
 
 ## Recent Changes
+
+- 008-link-skill-salamander: Added TypeScript on Node.js 26 + NestJS 11, class-validator, class-transformer
+
 - 007-survive-skill: Added TypeScript on Node.js 26 + NestJS 11, class-validator, class-transformer
 
 - 006-dynamic-skill-trigger: Added TypeScript on Node.js 26 + NestJS 11, class-validator, class-transformer

--- a/samples/cards.json
+++ b/samples/cards.json
@@ -262,6 +262,54 @@
           "duration": 1,
           "targetingStrategy": "self",
           "polarity": "buff"
+        },
+        {
+          "kind": "CONDITIONAL_ATTACK",
+          "name": "Larmes de la salamandre",
+          "event": "ally-health-below",
+          "targetCardId": "arionis",
+          "activationCondition": {
+            "type": "health-threshold",
+            "operator": "below",
+            "threshold": 0.3
+          },
+          "damages": [{ "type": "FIRE", "rate": 2.0 }],
+          "targetingStrategy": "last-attacker-of-ally",
+          "powerId": "salamander-tears"
+        },
+        {
+          "kind": "ALTERATION",
+          "name": "Larmes de la salamandre",
+          "event": "ally-health-below",
+          "targetCardId": "arionis",
+          "activationCondition": {
+            "type": "health-threshold",
+            "operator": "below",
+            "threshold": 0.3
+          },
+          "polarity": "buff",
+          "buffType": "attack",
+          "rate": 0.1,
+          "duration": 5,
+          "targetingStrategy": "linked-ally",
+          "powerId": "salamander-tears"
+        },
+        {
+          "kind": "ALTERATION",
+          "name": "Larmes de la salamandre",
+          "event": "ally-health-below",
+          "targetCardId": "arionis",
+          "activationCondition": {
+            "type": "health-threshold",
+            "operator": "below",
+            "threshold": 0.3
+          },
+          "polarity": "buff",
+          "buffType": "defense",
+          "rate": 0.2,
+          "duration": 5,
+          "targetingStrategy": "linked-ally",
+          "powerId": "salamander-tears"
         }
       ]
     },

--- a/specs/007-link-skill-salamander/checklists/requirements.md
+++ b/specs/007-link-skill-salamander/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Kaelion Link Skill - Salamander Tears
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All clarifications resolved via user input (2026-05-18):
+  - Q1: Last attacker dead when skill fires → explosion skipped, buffs still apply
+  - Q2: No prior attacker recorded → explosion skipped, buffs still apply
+  - Q3: Buff duration → permanent (no turn limit, no termination event)
+- Spec is ready for `/speckit.plan`.

--- a/specs/007-link-skill-salamander/contracts/link-skill-dto.md
+++ b/specs/007-link-skill-salamander/contracts/link-skill-dto.md
@@ -1,0 +1,161 @@
+# Contract: Link Skill DTO (Salamander Tears)
+
+## Context
+
+Kaelion's "Salamander Tears" skill is configured as **3 separate skills** inside `FightingCardDto.skills.others[]`, all linked via `powerId`. This approach reuses the existing kinds (`CONDITIONAL_ATTACK` and `ALTERATION`) with a new event type.
+
+## Full Configuration
+
+```json
+{
+  "skills": {
+    "others": [
+      {
+        "kind": "CONDITIONAL_ATTACK",
+        "name": "Salamander Tears",
+        "event": "ally-health-below",
+        "targetCardId": "arionis-uuid",
+        "activationCondition": {
+          "type": "health-threshold",
+          "operator": "below",
+          "threshold": 0.3
+        },
+        "damages": [{ "type": "FIRE", "rate": 2.0 }],
+        "targetingStrategy": "last-attacker-of-ally",
+        "powerId": "salamander-tears"
+      },
+      {
+        "kind": "ALTERATION",
+        "name": "Salamander Tears",
+        "event": "ally-health-below",
+        "targetCardId": "arionis-uuid",
+        "activationCondition": {
+          "type": "health-threshold",
+          "operator": "below",
+          "threshold": 0.3
+        },
+        "polarity": "buff",
+        "buffType": "attack",
+        "rate": 0.1,
+        "duration": 5,
+        "targetingStrategy": "linked-ally",
+        "powerId": "salamander-tears"
+      },
+      {
+        "kind": "ALTERATION",
+        "name": "Salamander Tears",
+        "event": "ally-health-below",
+        "targetCardId": "arionis-uuid",
+        "activationCondition": {
+          "type": "health-threshold",
+          "operator": "below",
+          "threshold": 0.3
+        },
+        "polarity": "buff",
+        "buffType": "defense",
+        "rate": 0.2,
+        "duration": 5,
+        "targetingStrategy": "linked-ally",
+        "powerId": "salamander-tears"
+      }
+    ]
+  }
+}
+```
+
+## New Enum Values
+
+### TriggerEvent
+
+| Value | Description |
+| --- | --- |
+| `"ally-health-below"` | Fires when the HP of a specific ally (identified by `targetCardId`) drops below the threshold defined in `activationCondition.threshold`. Edge-triggered; rearms when HP recovers above the threshold. |
+
+### TargetingStrategy (new values)
+
+| Value | Applicable to | Description |
+| --- | --- | --- |
+| `"last-attacker-of-ally"` | `CONDITIONAL_ATTACK` with `ally-health-below` | Targets the last enemy that dealt damage to the monitored ally. Returns empty if that enemy is dead or absent. |
+| `"linked-ally"` | `ALTERATION` with `ally-health-below` | Targets the ally specified by `targetCardId`. Searches in the caster's team. Returns empty if dead or absent. |
+
+## Validation Rules
+
+### Required fields when `event: "ally-health-below"`
+
+| Field | Required | Rule |
+| --- | --- | --- |
+| `targetCardId` | Yes | ID of the ally to monitor (extended from ally-death / enemy-death) |
+| `activationCondition` | Yes | Must be `type: "health-threshold"` with `operator` and `threshold` |
+| `activationCondition.threshold` | Yes | Between 0 and 1 |
+
+### Targeting rules
+
+- `"last-attacker-of-ally"` is only valid with `CONDITIONAL_ATTACK` + `ally-health-below`
+- `"linked-ally"` is only valid with `ALTERATION` + `ally-health-below`
+- If `targetCardId` does not match any card in the team, the skill never fires (silent no-op)
+
+### Note on `duration`
+
+For `ALTERATION` skills with `ally-health-below`, `duration: 5` maps directly to 5 turns in the domain. The buff expires after 5 turns via the standard `decreaseBuffAndDebuffDuration()` mechanism.
+
+## Fight Log Output
+
+### Full trigger (last attacker alive)
+
+```json
+{
+  "5": {
+    "kind": "attack",
+    "name": "Salamander Tears",
+    "attacker": { "id": "kaelion-uuid", "name": "Kaelion", "deckIdentity": "player1-0" },
+    "damages": [
+      {
+        "defender": { "id": "enemy-uuid", "name": "Enemy", "deckIdentity": "player2-0" },
+        "damage": 350,
+        "isCritical": false,
+        "dodge": false,
+        "remainingHealth": 150,
+        "kind": ["FIRE"]
+      }
+    ],
+    "energy": 2,
+    "powerId": "salamander-tears"
+  },
+  "6": {
+    "kind": "buff",
+    "name": "Salamander Tears",
+    "source": { "id": "kaelion-uuid", "name": "Kaelion", "deckIdentity": "player1-0" },
+    "alterations": [
+      {
+        "target": { "id": "arionis-uuid", "name": "Arionis", "deckIdentity": "player1-1" },
+        "kind": "attack",
+        "value": 21,
+        "remainingTurns": 5
+      }
+    ],
+    "energy": 2,
+    "powerId": "salamander-tears"
+  },
+  "7": {
+    "kind": "buff",
+    "name": "Salamander Tears",
+    "source": { "id": "kaelion-uuid", "name": "Kaelion", "deckIdentity": "player1-0" },
+    "alterations": [
+      {
+        "target": { "id": "arionis-uuid", "name": "Arionis", "deckIdentity": "player1-1" },
+        "kind": "defense",
+        "value": 40,
+        "remainingTurns": 5
+      }
+    ],
+    "energy": 2,
+    "powerId": "salamander-tears"
+  }
+}
+```
+
+> `remainingTurns: 5` decrements each turn via the standard buff duration mechanism; the buff expires after 5 turns.
+
+### Explosion skipped (last attacker dead or absent)
+
+Only the buff steps (6 and 7 in the example above) appear.

--- a/specs/007-link-skill-salamander/data-model.md
+++ b/specs/007-link-skill-salamander/data-model.md
@@ -1,0 +1,176 @@
+# Data Model: Kaelion Link Skill - Salamander Tears
+
+## New Domain Concepts
+
+### AllyHealthBelowThresholdTrigger (class)
+
+Implements `ActivatableTrigger`. Edge-triggered: fires once when a specific ally's HP drops below a threshold, rearms when HP recovers above it.
+
+| Field / Method | Type | Description |
+| --- | --- | --- |
+| `id` | `'ally-health-below-threshold'` | Stable trigger identity |
+| `monitoredAllyId` | `string` | ID of the ally card to watch |
+| `threshold` | `number` | HP ratio that triggers the skill (e.g. `0.3` for 30%) |
+| `lastAttackerStrategy` | `LastAttackerOfAllyTargetingStrategy?` | Shared instance with the attack skill (optional — not used by buff skills) |
+| *(private)* `wasAboveThreshold` | `boolean` | Arm state: `true` = above threshold, ready to fire |
+| *(private)* `shouldFire` | `boolean` | Set to `true` only on a downward crossing detected in `activate()` |
+
+**State transitions** (inside `activate(triggerId, context)`):
+
+```
+If triggerId does not match ally  → return (no-op)
+Resolve ally from context.sourcePlayer.allCards
+nowBelow = ally.healthRatio < threshold
+
+Case 1: wasAboveThreshold=true  && nowBelow=true  → shouldFire=true,  wasAboveThreshold=false
+                                                      (+ update lastAttackerStrategy)
+Case 2: !nowBelow                                 → shouldFire=false, wasAboveThreshold=true
+Case 3: wasAboveThreshold=false && nowBelow=true  → shouldFire=false  (already below, no re-fire)
+```
+
+**Event ID format**: `ally-health-${monitoredAllyId}` — dispatched by `ActionStage`.
+
+---
+
+### LastAttackerOfAllyTargetingStrategy (class)
+
+Implements `TargetingCardStrategy`. Targets the enemy card that most recently hit the monitored ally.
+
+| Field / Method | Type | Description |
+| --- | --- | --- |
+| `id` | `'last-attacker-of-ally'` | Strategy identity |
+| `setLastAttacker(card)` | method | Updated by the trigger on threshold crossing |
+| `targetedCards(...)` | method | Returns `[lastAttacker]` if alive, otherwise `[]` |
+
+**Sharing**: one instance is created in the controller factory and injected into both `AllyHealthBelowThresholdTrigger` and the `SimpleAttack` inside `ConditionalAttack`.
+
+---
+
+### AlliedCardByIdStrategy (class)
+
+Implements `TargetingCardStrategy`. Mirror of `TargetedCard` but searches `sourcePlayer` (ally) instead of `opponentPlayer` (enemy).
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `'allied-card-by-id'` | Strategy identity |
+| `allyId` | `string` | ID of the allied card to target |
+
+`targetedCards(_source, sourcePlayer, _opponentPlayer)`: finds `sourcePlayer.allCards.find(c => c.id === allyId)`. Returns `[]` if absent or dead.
+
+---
+
+## Modified Domain Concepts
+
+### FightingContext (extended)
+
+One new optional field:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `lastAttacker?` | `FightingCard` | Enemy card that just hit the ally. Populated by `ActionStage` when dispatching `ally-health-<id>`. |
+
+Same pattern as the existing `killerCard` — situational context passed to a trigger via `activate()`.
+
+---
+
+### ConditionalAttack (minimal changes)
+
+Two additions only — constructor signature is unchanged:
+
+1. **`AlwaysTrueAttackCondition`** (new file alongside existing condition implementations):
+   ```typescript
+   export class AlwaysTrueAttackCondition implements AttackCondition {
+     isTriggered(): boolean { return true; }
+     tick(): void {}
+     reset(): void {}
+   }
+   ```
+   The controller factory passes `new AlwaysTrueAttackCondition()` as the condition for Salamander Tears. No existing usages or tests are affected.
+
+2. **`activate()` method**: identical delegation pattern to `AlterationSkill` — calls `(this.trigger as ActivatableTrigger).activate(triggerId, context)` if the trigger implements it.
+
+---
+
+## Composition in the Controller
+
+For Kaelion's "Salamander Tears" skill, the factory creates **3 skills** inside `others`:
+
+```
+Skill 1: ConditionalAttack
+  └─ name: "Salamander Tears"
+  └─ attackSkill: SimpleAttack(name, [{FIRE, 2.0}], lastAttackerStrategy)
+  └─ trigger: AllyHealthBelowThresholdTrigger(arionisId, 0.3, lastAttackerStrategy)
+  └─ condition: none (omitted)
+  └─ powerId: "salamander-tears"
+
+Skill 2: AlterationSkill (attack buff)
+  └─ polarity: 'buff', type: 'attack', rate: 0.1, duration: 5
+  └─ trigger: AllyHealthBelowThresholdTrigger(arionisId, 0.3)
+  └─ targetingStrategy: AlliedCardByIdStrategy(arionisId)
+  └─ powerId: "salamander-tears"
+
+Skill 3: AlterationSkill (defense buff)
+  └─ polarity: 'buff', type: 'defense', rate: 0.2, duration: 5
+  └─ trigger: AllyHealthBelowThresholdTrigger(arionisId, 0.3)
+  └─ targetingStrategy: AlliedCardByIdStrategy(arionisId)
+  └─ powerId: "salamander-tears"
+```
+
+`lastAttackerStrategy` is a **shared instance** between Skill 1 and its trigger.  
+Each skill owns its **own trigger instance** (independent `wasAboveThreshold` state).
+
+---
+
+## Dispatch in ActionStage
+
+After each non-dodged hit in `handleAttackResult()`:
+
+```typescript
+if (!damageDealt.dodge) {
+  const damagedCardPlayer = this.player1.ownCard(defensiveCard) ? this.player1 : this.player2;
+  const attackerPlayer = damagedCardPlayer === this.player1 ? this.player2 : this.player1;
+  const allyHealthContext: FightingContext = {
+    sourcePlayer: damagedCardPlayer,
+    opponentPlayer: attackerPlayer,
+    lastAttacker: attackerCard,
+  };
+  damagedCardPlayer.playableCards
+    .filter((c) => c !== defensiveCard)
+    .forEach((caster) => {
+      const results = caster.launchSkills(`ally-health-${defensiveCard.id}`, allyHealthContext);
+      report.statusChanges.push(...skillResultsToSteps(caster, results));
+    });
+}
+```
+
+No changes to `skill-results-to-steps.ts` — results are existing `SkillKind.Attack` and `SkillKind.Buff`.
+
+---
+
+## Fight Log Impact
+
+No new `StepKind`. Existing step kinds are sufficient:
+
+```
+Step N:   { kind: 'attack', name: 'Salamander Tears', attacker: KaelionInfo, damages: [...], powerId: 'salamander-tears' }
+Step N+1: { kind: 'buff',   name: 'Salamander Tears', source: KaelionInfo, alterations: [attack +X on Arionis], powerId: 'salamander-tears' }
+Step N+2: { kind: 'buff',   name: 'Salamander Tears', source: KaelionInfo, alterations: [defense +Y on Arionis], powerId: 'salamander-tears' }
+```
+
+If the explosion is skipped (last attacker dead or absent), only steps N+1 and N+2 appear.
+
+---
+
+## DTO Layer
+
+### New enum values
+
+| Enum | Added value | Description |
+| --- | --- | --- |
+| `TriggerEvent` (DTO) | `ALLY_HEALTH_BELOW = 'ally-health-below'` | HP threshold event on an ally |
+| `TargetingStrategy` (DTO) | `LAST_ATTACKER_OF_ALLY = 'last-attacker-of-ally'` | For the `CONDITIONAL_ATTACK` skill |
+| `TargetingStrategy` (DTO) | `LINKED_ALLY = 'linked-ally'` | For the `ALTERATION` buff skills |
+
+### OtherSkillDto — reused fields
+
+No new DTO field required: `targetCardId` (already present, extended to cover `ALLY_HEALTH_BELOW`) and `activationCondition` (already present for `SHIELD`, reused here for the threshold).

--- a/specs/007-link-skill-salamander/plan.md
+++ b/specs/007-link-skill-salamander/plan.md
@@ -1,0 +1,218 @@
+# Implementation Plan: Kaelion Link Skill - Salamander Tears
+
+**Branch**: `007-link-skill-salamander` | **Date**: 2026-05-19 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/007-link-skill-salamander/spec.md`
+
+## Summary
+
+Implement Kaelion's "Salamander Tears" link skill by building on existing classes. The approach introduces one new trigger type (`AllyHealthBelowThresholdTrigger`) and two new targeting strategies (`LastAttackerOfAllyTargetingStrategy`, `AlliedCardByIdStrategy`). The skill is composed of 3 instances of existing skill classes (`ConditionalAttack` + 2 × `AlterationSkill`), all fired by the same trigger type and grouped by `powerId`. `ActionStage` dispatches an `ally-health-<id>` event after each non-dodged hit.
+
+## Technical Context
+
+**Language/Version**: TypeScript on Node.js 26  
+**Primary Dependencies**: NestJS 11, class-validator, class-transformer  
+**Storage**: N/A (stateless in-memory simulator)  
+**Testing**: Jest 29, ts-jest, supertest (e2e)  
+**Target Platform**: Linux server (Heroku)  
+**Project Type**: REST web service — single `POST /fight` endpoint  
+**Performance Goals**: No latency regression (stateless, in-memory)  
+**Constraints**: All four quality gates must pass: format → lint → test:cov → build  
+**Scale/Scope**: 3 new files, 5 modified files, no new SkillKind
+
+## Constitution Check
+
+| Principle | Status | Notes |
+| --- | --- | --- |
+| I. Domain Isolation | ✅ PASS | `AllyHealthBelowThresholdTrigger` and both strategies in `core/`. Factory in `http-api/`. |
+| II. Test-First Development | ✅ PASS (requirement) | Tests written before implementation — see step ordering. |
+| III. Simplicity — No Over-Engineering | ✅ PASS | No new `SkillKind`, no new `Skill` interface, no new `SkillResults`. Reuses `ConditionalAttack` and `AlterationSkill` unchanged. |
+| IV. Fail Fast — No Silent Errors | ✅ PASS | Factory throws on missing `activationCondition` or `targetCardId`. Trigger returns silently if ally is not found in context (card not in team). |
+| V. Eliminate Duplication | ✅ PASS | `AlliedCardByIdStrategy` mirrors the existing `TargetedCard`. `activate()` added to `ConditionalAttack` is an exact copy of the existing `AlterationSkill` pattern. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-link-skill-salamander/
+├── plan.md                ← this file
+├── research.md            ← Phase 0 output
+├── data-model.md          ← Phase 1 output
+├── contracts/
+│   └── link-skill-dto.md  ← Phase 1 output
+└── tasks.md               ← Phase 2 output (/speckit.tasks — not yet created)
+```
+
+### Source Code
+
+```text
+src/fight/core/
+├── cards/@types/
+│   └── fighting-context.ts              ← MODIFY: add lastAttacker?: FightingCard
+├── cards/skills/
+│   └── conditional-attack.ts            ← MODIFY: add activate() method
+├── trigger/
+│   └── ally-health-below-threshold-trigger.ts  ← CREATE
+└── targeting-card-strategies/
+    ├── last-attacker-of-ally.ts         ← CREATE
+    └── allied-card-by-id.ts             ← CREATE
+
+src/fight/card-action/
+└── action-stage.ts                      ← MODIFY: dispatch ally-health-<id> event
+
+src/fight/http-api/
+├── targeting-strategy-factory.ts        ← MODIFY: register 2 new strategies
+├── dto/
+│   └── fight-data.dto.ts                ← MODIFY: new TriggerEvent + TargetingStrategy values
+└── fight.controller.ts                  ← MODIFY: factory case for ally-health-below
+
+test/fight/                              ← MODIFY: add e2e test
+src/fight/core/trigger/__tests__/        ← CREATE: ally-health-below-threshold-trigger.spec.ts
+src/fight/core/targeting-card-strategies/__tests__/  ← CREATE or MODIFY: specs for both new strategies
+```
+
+**Structure Decision**: Single project. New files slot into existing directories (`trigger/`, `targeting-card-strategies/`).
+
+## Implementation Order
+
+### Step 1 — Type-only changes (no logic)
+
+Add `lastAttacker?: FightingCard` to `FightingContext`.  
+*(No test required — type-only change)*
+
+### Step 2 — Unit tests for `AllyHealthBelowThresholdTrigger` (RED)
+
+Write `ally-health-below-threshold-trigger.spec.ts` covering:
+- `isTriggered()` returns `false` before any `activate()` call
+- `activate()` with a non-matching event ID → `isTriggered()` stays `false`
+- First crossing (HP drops below threshold) → `isTriggered()` returns `true`
+- Subsequent hit still below threshold (no new crossing) → `isTriggered()` returns `false`
+- HP recovers above threshold → rearm: next crossing fires again
+- `lastAttackerStrategy.setLastAttacker()` called with `context.lastAttacker` on crossing
+- Ally not found in context → silent no-op
+
+Tests must fail (class does not exist yet).
+
+### Step 3 — Implement `AllyHealthBelowThresholdTrigger` (GREEN)
+
+Create `ally-health-below-threshold-trigger.ts`. All Step 2 tests pass.
+
+### Step 4 — Unit tests for the two new targeting strategies (RED)
+
+`last-attacker-of-ally.spec.ts`:
+- `targetedCards()` returns `[]` if `setLastAttacker(null)` was never called
+- Returns `[card]` after `setLastAttacker(card)` if card is alive
+- Returns `[]` if the targeted card is dead
+
+`allied-card-by-id.spec.ts`:
+- Returns `[card]` if the ally is alive in `sourcePlayer`
+- Returns `[]` if the ally is dead
+- Returns `[]` if the ally is absent from the team
+
+### Step 5 — Implement the two new targeting strategies (GREEN)
+
+Create `last-attacker-of-ally.ts` and `allied-card-by-id.ts`. All Step 4 tests pass.
+
+### Step 6 — Minimal changes to `ConditionalAttack`
+
+No constructor or signature change. Two additions only:
+
+1. **Create `AlwaysTrueAttackCondition`** (new file alongside the other condition implementations):
+   ```typescript
+   export class AlwaysTrueAttackCondition implements AttackCondition {
+     isTriggered(): boolean { return true; }
+     tick(): void {}
+     reset(): void {}
+   }
+   ```
+
+2. **Add `activate()`** to `ConditionalAttack` (exact copy of the `AlterationSkill` pattern):
+   ```typescript
+   activate(triggerId: string, context: FightingContext): void {
+     if ('activate' in this.trigger) {
+       (this.trigger as ActivatableTrigger).activate(triggerId, context);
+     }
+   }
+   ```
+
+The controller factory passes `new AlwaysTrueAttackCondition()` as the condition for Salamander Tears. No existing usages or tests are affected.
+
+### Step 7 — Wiring in `ActionStage`
+
+In `handleAttackResult()`, after the shield-broken check and before the dead/alive branch split, add:
+
+```typescript
+if (!damageDealt.dodge) {
+  const damagedCardPlayer = this.player1.ownCard(defensiveCard) ? this.player1 : this.player2;
+  const attackerPlayer = damagedCardPlayer === this.player1 ? this.player2 : this.player1;
+  const allyHealthContext: FightingContext = {
+    sourcePlayer: damagedCardPlayer,
+    opponentPlayer: attackerPlayer,
+    lastAttacker: attackerCard,
+  };
+  damagedCardPlayer.playableCards
+    .filter((c) => c !== defensiveCard)
+    .forEach((caster) => {
+      const results = caster.launchSkills(`ally-health-${defensiveCard.id}`, allyHealthContext);
+      report.statusChanges.push(...skillResultsToSteps(caster, results));
+    });
+}
+```
+
+No changes to `skillResultsToSteps` — results are existing `SkillKind.Attack` and `SkillKind.Buff`.
+
+### Step 8 — DTO + factory
+
+**`fight-data.dto.ts`**:
+- Add `ALLY_HEALTH_BELOW = 'ally-health-below'` to `TriggerEvent`
+- Add `LAST_ATTACKER_OF_ALLY = 'last-attacker-of-ally'` to `TargetingStrategy`
+- Add `LINKED_ALLY = 'linked-ally'` to `TargetingStrategy`
+- Extend `@ValidateIf` on `targetCardId` to include `ALLY_HEALTH_BELOW`
+- Require `activationCondition` when `event === ALLY_HEALTH_BELOW`
+
+**`targeting-strategy-factory.ts`**:
+- Add `LAST_ATTACKER_OF_ALLY` and `LINKED_ALLY` entries (note: these cannot be singletons — see controller note below)
+
+**`fight.controller.ts`**:
+- `CONDITIONAL_ATTACK` case: if `event === ALLY_HEALTH_BELOW`, bypass `buildTriggerForSkill()` and manually create the shared `lastAttackerStrategy` + trigger + `SimpleAttack`
+- `ALTERATION` case: if `event === ALLY_HEALTH_BELOW`, create `AllyHealthBelowThresholdTrigger` (without `lastAttackerStrategy`) + `AlliedCardByIdStrategy(skillData.targetCardId)`
+- Throw on missing `activationCondition` or `targetCardId` for both cases
+
+### Step 9 — E2E test
+
+Add a test in `test/fight/` verifying:
+- Kaelion + Arionis on the same team: when Arionis drops below 30% HP, Salamander Tears steps appear immediately after that damage step in the fight log
+- The attack step targets the correct last attacker (the enemy that most recently hit Arionis)
+- Two buff steps appear on Arionis (`attack` and `defense`), both with the same `powerId`
+- No re-trigger on subsequent hits while Arionis remains below 30%
+- No Salamander Tears steps when Arionis is absent from Kaelion's team
+
+### Step 10 — Quality gates
+
+```bash
+npm run format && npm run lint && npm run test:cov && npm run build
+```
+
+All four must be green before the branch is ready for review.
+
+## Key Design Decisions
+
+### `ConditionalAttack` constructor unchanged
+
+The constructor signature `(name, attackSkill, condition, trigger)` is not modified. The controller factory passes `new AlwaysTrueAttackCondition()` as the condition for Salamander Tears. No existing usages or tests require updates.
+
+### Shared `LastAttackerOfAllyTargetingStrategy` instance
+
+Created in the controller factory and injected into both the trigger and the `SimpleAttack`. The trigger calls `strategy.setLastAttacker(context.lastAttacker)` on threshold crossing. The `SimpleAttack` reads it via `targetedCards()`. Minimal coupling — the strategy is the single shared state.
+
+### Separate trigger instances per skill
+
+Each `ConditionalAttack` / `AlterationSkill` owns its own trigger instance. The `wasAboveThreshold` and `shouldFire` state is independent per skill. All three detect the same crossing simultaneously (same Arionis HP, same threshold). This avoids the double-reset bug that would occur with a shared trigger (`launchSkills()` calls `activate()` on each skill sequentially).
+
+### Buff duration: 5 turns
+
+`applyBuff(type, rate, 5, undefined, powerId)`. The buff expires after 5 turns via the standard `decreaseBuffAndDebuffDuration()` mechanism. The DTO passes `duration: 5` directly to the domain — no special mapping required.
+
+## Complexity Tracking
+
+*No constitution violations. No complexity justification needed.*

--- a/specs/007-link-skill-salamander/research.md
+++ b/specs/007-link-skill-salamander/research.md
@@ -1,0 +1,84 @@
+# Research: Kaelion Link Skill - Salamander Tears
+
+## Q1 — How to model the ally-health trigger without creating a new Skill interface?
+
+**Decision**: Create a new `AllyHealthBelowThresholdTrigger` implementing `ActivatableTrigger`. Reuse `ConditionalAttack` and `AlterationSkill` unchanged.
+
+**Rationale**: Triggering logic belongs in the `Trigger`, not in the `Skill`. All existing skills (`ConditionalAttack`, `AlterationSkill`) can change behavior simply by swapping their trigger. No new skill class is needed — only a new trigger type, which is the natural extension point of the current design (`DeathTrigger`, `DynamicTrigger` follow this same pattern).
+
+**Alternatives rejected**:
+- `AllyHealthReactiveSkill` interface + composite `SalamanderTearsSkill`: too many new concepts for a single skill. The trigger is the correct extension point.
+- Encoding the threshold detection directly in `ActionStage`: mixes triggering logic with orchestration logic.
+
+---
+
+## Q2 — How to pass `lastAttacker` to the trigger at activation time?
+
+**Decision**: Add `lastAttacker?: FightingCard` to `FightingContext`. `ActionStage` populates this field when dispatching the `ally-health-<id>` event after each non-dodged hit. `AllyHealthBelowThresholdTrigger.activate()` reads `context.lastAttacker` and updates `LastAttackerOfAllyTargetingStrategy`.
+
+**Rationale**: `FightingContext.killerCard` already passes situational context to `DynamicTrigger`. `lastAttacker` follows the exact same pattern — situational context that a trigger must be able to read during `activate()`.
+
+**Alternatives rejected**:
+- Storing the last attacker on `FightingCard` (Arionis): exposes a skill implementation detail on the domain entity.
+- Injecting the Arionis card reference into the trigger at construction time: requires a two-pass creation (create all cards, then rewire skills) in the controller.
+
+---
+
+## Q3 — How does the trigger know Arionis' HP without a direct card reference?
+
+**Decision**: The trigger stores `monitoredAllyId` (string). In `activate(triggerId, context)`, it resolves the ally via `context.sourcePlayer.allCards.find(c => c.id === monitoredAllyId)`. The HP has already been updated by the time `activate()` is called.
+
+**Rationale**: Avoids a two-pass construction in the controller. Resolution via context mirrors the pattern used by `TargetedCard` and `DynamicTrigger` (which use `context.killerCard`). The ally is always in `sourcePlayer` because `ActionStage` builds the context from the caster's (Kaelion's) perspective.
+
+---
+
+## Q4 — How is `LastAttackerOfAllyTargetingStrategy` shared between the trigger and the attack skill?
+
+**Decision**: In the controller factory, for `CONDITIONAL_ATTACK` with event `ALLY_HEALTH_BELOW`, manually create a shared `LastAttackerOfAllyTargetingStrategy` instance, inject it into both the trigger and the `SimpleAttack`. The trigger calls `strategy.setLastAttacker(context.lastAttacker)` on threshold crossing.
+
+**Rationale**: The factory is the right place for this wiring. It mirrors what the existing factory already does for `TARGETING_OVERRIDE` with `targeted-card` — it creates the `TargetedCard` strategy in a non-standard way. Same pattern here.
+
+**Alternatives rejected**:
+- Sharing one trigger instance across all 3 skills: `launchSkills()` calls `activate()` sequentially on each skill — the same shared trigger would receive 3 `activate()` calls, resetting `shouldFire` to `false` on the 2nd call. Incorrect behavior.
+- Resolving the target inside `ConditionalAttack.launch()` via context: `AttackSkill.launch()` does not receive `lastAttacker` explicitly; would require changing the `TargetingCardStrategy` interface to accept context, impacting the entire system.
+
+---
+
+## Q5 — How to target Arionis specifically for the buffs?
+
+**Decision**: Create `AlliedCardByIdStrategy(allyId: string)` — same pattern as `TargetedCard` but searches `sourcePlayer.allCards` instead of `opponentPlayer`. Returns `[]` if card is dead or absent.
+
+**Rationale**: `TargetedCard` targets an enemy by ID. `AlliedCardByIdStrategy` targets an ally by ID. Minimal duplication — two mirror classes with one difference: `sourcePlayer` vs `opponentPlayer`.
+
+---
+
+## Q6 — How does `ConditionalAttack` support the new pattern?
+
+**Decision**: Two minimal changes to `ConditionalAttack`:
+1. Make `AttackCondition` optional (if absent, always `true`)
+2. Add `activate()` delegating to the trigger if it implements `ActivatableTrigger` — same pattern as `AlterationSkill`
+
+**Rationale**: For Salamander Tears, the condition IS the trigger (threshold crossing). No `EveryNTurnsCondition` needed. Making the condition optional avoids a useless `AlwaysTrueAttackCondition` class. Adding `activate()` is an exact copy of what `AlterationSkill` already does.
+
+---
+
+## Q7 — Where in `ActionStage` to dispatch the ally-health event?
+
+**Decision**: In `handleAttackResult()`, after the shield-broken check and BEFORE the dead/alive branch split, if `!damageDealt.dodge`: dispatch `ally-health-${defensiveCard.id}` to all living cards on the same team as the damaged card (excluding the damaged card itself), with `lastAttacker = attackerCard` in the context.
+
+**Rationale**: Must fire even if Arionis dies from the hit (spec edge case: "death below 30% counts as threshold crossing"). Dispatching before the dead/alive split covers both cases. The `!damageDealt.dodge` guard is correct — a dodge produces no HP change.
+
+---
+
+## Q8 — Do the 3 separate trigger instances all detect the crossing correctly?
+
+**Decision**: Yes. Each skill owns its own `AllyHealthBelowThresholdTrigger` instance with independent `wasAboveThreshold` state. They all read the same Arionis HP during `activate()`. They all detect the same crossing simultaneously. `shouldFire` is reset to `false` in the non-crossing branches of `activate()`.
+
+**Trigger state after each `activate(triggerId, context)` call**:
+
+```
+First hit BELOW threshold:              shouldFire=true,  wasAboveThreshold=false
+Subsequent hits BELOW threshold:        shouldFire=false  (else branch — already below, no re-fire)
+Hit bringing HP ABOVE threshold:        shouldFire=false, wasAboveThreshold=true  (rearm)
+Next hit BELOW threshold (2nd crossing): shouldFire=true  ← fires again correctly
+```

--- a/specs/007-link-skill-salamander/spec.md
+++ b/specs/007-link-skill-salamander/spec.md
@@ -1,0 +1,106 @@
+# Feature Specification: Kaelion Link Skill - Salamander Tears
+
+**Feature Branch**: `007-link-skill-salamander`  
+**Created**: 2026-05-18  
+**Status**: Draft  
+**Input**: https://github.com/cegerard/card-game/issues/328
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Ally-Health Conditional Trigger (Priority: P1)
+
+A game developer configures Kaelion with the "Salamander Tears" skill, specifying Arionis as the linked ally. When a battle simulation runs with both Kaelion and Arionis in the same team, and Arionis' HP drops below 30%, the system automatically triggers Kaelion's link skill. The skill fires exactly once per threshold crossing (edge-triggered) and does not fire again unless Arionis recovers above 30% and drops below again.
+
+**Why this priority**: This is the core activation mechanism of the entire link skill. Without it, the other components cannot function. It defines a new category of skill trigger — monitoring an ally's health rather than reacting to the card's own state or a turn event.
+
+**Independent Test**: Configure a battle with Kaelion (Salamander Tears skill linked to Arionis) and Arionis in the same deck. Have an enemy deal enough damage to bring Arionis below 30% HP. Verify that the Salamander Tears sequence appears in the fight log exactly once at that moment, and does not repeat on subsequent damage while Arionis remains below 30%.
+
+**Acceptance Scenarios**:
+
+1. **Given** Kaelion and Arionis are both in the team, **When** Arionis' HP drops below 30% for the first time, **Then** the Salamander Tears skill triggers and its steps appear immediately after the HP-crossing event in the fight log.
+2. **Given** Arionis is already below 30% HP, **When** Arionis takes additional damage, **Then** the Salamander Tears skill does NOT trigger again.
+3. **Given** Arionis' HP crossed below 30% and then was healed back above 30%, **When** Arionis takes damage and drops below 30% again, **Then** the Salamander Tears skill triggers a second time.
+4. **Given** Arionis is NOT present in the team, **When** a battle is simulated with Kaelion only, **Then** the Salamander Tears skill does not exist / cannot fire.
+5. **Given** Kaelion is dead before Arionis drops below 30%, **When** Arionis' HP crosses the threshold, **Then** the skill does NOT trigger (dead cards cannot act).
+
+---
+
+### User Story 2 - Massive Explosion: Fire Attack on Last Attacker (Priority: P2)
+
+When Salamander Tears triggers, Kaelion unleashes a fire-based attack dealing 200% of his attack stat as fire-type damage against the enemy who most recently damaged Arionis.
+
+**Why this priority**: This is the primary offensive component of the skill. It delivers the combat impact and tests a new targeting concept — resolving the "last attacker" of a specific ally — which is the main mechanical novelty.
+
+**Independent Test**: Configure a battle where enemy card A attacks Arionis first and enemy card B attacks Arionis last before the threshold is crossed. Verify that only card B receives the 200% fire damage from Kaelion's Salamander Tears explosion.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple enemies have attacked Arionis, **When** Salamander Tears fires, **Then** the fire damage targets only the enemy card that most recently dealt damage to Arionis.
+2. **Given** Salamander Tears fires, **When** the explosion step is emitted, **Then** it shows fire-type damage equal to 200% of Kaelion's attack stat, applied against the last attacker's element resistances.
+3. **Given** the last enemy who attacked Arionis has already died, **When** Salamander Tears fires, **Then** the Massive Explosion step is skipped and only the Power Transfer buffs are applied.
+4. **Given** no enemy has yet attacked Arionis when the threshold is crossed, **When** Salamander Tears fires, **Then** the Massive Explosion step is skipped and only the Power Transfer buffs are applied.
+
+---
+
+### User Story 3 - Power Transfer: Buff Arionis (Priority: P3)
+
+After the fire explosion, Kaelion applies a +10% attack buff and a +20% defense buff specifically to Arionis, both associated with the "Salamander Tears" event name so they can be referenced or removed by event-bound mechanisms.
+
+**Why this priority**: This is the support component of the skill that reinforces the narrative of Kaelion protecting and empowering his brother. It reuses existing buff mechanics and depends on the trigger already established in Story 1.
+
+**Independent Test**: Configure a battle where Arionis drops below 30% HP (triggering Salamander Tears). Verify that two buff steps appear in the fight log after the explosion step: one granting Arionis +10% attack and one granting +20% defense, both tagged with the "Salamander Tears" event.
+
+**Acceptance Scenarios**:
+
+1. **Given** Salamander Tears triggers, **When** the buff steps are emitted, **Then** Arionis receives an attack buff of +10% and a defense buff of +20%, and both are tagged with the "Salamander Tears" event name.
+2. **Given** Arionis is dead when the buff step would apply, **When** the buff step is processed, **Then** the buff is skipped (no dead-card buff).
+3. **Given** the buffs last 3 turns, **When** five turns passed, **Then** the buffs are removed.
+
+---
+
+### Edge Cases
+
+- What happens if Arionis and Kaelion are on opposing teams? The skill requires Arionis as a team ally; placing him on the enemy side MUST not activate the link.
+- What if Arionis takes damage that kills him exactly at the 30% boundary in the same hit that would trigger the skill? The trigger condition is crossing below 30%; death below 30% should still be considered a threshold crossing for trigger evaluation, but Kaelion cannot buff a dead Arionis.
+- What if Kaelion himself deals the last hit of damage to Arionis (e.g., via splash or AOE)? This would be a self-team damage edge case — Kaelion is an ally, not an enemy, so ally-sourced damage should not be tracked as "last attacker" for explosion targeting.
+- What if multiple cards deal damage to Arionis in the same resolution step? The system must have a deterministic rule for which counts as "last" (e.g., ordering within the step).
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The "Salamander Tears" skill MUST only activate if the card designated as the linked ally (identified by ID) is present in the same team at battle start.
+- **FR-002**: The skill MUST monitor the linked ally's HP ratio and trigger once when that ratio crosses below a configurable threshold (defaulting to 30%), edge-triggered (one fire per downward crossing).
+- **FR-003**: When triggered, the skill MUST deal fire-type damage equal to 200% of Kaelion's attack stat to the enemy card that most recently damaged the linked ally.
+- **FR-004**: The system MUST track, per card, the identity of the last enemy that dealt damage to it throughout the battle, and expose this information for targeting resolution.
+- **FR-005**: After the fire attack resolves, the skill MUST apply a +10% attack buff and a +20% defense buff to the linked ally.
+- **FR-006**: Both buffs MUST last 5 turns (no termination event), applied directly to Arionis when the skill fires.
+- **FR-007**: The skill MUST be grouped as a composite power (sharing the same `powerId` named "Salamander Tears") so that all its components (attack + buffs) are represented together in the fight log.
+- **FR-008**: The skill MUST NOT trigger if Kaelion is dead at the time the linked ally's HP crosses the threshold.
+- **FR-009**: The skill MUST re-arm after the linked ally's HP recovers above the threshold, enabling a second trigger if HP drops below again later in the battle.
+
+### Key Entities
+
+- **Link Skill**: A composite skill bound to a specific ally card by ID, monitoring that ally's HP rather than the caster's own HP. Combines an ally-HP threshold trigger with a conditional attack and buffing components.
+- **Last Attacker Tracker**: A per-card record of the most recent enemy card that dealt damage to it. Updated on every damage event. Used as the targeting reference for the Massive Explosion component.
+- **Ally-Health Trigger**: A trigger type that evaluates an ally card's HP ratio (rather than self or a game event) and fires on a downward threshold crossing.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A battle simulation with Kaelion + Arionis in the same team completes without errors when Arionis drops below 30% HP, and the Salamander Tears sequence (attack step + two buff steps) appears exactly once in the fight log at that point.
+- **SC-002**: The fire damage step correctly targets the card that last attacked Arionis, verified across at least 3 distinct test scenarios with different attacker sequences.
+- **SC-003**: The Salamander Tears skill does NOT appear in fight logs for battles where Arionis is absent from the team, confirming the ally-presence gate works.
+- **SC-004**: The edge-trigger behavior is verified: the skill fires exactly once per downward HP crossing, and correctly re-arms and fires again if Arionis recovers and drops below 30% a second time.
+- **SC-005**: Both buffs on Arionis are active from the moment Salamander Tears fires until five turn passed, verified by confirming buff expiration in the fight log.
+
+## Assumptions
+
+- Buff duration for the Power Transfer buffs last **five turns** (no termination event): +10% attack and +20% defense remain on Arionis for the next five turns.
+- The "Salamander Tears" label in the issue refers to the `powerId` grouping the skill components for fight log reporting, not a buff termination event.
+- "Last enemy who hurt Arionis" means the most recent enemy card to successfully deal damage (dodge events do not update the tracker).
+- If no enemy has yet attacked Arionis when the threshold is crossed, the Massive Explosion step is skipped and only the buff component fires.
+- If the last attacker of Arionis is already dead when the skill fires, the Massive Explosion step is also skipped.
+- The skill is edge-triggered in the same manner as the existing SHIELD skill: one fire per downward crossing, rearms on upward crossing.
+- The 200% fire damage uses Kaelion's current attack stat (after all active buffs/debuffs) at the moment the skill fires, consistent with how other attack skills compute damage.

--- a/specs/007-link-skill-salamander/tasks.md
+++ b/specs/007-link-skill-salamander/tasks.md
@@ -1,0 +1,164 @@
+# Tasks: Kaelion Link Skill - Salamander Tears
+
+**Input**: Design documents from `/specs/007-link-skill-salamander/`
+**Branch**: `007-link-skill-salamander`
+**Plan**: [plan.md](plan.md) | **Spec**: [spec.md](spec.md)
+
+**Organization**: Tasks follow the test-first order defined in plan.md. Each user story phase is independently testable before moving to the next.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+
+---
+
+## Phase 1: Foundational (Blocking Prerequisites)
+
+**Purpose**: Type extension that all trigger and strategy implementations depend on.
+
+**⚠️ CRITICAL**: Must be complete before any Phase 2+ work.
+
+- [ ] T001 Add `lastAttacker?: FightingCard` to `FightingContext` in `src/fight/core/cards/@types/fighting-context.ts`
+
+**Checkpoint**: Type compiles — all downstream code can reference `context.lastAttacker`.
+
+---
+
+## Phase 2: User Story 1 — Ally-Health Conditional Trigger (Priority: P1) 🎯 MVP
+
+**Goal**: `AllyHealthBelowThresholdTrigger` fires once when an ally's HP crosses below a threshold, rearms on recovery, and dispatches via `ActionStage`.
+
+**Independent Test**: Run `npm test -- ally-health-below-threshold-trigger.spec.ts` — all trigger specs green. Verify `action-stage` integration manually via an e2e payload where Arionis drops below 30% HP.
+
+> **Write tests first (RED), implement second (GREEN)**
+
+- [ ] T002 [US1] Write unit tests (RED) for `AllyHealthBelowThresholdTrigger` covering: `isTriggered()` before any activate, non-matching event ID no-op, first crossing fires, subsequent below-threshold no re-fire, rearm on recovery, `setLastAttacker()` called on crossing, ally absent silent no-op — in `src/fight/core/trigger/__tests__/ally-health-below-threshold-trigger.spec.ts`
+- [ ] T003 [US1] Implement `AllyHealthBelowThresholdTrigger` (implements `ActivatableTrigger`) with `monitoredAllyId`, `threshold`, optional `lastAttackerStrategy`, private `wasAboveThreshold`/`shouldFire` state — in `src/fight/core/trigger/ally-health-below-threshold-trigger.ts`
+- [ ] T004 [US1] Dispatch `ally-health-<id>` events to teammates after each non-dodged hit in `handleAttackResult()` in `src/fight/card-action/action-stage.ts`
+- [ ] T005 [US1] Add `ALLY_HEALTH_BELOW = 'ally-health-below'` to `TriggerEvent` enum, extend `@ValidateIf` on `targetCardId` and `activationCondition` to include `ALLY_HEALTH_BELOW` — in `src/fight/http-api/dto/fight-data.dto.ts`
+
+**Checkpoint**: Trigger unit tests pass. `ActionStage` dispatches the event; skills with a matching trigger can `activate()`.
+
+---
+
+## Phase 3: User Story 2 — Massive Explosion (Priority: P2)
+
+**Goal**: When Salamander Tears triggers, Kaelion fires 200% fire damage at Arionis' last attacker via `ConditionalAttack` + `LastAttackerOfAllyTargetingStrategy`.
+
+**Independent Test**: Run `npm test -- last-attacker-of-ally.spec.ts` — all strategy specs green. Send a fight payload with a `CONDITIONAL_ATTACK` + `ally-health-below` skill and verify the attack step appears in the fight log targeting the correct enemy.
+
+> **Write tests first (RED), implement second (GREEN)**
+
+- [ ] T006 [US2] Write unit tests (RED) for `LastAttackerOfAllyTargetingStrategy` covering: returns `[]` before `setLastAttacker()`, returns `[card]` after `setLastAttacker(card)` if alive, returns `[]` if card is dead — in `src/fight/core/targeting-card-strategies/__tests__/last-attacker-of-ally.spec.ts`
+- [ ] T007 [P] [US2] Create `AlwaysTrueAttackCondition` implementing `AttackCondition` with `isTriggered(): true`, no-op `tick()` and `reset()` — in `src/fight/core/cards/@types/attack/conditions/always-true-attack-condition.ts`
+- [ ] T008 [P] [US2] Add `activate(triggerId, context)` method to `ConditionalAttack` delegating to `(this.trigger as ActivatableTrigger).activate()` when trigger implements `ActivatableTrigger` — in `src/fight/core/cards/skills/conditional-attack.ts`
+- [ ] T009 [US2] Implement `LastAttackerOfAllyTargetingStrategy` with `setLastAttacker(card)` and `targetedCards()` returning `[lastAttacker]` if alive — in `src/fight/core/targeting-card-strategies/last-attacker-of-ally.ts`
+- [ ] T010 [P] [US2] Add `LAST_ATTACKER_OF_ALLY = 'last-attacker-of-ally'` to `TargetingStrategy` enum in `src/fight/http-api/dto/fight-data.dto.ts`
+- [ ] T011 [P] [US2] Register `LastAttackerOfAllyTargetingStrategy` in `src/fight/http-api/targeting-strategy-factory.ts`
+- [ ] T012 [US2] Wire `CONDITIONAL_ATTACK` + `ALLY_HEALTH_BELOW` case in `fight.controller.ts`: create shared `LastAttackerOfAllyTargetingStrategy`, create `AllyHealthBelowThresholdTrigger(targetCardId, threshold, sharedStrategy)`, create `SimpleAttack` using shared strategy, pass `AlwaysTrueAttackCondition`; throw on missing `activationCondition` or `targetCardId` — in `src/fight/http-api/fight.controller.ts`
+
+**Checkpoint**: Explosion unit tests pass. Fight log includes an `attack` step with `powerId: "salamander-tears"` targeting the last attacker when threshold is crossed.
+
+---
+
+## Phase 4: User Story 3 — Power Transfer (Priority: P3)
+
+**Goal**: When Salamander Tears triggers, Arionis receives +10% attack and +20% defense buffs for 5 turns via `AlterationSkill` + `AlliedCardByIdStrategy`.
+
+**Independent Test**: Run `npm test -- allied-card-by-id.spec.ts` — all strategy specs green. Send a fight payload with both `ALTERATION` + `ally-health-below` skills and verify two `buff` steps appear in the fight log on Arionis, both with `powerId: "salamander-tears"`.
+
+> **Write tests first (RED), implement second (GREEN)**
+
+- [ ] T013 [US3] Write unit tests (RED) for `AlliedCardByIdStrategy` covering: returns `[card]` if ally is alive in `sourcePlayer`, returns `[]` if ally is dead, returns `[]` if ally is absent from team — in `src/fight/core/targeting-card-strategies/__tests__/allied-card-by-id.spec.ts`
+- [ ] T014 [US3] Implement `AlliedCardByIdStrategy` searching `sourcePlayer.allCards` by `allyId`, returning `[]` if absent or dead — in `src/fight/core/targeting-card-strategies/allied-card-by-id.ts`
+- [ ] T015 [P] [US3] Add `LINKED_ALLY = 'linked-ally'` to `TargetingStrategy` enum in `src/fight/http-api/dto/fight-data.dto.ts`
+- [ ] T016 [P] [US3] Register `AlliedCardByIdStrategy` in `src/fight/http-api/targeting-strategy-factory.ts`
+- [ ] T017 [US3] Wire `ALTERATION` + `ALLY_HEALTH_BELOW` case in `fight.controller.ts`: create `AllyHealthBelowThresholdTrigger(targetCardId, threshold)` (no shared strategy), use `AlliedCardByIdStrategy(targetCardId)`; throw on missing `activationCondition` or `targetCardId` — in `src/fight/http-api/fight.controller.ts`
+
+**Checkpoint**: Buff unit tests pass. Fight log includes two `buff` steps on Arionis with `remainingTurns: 5` and `powerId: "salamander-tears"` immediately after the threshold crossing.
+
+---
+
+## Phase 5: Polish & Integration
+
+**Purpose**: End-to-end validation and all four quality gates.
+
+- [ ] T018 Write e2e test covering: threshold crossing emits attack + two buff steps in order with same `powerId`; correct last-attacker targeting; no re-trigger while below threshold; no steps when Arionis absent from team — in `test/fight/salamander-tears.e2e-spec.ts`
+- [ ] T019 Run quality gates in order: `npm run format && npm run lint && npm run test:cov && npm run build`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 1)**: No dependencies — start immediately
+- **US1 (Phase 2)**: Depends on Phase 1 — blocks US2 and US3
+- **US2 (Phase 3)**: Depends on Phase 2 (trigger must exist to wire the controller)
+- **US3 (Phase 4)**: Depends on Phase 2 (trigger must exist); independent from US2
+- **Polish (Phase 5)**: Depends on US1 + US2 + US3 all complete
+
+### Within Phase 3 (US2)
+
+```
+T006 (write tests)    ──────────────────────► T009 (implement) ──► T010 ──►
+T007 (AlwaysTrueCond) ─► T008 (activate())                        T011 ──► T012
+```
+
+T007 and T008 can run in parallel with T006 (different files, no shared dependency).  
+T010 and T011 can run in parallel with each other after T009 (different files).
+
+### Within Phase 4 (US3)
+
+```
+T013 (write tests) ──► T014 (implement) ──► T015 ──►
+                                            T016 ──► T017
+```
+
+T015 and T016 can run in parallel with each other after T014.
+
+### Parallel Execution Examples
+
+```bash
+# Phase 3 — Step 1: tests + condition class + activate() method (all independent files)
+Task T006: "Write unit tests for LastAttackerOfAllyTargetingStrategy"
+Task T007: "Create AlwaysTrueAttackCondition"
+Task T008: "Add activate() to ConditionalAttack"
+
+# Phase 3 — Step 2: enum + factory registration (after T009)
+Task T010: "Add LAST_ATTACKER_OF_ALLY to TargetingStrategy enum"
+Task T011: "Register LastAttackerOfAllyTargetingStrategy in factory"
+
+# Phase 4 — Step 2: enum + factory registration (after T014)
+Task T015: "Add LINKED_ALLY to TargetingStrategy enum"
+Task T016: "Register AlliedCardByIdStrategy in factory"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (Foundational)
+2. Complete Phase 2 (US1): trigger + ActionStage dispatch + DTO enum
+3. **Stop and validate**: trigger unit tests green, ActionStage compiles
+4. Proceed to US2 and US3
+
+### Incremental Delivery
+
+1. Phase 1 → Phase 2: Trigger works, event dispatched — core mechanism proven
+2. Phase 3: Explosion works — fight log contains attack step with correct target
+3. Phase 4: Buffs work — complete fight log with all 3 steps under same `powerId`
+4. Phase 5: E2E green, all quality gates pass — branch ready for review
+
+---
+
+## Notes
+
+- [P] tasks touch different files with no incomplete dependencies — safe to run simultaneously
+- All test tasks must be written **and confirmed failing** before implementation begins (TDD red-green cycle)
+- T007 and T008 are both [P] within Phase 3: they can be done in parallel with T006 since none share a file
+- T012 and T017 both modify `fight.controller.ts` — they are in separate phases and must be sequential
+- T010/T015 both modify `fight-data.dto.ts` — they are in separate phases and must be sequential

--- a/specs/007-link-skill-salamander/tasks.md
+++ b/specs/007-link-skill-salamander/tasks.md
@@ -19,7 +19,7 @@
 
 **⚠️ CRITICAL**: Must be complete before any Phase 2+ work.
 
-- [ ] T001 Add `lastAttacker?: FightingCard` to `FightingContext` in `src/fight/core/cards/@types/fighting-context.ts`
+- [x] T001 Add `lastAttacker?: FightingCard` to `FightingContext` in `src/fight/core/cards/@types/fighting-context.ts`
 
 **Checkpoint**: Type compiles — all downstream code can reference `context.lastAttacker`.
 
@@ -33,10 +33,10 @@
 
 > **Write tests first (RED), implement second (GREEN)**
 
-- [ ] T002 [US1] Write unit tests (RED) for `AllyHealthBelowThresholdTrigger` covering: `isTriggered()` before any activate, non-matching event ID no-op, first crossing fires, subsequent below-threshold no re-fire, rearm on recovery, `setLastAttacker()` called on crossing, ally absent silent no-op — in `src/fight/core/trigger/__tests__/ally-health-below-threshold-trigger.spec.ts`
-- [ ] T003 [US1] Implement `AllyHealthBelowThresholdTrigger` (implements `ActivatableTrigger`) with `monitoredAllyId`, `threshold`, optional `lastAttackerStrategy`, private `wasAboveThreshold`/`shouldFire` state — in `src/fight/core/trigger/ally-health-below-threshold-trigger.ts`
-- [ ] T004 [US1] Dispatch `ally-health-<id>` events to teammates after each non-dodged hit in `handleAttackResult()` in `src/fight/card-action/action-stage.ts`
-- [ ] T005 [US1] Add `ALLY_HEALTH_BELOW = 'ally-health-below'` to `TriggerEvent` enum, extend `@ValidateIf` on `targetCardId` and `activationCondition` to include `ALLY_HEALTH_BELOW` — in `src/fight/http-api/dto/fight-data.dto.ts`
+- [x] T002 [US1] Write unit tests (RED) for `AllyHealthBelowThresholdTrigger` covering: `isTriggered()` before any activate, non-matching event ID no-op, first crossing fires, subsequent below-threshold no re-fire, rearm on recovery, `setLastAttacker()` called on crossing, ally absent silent no-op — in `src/fight/core/trigger/__tests__/ally-health-below-threshold-trigger.spec.ts`
+- [x] T003 [US1] Implement `AllyHealthBelowThresholdTrigger` (implements `ActivatableTrigger`) with `monitoredAllyId`, `threshold`, optional `lastAttackerStrategy`, private `wasAboveThreshold`/`shouldFire` state — in `src/fight/core/trigger/ally-health-below-threshold-trigger.ts`
+- [x] T004 [US1] Dispatch `ally-health-<id>` events to teammates after each non-dodged hit in `handleAttackResult()` in `src/fight/card-action/action-stage.ts`
+- [x] T005 [US1] Add `ALLY_HEALTH_BELOW = 'ally-health-below'` to `TriggerEvent` enum, extend `@ValidateIf` on `targetCardId` and `activationCondition` to include `ALLY_HEALTH_BELOW` — in `src/fight/http-api/dto/fight-data.dto.ts`
 
 **Checkpoint**: Trigger unit tests pass. `ActionStage` dispatches the event; skills with a matching trigger can `activate()`.
 
@@ -50,13 +50,13 @@
 
 > **Write tests first (RED), implement second (GREEN)**
 
-- [ ] T006 [US2] Write unit tests (RED) for `LastAttackerOfAllyTargetingStrategy` covering: returns `[]` before `setLastAttacker()`, returns `[card]` after `setLastAttacker(card)` if alive, returns `[]` if card is dead — in `src/fight/core/targeting-card-strategies/__tests__/last-attacker-of-ally.spec.ts`
-- [ ] T007 [P] [US2] Create `AlwaysTrueAttackCondition` implementing `AttackCondition` with `isTriggered(): true`, no-op `tick()` and `reset()` — in `src/fight/core/cards/@types/attack/conditions/always-true-attack-condition.ts`
-- [ ] T008 [P] [US2] Add `activate(triggerId, context)` method to `ConditionalAttack` delegating to `(this.trigger as ActivatableTrigger).activate()` when trigger implements `ActivatableTrigger` — in `src/fight/core/cards/skills/conditional-attack.ts`
-- [ ] T009 [US2] Implement `LastAttackerOfAllyTargetingStrategy` with `setLastAttacker(card)` and `targetedCards()` returning `[lastAttacker]` if alive — in `src/fight/core/targeting-card-strategies/last-attacker-of-ally.ts`
-- [ ] T010 [P] [US2] Add `LAST_ATTACKER_OF_ALLY = 'last-attacker-of-ally'` to `TargetingStrategy` enum in `src/fight/http-api/dto/fight-data.dto.ts`
-- [ ] T011 [P] [US2] Register `LastAttackerOfAllyTargetingStrategy` in `src/fight/http-api/targeting-strategy-factory.ts`
-- [ ] T012 [US2] Wire `CONDITIONAL_ATTACK` + `ALLY_HEALTH_BELOW` case in `fight.controller.ts`: create shared `LastAttackerOfAllyTargetingStrategy`, create `AllyHealthBelowThresholdTrigger(targetCardId, threshold, sharedStrategy)`, create `SimpleAttack` using shared strategy, pass `AlwaysTrueAttackCondition`; throw on missing `activationCondition` or `targetCardId` — in `src/fight/http-api/fight.controller.ts`
+- [x] T006 [US2] Write unit tests (RED) for `LastAttackerOfAllyTargetingStrategy` covering: returns `[]` before `setLastAttacker()`, returns `[card]` after `setLastAttacker(card)` if alive, returns `[]` if card is dead — in `src/fight/core/targeting-card-strategies/__tests__/last-attacker-of-ally.spec.ts`
+- [x] T007 [P] [US2] Create `AlwaysTrueAttackCondition` implementing `AttackCondition` with `isTriggered(): true`, no-op `tick()` and `reset()` — in `src/fight/core/cards/@types/attack/conditions/always-true-attack-condition.ts`
+- [x] T008 [P] [US2] Add `activate(triggerId, context)` method to `ConditionalAttack` delegating to `(this.trigger as ActivatableTrigger).activate()` when trigger implements `ActivatableTrigger` — in `src/fight/core/cards/skills/conditional-attack.ts`
+- [x] T009 [US2] Implement `LastAttackerOfAllyTargetingStrategy` with `setLastAttacker(card)` and `targetedCards()` returning `[lastAttacker]` if alive — in `src/fight/core/targeting-card-strategies/last-attacker-of-ally.ts`
+- [x] T010 [P] [US2] Add `LAST_ATTACKER_OF_ALLY = 'last-attacker-of-ally'` to `TargetingStrategy` enum in `src/fight/http-api/dto/fight-data.dto.ts`
+- [x] T011 [P] [US2] Register `LastAttackerOfAllyTargetingStrategy` in `src/fight/http-api/targeting-strategy-factory.ts`
+- [x] T012 [US2] Wire `CONDITIONAL_ATTACK` + `ALLY_HEALTH_BELOW` case in `fight.controller.ts`: create shared `LastAttackerOfAllyTargetingStrategy`, create `AllyHealthBelowThresholdTrigger(targetCardId, threshold, sharedStrategy)`, create `SimpleAttack` using shared strategy, pass `AlwaysTrueAttackCondition`; throw on missing `activationCondition` or `targetCardId` — in `src/fight/http-api/fight.controller.ts`
 
 **Checkpoint**: Explosion unit tests pass. Fight log includes an `attack` step with `powerId: "salamander-tears"` targeting the last attacker when threshold is crossed.
 
@@ -70,11 +70,11 @@
 
 > **Write tests first (RED), implement second (GREEN)**
 
-- [ ] T013 [US3] Write unit tests (RED) for `AlliedCardByIdStrategy` covering: returns `[card]` if ally is alive in `sourcePlayer`, returns `[]` if ally is dead, returns `[]` if ally is absent from team — in `src/fight/core/targeting-card-strategies/__tests__/allied-card-by-id.spec.ts`
-- [ ] T014 [US3] Implement `AlliedCardByIdStrategy` searching `sourcePlayer.allCards` by `allyId`, returning `[]` if absent or dead — in `src/fight/core/targeting-card-strategies/allied-card-by-id.ts`
-- [ ] T015 [P] [US3] Add `LINKED_ALLY = 'linked-ally'` to `TargetingStrategy` enum in `src/fight/http-api/dto/fight-data.dto.ts`
-- [ ] T016 [P] [US3] Register `AlliedCardByIdStrategy` in `src/fight/http-api/targeting-strategy-factory.ts`
-- [ ] T017 [US3] Wire `ALTERATION` + `ALLY_HEALTH_BELOW` case in `fight.controller.ts`: create `AllyHealthBelowThresholdTrigger(targetCardId, threshold)` (no shared strategy), use `AlliedCardByIdStrategy(targetCardId)`; throw on missing `activationCondition` or `targetCardId` — in `src/fight/http-api/fight.controller.ts`
+- [x] T013 [US3] Write unit tests (RED) for `AlliedCardByIdStrategy` covering: returns `[card]` if ally is alive in `sourcePlayer`, returns `[]` if ally is dead, returns `[]` if ally is absent from team — in `src/fight/core/targeting-card-strategies/__tests__/allied-card-by-id.spec.ts`
+- [x] T014 [US3] Implement `AlliedCardByIdStrategy` searching `sourcePlayer.allCards` by `allyId`, returning `[]` if absent or dead — in `src/fight/core/targeting-card-strategies/allied-card-by-id.ts`
+- [x] T015 [P] [US3] Add `LINKED_ALLY = 'linked-ally'` to `TargetingStrategy` enum in `src/fight/http-api/dto/fight-data.dto.ts`
+- [x] T016 [P] [US3] Register `AlliedCardByIdStrategy` in `src/fight/http-api/targeting-strategy-factory.ts`
+- [x] T017 [US3] Wire `ALTERATION` + `ALLY_HEALTH_BELOW` case in `fight.controller.ts`: create `AllyHealthBelowThresholdTrigger(targetCardId, threshold)` (no shared strategy), use `AlliedCardByIdStrategy(targetCardId)`; throw on missing `activationCondition` or `targetCardId` — in `src/fight/http-api/fight.controller.ts`
 
 **Checkpoint**: Buff unit tests pass. Fight log includes two `buff` steps on Arionis with `remainingTurns: 5` and `powerId: "salamander-tears"` immediately after the threshold crossing.
 
@@ -84,8 +84,8 @@
 
 **Purpose**: End-to-end validation and all four quality gates.
 
-- [ ] T018 Write e2e test covering: threshold crossing emits attack + two buff steps in order with same `powerId`; correct last-attacker targeting; no re-trigger while below threshold; no steps when Arionis absent from team — in `test/fight/salamander-tears.e2e-spec.ts`
-- [ ] T019 Run quality gates in order: `npm run format && npm run lint && npm run test:cov && npm run build`
+- [x] T018 Write e2e test covering: threshold crossing emits attack + two buff steps in order with same `powerId`; correct last-attacker targeting; no re-trigger while below threshold; no steps when Arionis absent from team — in `test/fight/salamander-tears.e2e-spec.ts`
+- [x] T019 Run quality gates in order: `npm run format && npm run lint && npm run test:cov && npm run build`
 
 ---
 

--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -303,6 +303,27 @@ export class ActionStage {
         );
       }
 
+      if (!damageDealt.dodge) {
+        defensiveCard.lastAttacker = attackerCard;
+        const damagedCardPlayer = this.player1.ownCard(defensiveCard)
+          ? this.player1
+          : this.player2;
+        const allyHealthContext: FightingContext = {
+          sourcePlayer: this.player1,
+          opponentPlayer: this.player2,
+          lastAttacker: attackerCard,
+        };
+        damagedCardPlayer.playableCards
+          .filter((c) => c !== defensiveCard)
+          .forEach((caster) => {
+            const results = caster.launchSkills(
+              `ally-health-${defensiveCard.id}`,
+              allyHealthContext,
+            );
+            report.statusChanges.push(...skillResultsToSteps(caster, results));
+          });
+      }
+
       if (defensiveCard.isDead() && !reportedDeaths.has(defensiveCard)) {
         reportedDeaths.add(defensiveCard);
         this.notifyDeath(defensiveCard, attackerCard);

--- a/src/fight/core/cards/@types/attack/conditions/always-true-attack-condition.ts
+++ b/src/fight/core/cards/@types/attack/conditions/always-true-attack-condition.ts
@@ -1,0 +1,11 @@
+import { AttackCondition } from '../attack-condition';
+
+export class AlwaysTrueAttackCondition implements AttackCondition {
+  isTriggered(): boolean {
+    return true;
+  }
+
+  tick(): void {}
+
+  reset(): void {}
+}

--- a/src/fight/core/cards/@types/fighting-context.ts
+++ b/src/fight/core/cards/@types/fighting-context.ts
@@ -5,4 +5,5 @@ export type FightingContext = {
   sourcePlayer: Player;
   opponentPlayer: Player;
   killerCard?: FightingCard;
+  lastAttacker?: FightingCard;
 };

--- a/src/fight/core/cards/fighting-card.ts
+++ b/src/fight/core/cards/fighting-card.ts
@@ -54,6 +54,7 @@ export class FightingCard {
   private specialEnergy: number = 0;
   private receivedDamages: number = 0;
   private receivedHeal: number = 0;
+  public lastAttacker?: FightingCard;
 
   // Buffs
   private buffs: Buff[] = [];

--- a/src/fight/core/cards/skills/conditional-attack.ts
+++ b/src/fight/core/cards/skills/conditional-attack.ts
@@ -4,6 +4,7 @@ import { AttackCondition } from '../@types/attack/attack-condition';
 import { AttackSkill } from './attack-skill';
 import { Skill, SkillKind, SkillResults } from './skill';
 import { Trigger } from '../../trigger/trigger';
+import { isActivatableTrigger } from '../../trigger/activatable-trigger';
 import { TargetingCardStrategy } from '../../targeting-card-strategies/targeting-card-strategy';
 
 export class ConditionalAttack implements Skill {
@@ -14,6 +15,7 @@ export class ConditionalAttack implements Skill {
     private readonly attackSkill: AttackSkill,
     private readonly condition: AttackCondition,
     private readonly trigger: Trigger,
+    private readonly powerId?: string,
   ) {}
 
   isTriggered(triggerName: string): boolean {
@@ -38,7 +40,14 @@ export class ConditionalAttack implements Skill {
       skillKind: SkillKind.Attack,
       results: attackResults.results,
       name: this.name,
+      powerId: this.powerId,
     };
+  }
+
+  activate(triggerId: string, context: FightingContext): void {
+    if (isActivatableTrigger(this.trigger)) {
+      this.trigger.activate(triggerId, context);
+    }
   }
 
   tick(): void {

--- a/src/fight/core/fight-simulator/@types/damage-report.ts
+++ b/src/fight/core/fight-simulator/@types/damage-report.ts
@@ -16,6 +16,7 @@ export type DamageReport = {
   attacker: CardInfo;
   damages: Damage[];
   energy: number;
+  powerId?: string;
 };
 
 export type AttackStepReport = { kind: StepKind.Attack } & DamageReport;

--- a/src/fight/core/fight-simulator/skill-results-to-steps.ts
+++ b/src/fight/core/fight-simulator/skill-results-to-steps.ts
@@ -62,6 +62,7 @@ export function skillResultsToSteps(
             kind: r.kind,
           })),
           energy: card.actualEnergy,
+          powerId: skillResult.powerId,
         });
 
         const statusChanges: StatusChangeReport[] = skillResult.results.flatMap(

--- a/src/fight/core/targeting-card-strategies/__tests__/allied-card-by-id.spec.ts
+++ b/src/fight/core/targeting-card-strategies/__tests__/allied-card-by-id.spec.ts
@@ -1,0 +1,64 @@
+import { AlliedCardByIdStrategy } from '../allied-card-by-id';
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+import { FightingCard } from '../../cards/fighting-card';
+import { Player } from '../../player';
+
+describe('AlliedCardByIdStrategy', () => {
+  let opponentPlayer: Player;
+
+  beforeEach(() => {
+    opponentPlayer = new Player('opponent', [createFightingCard()]);
+  });
+
+  describe('when ally is alive in sourcePlayer', () => {
+    let ally: FightingCard;
+    let sourcePlayer: Player;
+    let strategy: AlliedCardByIdStrategy;
+
+    beforeEach(() => {
+      ally = createFightingCard({ id: 'ally-01' });
+      sourcePlayer = new Player('source', [createFightingCard(), ally]);
+      strategy = new AlliedCardByIdStrategy('ally-01');
+    });
+
+    it('returns the ally card', () => {
+      expect(
+        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+      ).toEqual([ally]);
+    });
+  });
+
+  describe('when ally is dead', () => {
+    let sourcePlayer: Player;
+    let strategy: AlliedCardByIdStrategy;
+
+    beforeEach(() => {
+      const deadAlly = createFightingCard({ id: 'ally-01', health: 1 });
+      deadAlly.applyFinalDamage(9999);
+      sourcePlayer = new Player('source', [createFightingCard(), deadAlly]);
+      strategy = new AlliedCardByIdStrategy('ally-01');
+    });
+
+    it('returns empty array', () => {
+      expect(
+        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+      ).toEqual([]);
+    });
+  });
+
+  describe('when ally is absent from team', () => {
+    let sourcePlayer: Player;
+    let strategy: AlliedCardByIdStrategy;
+
+    beforeEach(() => {
+      sourcePlayer = new Player('source', [createFightingCard()]);
+      strategy = new AlliedCardByIdStrategy('non-existent-id');
+    });
+
+    it('returns empty array', () => {
+      expect(
+        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+      ).toEqual([]);
+    });
+  });
+});

--- a/src/fight/core/targeting-card-strategies/__tests__/last-attacker-of-ally.spec.ts
+++ b/src/fight/core/targeting-card-strategies/__tests__/last-attacker-of-ally.spec.ts
@@ -1,0 +1,82 @@
+import { LastAttackerOfAllyTargetingStrategy } from '../last-attacker-of-ally';
+import { createFightingCard } from '../../../../../test/helpers/fighting-card';
+import { Player } from '../../player';
+
+describe('LastAttackerOfAllyTargetingStrategy', () => {
+  const ALLY_ID = 'ally-01';
+  let strategy: LastAttackerOfAllyTargetingStrategy;
+  let sourcePlayer: Player;
+  let opponentPlayer: Player;
+
+  beforeEach(() => {
+    strategy = new LastAttackerOfAllyTargetingStrategy(ALLY_ID);
+    sourcePlayer = new Player('source', [createFightingCard({ id: ALLY_ID })]);
+    opponentPlayer = new Player('opponent', [createFightingCard()]);
+  });
+
+  describe('when ally has no lastAttacker recorded', () => {
+    it('returns empty array', () => {
+      expect(
+        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+      ).toEqual([]);
+    });
+  });
+
+  describe('when ally has an alive lastAttacker', () => {
+    let attacker: ReturnType<typeof createFightingCard>;
+
+    beforeEach(() => {
+      attacker = createFightingCard();
+      sourcePlayer.allCards[0].lastAttacker = attacker;
+    });
+
+    it('returns the last attacker card', () => {
+      expect(
+        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+      ).toEqual([attacker]);
+    });
+  });
+
+  describe('when ally lastAttacker is dead', () => {
+    beforeEach(() => {
+      const deadAttacker = createFightingCard({ health: 1 });
+      deadAttacker.applyFinalDamage(9999);
+      sourcePlayer.allCards[0].lastAttacker = deadAttacker;
+    });
+
+    it('returns empty array', () => {
+      expect(
+        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+      ).toEqual([]);
+    });
+  });
+
+  describe('when ally is absent from both players', () => {
+    beforeEach(() => {
+      strategy = new LastAttackerOfAllyTargetingStrategy('non-existent-id');
+    });
+
+    it('returns empty array', () => {
+      expect(
+        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+      ).toEqual([]);
+    });
+  });
+
+  describe('when ally is in defendingPlayer team only', () => {
+    let attacker: ReturnType<typeof createFightingCard>;
+
+    beforeEach(() => {
+      attacker = createFightingCard();
+      sourcePlayer = new Player('source', [createFightingCard()]);
+      opponentPlayer = new Player('opponent', [createFightingCard({ id: ALLY_ID })]);
+      opponentPlayer.allCards[0].lastAttacker = attacker;
+    });
+
+    it('finds ally via fallback and returns last attacker', () => {
+      expect(
+        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+      ).toEqual([attacker]);
+    });
+  });
+});

--- a/src/fight/core/targeting-card-strategies/allied-card-by-id.ts
+++ b/src/fight/core/targeting-card-strategies/allied-card-by-id.ts
@@ -1,0 +1,23 @@
+import { FightingCard } from '../cards/fighting-card';
+import { Player } from '../player';
+import { TargetingCardStrategy } from './targeting-card-strategy';
+
+export class AlliedCardByIdStrategy implements TargetingCardStrategy {
+  public readonly id = 'allied-card-by-id';
+
+  constructor(private readonly allyId: string) {}
+
+  targetedCards(
+    _attackingCard: FightingCard,
+    attackingPlayer: Player,
+    _defendingPlayer: Player,
+  ): FightingCard[] {
+    const ally = attackingPlayer.allCards.find((c) => c.id === this.allyId);
+
+    if (!ally || ally.isDead()) {
+      return [];
+    }
+
+    return [ally];
+  }
+}

--- a/src/fight/core/targeting-card-strategies/last-attacker-of-ally.ts
+++ b/src/fight/core/targeting-card-strategies/last-attacker-of-ally.ts
@@ -1,0 +1,23 @@
+import { FightingCard } from '../cards/fighting-card';
+import { Player } from '../player';
+import { TargetingCardStrategy } from './targeting-card-strategy';
+
+export class LastAttackerOfAllyTargetingStrategy implements TargetingCardStrategy {
+  public readonly id = 'last-attacker-of-ally';
+
+  constructor(private readonly allyId: string) {}
+
+  targetedCards(
+    _attackingCard: FightingCard,
+    attackingPlayer: Player,
+    defendingPlayer: Player,
+  ): FightingCard[] {
+    const ally =
+      attackingPlayer.allCards.find((c) => c.id === this.allyId) ??
+      defendingPlayer.allCards.find((c) => c.id === this.allyId);
+    if (!ally?.lastAttacker || ally.lastAttacker.isDead()) {
+      return [];
+    }
+    return [ally.lastAttacker];
+  }
+}

--- a/src/fight/core/trigger/__tests__/ally-health-below-threshold-trigger.spec.ts
+++ b/src/fight/core/trigger/__tests__/ally-health-below-threshold-trigger.spec.ts
@@ -1,0 +1,83 @@
+import { AllyHealthBelowThresholdTrigger } from '../ally-health-below-threshold-trigger';
+import { FightingCard } from '../../cards/fighting-card';
+import { Player } from '../../player';
+import { FightingContext } from '../../cards/@types/fighting-context';
+
+function makeAlly(id: string, healthRatio: number): FightingCard {
+  return { id, healthRatio } as unknown as FightingCard;
+}
+
+function makeContext(allyId: string, healthRatio: number): FightingContext {
+  const ally = makeAlly(allyId, healthRatio);
+  return {
+    sourcePlayer: { allCards: [ally] } as unknown as Player,
+    opponentPlayer: { allCards: [] } as unknown as Player,
+  };
+}
+
+describe('AllyHealthBelowThresholdTrigger', () => {
+  const ALLY_ID = 'arionis-01';
+  const THRESHOLD = 0.3;
+  const EVENT_ID = `ally-health-${ALLY_ID}`;
+
+  describe('initial state', () => {
+    it('is not triggered before any activate call', () => {
+      const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
+      expect(trigger.isTriggered(EVENT_ID)).toBe(false);
+    });
+  });
+
+  describe('non-matching event', () => {
+    it('does not trigger on a different ally id', () => {
+      const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
+      trigger.activate('ally-health-other-id', makeContext(ALLY_ID, 0.2));
+      expect(trigger.isTriggered(EVENT_ID)).toBe(false);
+    });
+  });
+
+  describe('first threshold crossing (HP goes below threshold)', () => {
+    it('returns true on the tick after the crossing', () => {
+      const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
+      trigger.activate(EVENT_ID, makeContext(ALLY_ID, 0.2));
+      expect(trigger.isTriggered(EVENT_ID)).toBe(true);
+    });
+  });
+
+  describe('subsequent hits while already below threshold', () => {
+    it('does not re-trigger on the next hit', () => {
+      const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
+      trigger.activate(EVENT_ID, makeContext(ALLY_ID, 0.2));
+      trigger.activate(EVENT_ID, makeContext(ALLY_ID, 0.1));
+      expect(trigger.isTriggered(EVENT_ID)).toBe(false);
+    });
+  });
+
+  describe('recovery and re-arm', () => {
+    it('fires again after HP recovers above threshold and drops below again', () => {
+      const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
+      trigger.activate(EVENT_ID, makeContext(ALLY_ID, 0.2));
+      trigger.activate(EVENT_ID, makeContext(ALLY_ID, 0.5));
+      trigger.activate(EVENT_ID, makeContext(ALLY_ID, 0.2));
+      expect(trigger.isTriggered(EVENT_ID)).toBe(true);
+    });
+
+    it('resets to not triggered after recovery', () => {
+      const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
+      trigger.activate(EVENT_ID, makeContext(ALLY_ID, 0.2));
+      trigger.activate(EVENT_ID, makeContext(ALLY_ID, 0.5));
+      expect(trigger.isTriggered(EVENT_ID)).toBe(false);
+    });
+  });
+
+  describe('ally absent from context', () => {
+    it('is a silent no-op when ally is not in sourcePlayer', () => {
+      const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
+      const context: FightingContext = {
+        sourcePlayer: { allCards: [] } as unknown as Player,
+        opponentPlayer: {} as unknown as Player,
+      };
+      expect(() => trigger.activate(EVENT_ID, context)).not.toThrow();
+      expect(trigger.isTriggered(EVENT_ID)).toBe(false);
+    });
+  });
+});

--- a/src/fight/core/trigger/activatable-trigger.ts
+++ b/src/fight/core/trigger/activatable-trigger.ts
@@ -4,3 +4,7 @@ import { Trigger } from './trigger';
 export interface ActivatableTrigger extends Trigger {
   activate(triggerId: string, context: FightingContext): void;
 }
+
+export function isActivatableTrigger(trigger: Trigger): trigger is ActivatableTrigger {
+  return typeof (trigger as ActivatableTrigger).activate === 'function';
+}

--- a/src/fight/core/trigger/ally-health-below-threshold-trigger.ts
+++ b/src/fight/core/trigger/ally-health-below-threshold-trigger.ts
@@ -1,0 +1,50 @@
+import { FightingContext } from '../cards/@types/fighting-context';
+import { ActivatableTrigger } from './activatable-trigger';
+
+export class AllyHealthBelowThresholdTrigger implements ActivatableTrigger {
+  public readonly id = 'ally-health-below-threshold';
+
+  private wasAboveThreshold = true;
+  private shouldFire = false;
+
+  constructor(
+    private readonly monitoredAllyId: string,
+    private readonly threshold: number,
+  ) {}
+
+  isTriggered(triggerId: string): boolean {
+    if (triggerId !== `ally-health-${this.monitoredAllyId}`) return false;
+    return this.shouldFire;
+  }
+
+  activate(triggerId: string, context: FightingContext): void {
+    if (triggerId !== `ally-health-${this.monitoredAllyId}`) return;
+
+    const attackerPlayer =
+      context.lastAttacker &&
+      context.sourcePlayer.allCards.some((c) => c === context.lastAttacker)
+        ? context.sourcePlayer
+        : context.opponentPlayer;
+    const allyPlayer =
+      attackerPlayer === context.sourcePlayer
+        ? context.opponentPlayer
+        : context.sourcePlayer;
+
+    const ally =
+      allyPlayer.allCards.find((c) => c.id === this.monitoredAllyId) ??
+      attackerPlayer.allCards?.find((c) => c.id === this.monitoredAllyId);
+    if (!ally) return;
+
+    const nowBelow = ally.healthRatio < this.threshold;
+
+    if (this.wasAboveThreshold && nowBelow) {
+      this.shouldFire = true;
+      this.wasAboveThreshold = false;
+    } else if (!nowBelow) {
+      this.shouldFire = false;
+      this.wasAboveThreshold = true;
+    } else {
+      this.shouldFire = false;
+    }
+  }
+}

--- a/src/fight/http-api/dto/fight-data.dto.ts
+++ b/src/fight/http-api/dto/fight-data.dto.ts
@@ -88,6 +88,7 @@ export enum TriggerEvent {
   ENEMY_DEATH = 'enemy-death',
   DORMANT = 'dormant',
   SURVIVED = 'survived',
+  ALLY_HEALTH_BELOW = 'ally-health-below',
 }
 
 export enum TargetingStrategy {
@@ -98,6 +99,8 @@ export enum TargetingStrategy {
   ALL_ALLIES = 'all-allies',
   SELF = 'self',
   TARGETED_CARD = 'targeted-card',
+  LAST_ATTACKER_OF_ALLY = 'last-attacker-of-ally',
+  LINKED_ALLY = 'linked-ally',
 }
 
 export enum CardSelectorStrategy {
@@ -400,7 +403,11 @@ export class OtherSkillDto {
   @Type(/* istanbul ignore next */ () => DamageCompositionDto)
   damages?: DamageCompositionDto[];
 
-  @ValidateIf((o) => o.kind === SkillKind.CONDITIONAL_ATTACK)
+  @ValidateIf(
+    (o) =>
+      o.kind === SkillKind.CONDITIONAL_ATTACK &&
+      o.event !== TriggerEvent.ALLY_HEALTH_BELOW,
+  )
   @IsDefined()
   @IsNumber()
   @Min(1)
@@ -426,11 +433,12 @@ export class OtherSkillDto {
   @Type(/* istanbul ignore next */ () => DamageCompositionDto)
   comboFinisher?: DamageCompositionDto[];
 
-  // Required when event is ally-death or enemy-death
+  // Required when event is ally-death, enemy-death, or ally-health-below
   @ValidateIf(
     (o) =>
       o.event === TriggerEvent.ALLY_DEATH ||
-      o.event === TriggerEvent.ENEMY_DEATH,
+      o.event === TriggerEvent.ENEMY_DEATH ||
+      o.event === TriggerEvent.ALLY_HEALTH_BELOW,
   )
   @IsDefined()
   @IsString()

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -55,6 +55,10 @@ import { HealthThresholdCondition } from '../core/cards/@types/skill-activation-
 import { DamageComposition } from '../core/cards/@types/damage/damage-composition';
 import { ConditionalAttack } from '../core/cards/skills/conditional-attack';
 import { EveryNTurnsCondition } from '../core/cards/@types/attack/conditions/every-n-turns-condition';
+import { AlwaysTrueAttackCondition } from '../core/cards/@types/attack/conditions/always-true-attack-condition';
+import { AllyHealthBelowThresholdTrigger } from '../core/trigger/ally-health-below-threshold-trigger';
+import { LastAttackerOfAllyTargetingStrategy } from '../core/targeting-card-strategies/last-attacker-of-ally';
+import { AlliedCardByIdStrategy } from '../core/targeting-card-strategies/allied-card-by-id';
 import { MultipleAttack } from '../core/cards/skills/multiple-attack';
 import { AttackSkill } from '../core/cards/skills/attack-skill';
 import { TargetedCard } from '../core/targeting-card-strategies/targeted-card';
@@ -377,6 +381,33 @@ export class FightController {
         if (!skillData.polarity) {
           throw new Error('Alteration skill requires polarity');
         }
+        if (skillData.event === TriggerEvent.ALLY_HEALTH_BELOW) {
+          if (!skillData.activationCondition) {
+            throw new BadRequestException(
+              'ALTERATION with ally-health-below requires activationCondition',
+            );
+          }
+          if (!skillData.targetCardId) {
+            throw new BadRequestException(
+              'ALTERATION with ally-health-below requires targetCardId',
+            );
+          }
+          return new AlterationSkill({
+            name: skillData.name,
+            polarity: skillData.polarity,
+            attributeType: this.mapAlterationType(skillData.buffType),
+            rate: skillData.rate,
+            duration: skillData.duration ?? 0,
+            trigger: new AllyHealthBelowThresholdTrigger(
+              skillData.targetCardId,
+              skillData.activationCondition.threshold,
+            ),
+            targetingStrategy: new AlliedCardByIdStrategy(
+              skillData.targetCardId,
+            ),
+            powerId: skillData.powerId,
+          });
+        }
         const alterationCondition = skillData.activationCondition
           ? buildAlterationCondition(skillData.activationCondition.type, {
               allyName: skillData.activationCondition.allyName,
@@ -406,6 +437,41 @@ export class FightController {
           powerId: skillData.powerId,
         });
       case SkillKind.CONDITIONAL_ATTACK:
+        if (skillData.event === TriggerEvent.ALLY_HEALTH_BELOW) {
+          if (!skillData.activationCondition) {
+            throw new BadRequestException(
+              'CONDITIONAL_ATTACK with ally-health-below requires activationCondition',
+            );
+          }
+          if (!skillData.targetCardId) {
+            throw new BadRequestException(
+              'CONDITIONAL_ATTACK with ally-health-below requires targetCardId',
+            );
+          }
+          const ahDamages = skillData.damages.map(
+            (d) => new DamageComposition(d.type, d.rate),
+          );
+          const ahEffects = skillData.effect
+            ? [this.buildEffect(skillData.effect)]
+            : undefined;
+          const ahAttackSkill = new SimpleAttack(
+            skillData.name,
+            ahDamages,
+            new LastAttackerOfAllyTargetingStrategy(skillData.targetCardId),
+            ahEffects,
+          );
+          const ahTrigger = new AllyHealthBelowThresholdTrigger(
+            skillData.targetCardId,
+            skillData.activationCondition.threshold,
+          );
+          return new ConditionalAttack(
+            skillData.name,
+            ahAttackSkill,
+            new AlwaysTrueAttackCondition(),
+            ahTrigger,
+            skillData.powerId,
+          );
+        }
         const caDamages = skillData.damages.map(
           (d) => new DamageComposition(d.type, d.rate),
         );

--- a/test/fight/salamander-tears.e2e-spec.ts
+++ b/test/fight/salamander-tears.e2e-spec.ts
@@ -1,0 +1,409 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module';
+
+const ARIONIS_ID = 'arionis-01';
+const KAELION_ID = 'kaelion-01';
+const ENEMY_ID = 'enemy-01';
+
+function buildPayload() {
+  return {
+    cardSelectorStrategy: 'player-by-player',
+    player1: {
+      name: 'Team Kaelion',
+      deck: [
+        {
+          id: KAELION_ID,
+          name: 'Kaelion',
+          attack: 200,
+          defense: 0,
+          health: 5000,
+          speed: 100,
+          agility: 0,
+          accuracy: 100,
+          criticalChance: 0,
+          skills: {
+            special: {
+              kind: 'ATTACK',
+              name: 'Fire Nova',
+              damages: [{ type: 'FIRE', rate: 3 }],
+              energy: 9999,
+              targetingStrategy: 'position-based',
+            },
+            simpleAttack: {
+              name: 'Slash',
+              damages: [{ type: 'PHYSICAL', rate: 1.0 }],
+              targetingStrategy: 'position-based',
+            },
+            others: [
+              {
+                kind: 'CONDITIONAL_ATTACK',
+                name: 'Salamander Tears',
+                event: 'ally-health-below',
+                targetCardId: ARIONIS_ID,
+                activationCondition: {
+                  type: 'health-threshold',
+                  operator: 'below',
+                  threshold: 0.3,
+                },
+                damages: [{ type: 'FIRE', rate: 2.0 }],
+                targetingStrategy: 'last-attacker-of-ally',
+                powerId: 'salamander-tears',
+              },
+              {
+                kind: 'ALTERATION',
+                name: 'Salamander Tears',
+                event: 'ally-health-below',
+                targetCardId: ARIONIS_ID,
+                activationCondition: {
+                  type: 'health-threshold',
+                  operator: 'below',
+                  threshold: 0.3,
+                },
+                polarity: 'buff',
+                buffType: 'attack',
+                rate: 0.1,
+                duration: 5,
+                targetingStrategy: 'linked-ally',
+                powerId: 'salamander-tears',
+              },
+              {
+                kind: 'ALTERATION',
+                name: 'Salamander Tears',
+                event: 'ally-health-below',
+                targetCardId: ARIONIS_ID,
+                activationCondition: {
+                  type: 'health-threshold',
+                  operator: 'below',
+                  threshold: 0.3,
+                },
+                polarity: 'buff',
+                buffType: 'defense',
+                rate: 0.2,
+                duration: 5,
+                targetingStrategy: 'linked-ally',
+                powerId: 'salamander-tears',
+              },
+            ],
+          },
+          behaviors: { dodge: 'simple-dodge' },
+        },
+        {
+          id: ARIONIS_ID,
+          name: 'Arionis',
+          attack: 100,
+          defense: 0,
+          health: 1000,
+          speed: 100,
+          agility: 0,
+          accuracy: 100,
+          criticalChance: 0,
+          skills: {
+            special: {
+              kind: 'ATTACK',
+              name: 'Inferno',
+              damages: [{ type: 'FIRE', rate: 3 }],
+              energy: 9999,
+              targetingStrategy: 'position-based',
+            },
+            simpleAttack: {
+              name: 'Fire Strike',
+              damages: [{ type: 'PHYSICAL', rate: 1.0 }],
+              targetingStrategy: 'position-based',
+            },
+            others: [],
+          },
+          behaviors: { dodge: 'simple-dodge' },
+        },
+      ],
+    },
+    player2: {
+      name: 'Team Enemy',
+      deck: [
+        {
+          id: ENEMY_ID,
+          name: 'Enemy',
+          attack: 200,
+          defense: 0,
+          health: 50000,
+          speed: 100,
+          agility: 0,
+          accuracy: 100,
+          criticalChance: 0,
+          skills: {
+            special: {
+              kind: 'ATTACK',
+              name: 'Big Slash',
+              damages: [{ type: 'PHYSICAL', rate: 3 }],
+              energy: 9999,
+              targetingStrategy: 'target-all',
+            },
+            simpleAttack: {
+              name: 'Smash',
+              damages: [{ type: 'PHYSICAL', rate: 1.0 }],
+              targetingStrategy: 'target-all',
+            },
+            others: [],
+          },
+          behaviors: { dodge: 'simple-dodge' },
+        },
+      ],
+    },
+  };
+}
+
+function buildPayloadWithoutArionis() {
+  return {
+    cardSelectorStrategy: 'player-by-player',
+    player1: {
+      name: 'Team Kaelion Solo',
+      deck: [
+        {
+          id: KAELION_ID,
+          name: 'Kaelion',
+          attack: 200,
+          defense: 0,
+          health: 5000,
+          speed: 100,
+          agility: 0,
+          accuracy: 100,
+          criticalChance: 0,
+          skills: {
+            special: {
+              kind: 'ATTACK',
+              name: 'Fire Nova',
+              damages: [{ type: 'FIRE', rate: 3 }],
+              energy: 9999,
+              targetingStrategy: 'position-based',
+            },
+            simpleAttack: {
+              name: 'Slash',
+              damages: [{ type: 'PHYSICAL', rate: 1.0 }],
+              targetingStrategy: 'position-based',
+            },
+            others: [
+              {
+                kind: 'CONDITIONAL_ATTACK',
+                name: 'Salamander Tears',
+                event: 'ally-health-below',
+                targetCardId: ARIONIS_ID,
+                activationCondition: {
+                  type: 'health-threshold',
+                  operator: 'below',
+                  threshold: 0.3,
+                },
+                damages: [{ type: 'FIRE', rate: 2.0 }],
+                targetingStrategy: 'last-attacker-of-ally',
+                powerId: 'salamander-tears',
+              },
+              {
+                kind: 'ALTERATION',
+                name: 'Salamander Tears',
+                event: 'ally-health-below',
+                targetCardId: ARIONIS_ID,
+                activationCondition: {
+                  type: 'health-threshold',
+                  operator: 'below',
+                  threshold: 0.3,
+                },
+                polarity: 'buff',
+                buffType: 'attack',
+                rate: 0.1,
+                duration: 5,
+                targetingStrategy: 'linked-ally',
+                powerId: 'salamander-tears',
+              },
+              {
+                kind: 'ALTERATION',
+                name: 'Salamander Tears',
+                event: 'ally-health-below',
+                targetCardId: ARIONIS_ID,
+                activationCondition: {
+                  type: 'health-threshold',
+                  operator: 'below',
+                  threshold: 0.3,
+                },
+                polarity: 'buff',
+                buffType: 'defense',
+                rate: 0.2,
+                duration: 5,
+                targetingStrategy: 'linked-ally',
+                powerId: 'salamander-tears',
+              },
+            ],
+          },
+          behaviors: { dodge: 'simple-dodge' },
+        },
+      ],
+    },
+    player2: {
+      name: 'Team Enemy',
+      deck: [
+        {
+          id: ENEMY_ID,
+          name: 'Enemy',
+          attack: 200,
+          defense: 0,
+          health: 50000,
+          speed: 100,
+          agility: 0,
+          accuracy: 100,
+          criticalChance: 0,
+          skills: {
+            special: {
+              kind: 'ATTACK',
+              name: 'Big Slash',
+              damages: [{ type: 'PHYSICAL', rate: 3 }],
+              energy: 9999,
+              targetingStrategy: 'position-based',
+            },
+            simpleAttack: {
+              name: 'Smash',
+              damages: [{ type: 'PHYSICAL', rate: 1.0 }],
+              targetingStrategy: 'position-based',
+            },
+            others: [],
+          },
+          behaviors: { dodge: 'simple-dodge' },
+        },
+      ],
+    },
+  };
+}
+
+describe('Salamander Tears — link skill trigger', () => {
+  let app: INestApplication;
+  let stepEntries: [string, any][];
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useLogger(false);
+    await app.init();
+
+    const response = await request(app.getHttpServer())
+      .post('/fight')
+      .send(buildPayload())
+      .expect(200);
+
+    stepEntries = Object.entries(response.body) as [string, any][];
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('produces an attack step with powerId salamander-tears', () => {
+    const idx = stepEntries.findIndex(
+      ([, s]) => s.kind === 'attack' && s.powerId === 'salamander-tears',
+    );
+    expect(idx).toBeGreaterThan(-1);
+  });
+
+  it('attack step targets the last attacker of Arionis', () => {
+    const step = stepEntries.find(
+      ([, s]) => s.kind === 'attack' && s.powerId === 'salamander-tears',
+    );
+    const defender = step?.[1].damages?.[0]?.defender;
+    expect(defender?.id).toBe(ENEMY_ID);
+  });
+
+  it('produces two buff steps with powerId salamander-tears', () => {
+    const buffSteps = stepEntries.filter(
+      ([, s]) => s.kind === 'buff' && s.powerId === 'salamander-tears',
+    );
+    expect(buffSteps).toHaveLength(2);
+  });
+
+  it('buff steps target Arionis', () => {
+    const buffSteps = stepEntries.filter(
+      ([, s]) => s.kind === 'buff' && s.powerId === 'salamander-tears',
+    );
+    buffSteps.forEach(([, step]) => {
+      expect(step.alterations[0].target.id).toBe(ARIONIS_ID);
+    });
+  });
+
+  it('buff steps have remainingTurns of 5', () => {
+    const buffSteps = stepEntries.filter(
+      ([, s]) => s.kind === 'buff' && s.powerId === 'salamander-tears',
+    );
+    buffSteps.forEach(([, step]) => {
+      expect(step.alterations[0].remainingTurns).toBe(5);
+    });
+  });
+
+  it('attack buff has rate-based value (attack +10%)', () => {
+    const attackBuff = stepEntries.find(
+      ([, s]) =>
+        s.kind === 'buff' &&
+        s.powerId === 'salamander-tears' &&
+        s.alterations[0].kind === 'attack',
+    );
+    expect(attackBuff).toBeDefined();
+  });
+
+  it('defense buff has rate-based value (defense +20%)', () => {
+    const defenseBuff = stepEntries.find(
+      ([, s]) =>
+        s.kind === 'buff' &&
+        s.powerId === 'salamander-tears' &&
+        s.alterations[0].kind === 'defense',
+    );
+    expect(defenseBuff).toBeDefined();
+  });
+
+  it('salamander tears fires exactly once (edge-triggered, no re-trigger)', () => {
+    const attackSteps = stepEntries.filter(
+      ([, s]) => s.kind === 'attack' && s.powerId === 'salamander-tears',
+    );
+    expect(attackSteps).toHaveLength(1);
+  });
+
+  it('attack step appears before the two buff steps (same power)', () => {
+    const attackIdx = stepEntries.findIndex(
+      ([, s]) => s.kind === 'attack' && s.powerId === 'salamander-tears',
+    );
+    const firstBuffIdx = stepEntries.findIndex(
+      ([, s]) => s.kind === 'buff' && s.powerId === 'salamander-tears',
+    );
+    expect(attackIdx).toBeLessThan(firstBuffIdx);
+  });
+});
+
+describe('Salamander Tears — Arionis absent from team', () => {
+  let app: INestApplication;
+  let stepEntries: [string, any][];
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useLogger(false);
+    await app.init();
+
+    const response = await request(app.getHttpServer())
+      .post('/fight')
+      .send(buildPayloadWithoutArionis())
+      .expect(200);
+
+    stepEntries = Object.entries(response.body) as [string, any][];
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('no Salamander Tears steps appear when Arionis is absent', () => {
+    const salamanderSteps = stepEntries.filter(
+      ([, s]) => s.powerId === 'salamander-tears',
+    );
+    expect(salamanderSteps).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## ✅ Type of PR

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Introduces the **Salamander Tears** link skill for Kaelion: a composite ally-health-reactive skill that monitors a linked ally's HP ratio, fires a fire-type counter-attack at the last attacker, and applies buffs to the ally when their HP crosses below a configurable threshold.

New building blocks added:
- `AllyHealthBelowThresholdTrigger` — edge-triggered on downward HP crossing, rearms on recovery
- `LastAttackerOfAllyTargetingStrategy` — resolves the last enemy to damage a specific ally
- `AlliedCardByIdStrategy` — targets a specific ally card by ID
- `FightingContext.lastAttacker` — tracks last attacker per card after each non-dodged hit
- `AlwaysTrueAttackCondition` + `ConditionalAttack.activate()` — wires the trigger to the attack
- New DTO values: `ally-health-below` trigger event, `last-attacker-of-ally` and `linked-ally` targeting strategies

## 🚶‍➡️ Behavior

- When `CONDITIONAL_ATTACK` + `ally-health-below` is configured with a `targetCardId` and `activationCondition`, Kaelion fires a 200% fire attack at the enemy who last damaged the linked ally
- When `ALTERATION` + `ally-health-below` is configured, Kaelion applies buffs directly to the linked ally by ID
- Both components share a `powerId` so they appear grouped in the fight log
- The trigger is edge-triggered: fires once per downward crossing; re-arms when the ally recovers above the threshold
- If no enemy has attacked the linked ally yet, or the last attacker is already dead, the explosion step is skipped silently

## 🧪 Steps to test

- [x] Run `npm run test -- ally-health-below-threshold-trigger.spec.ts` — all trigger unit tests pass
- [x] Run `npm run test -- last-attacker-of-ally.spec.ts` — targeting strategy unit tests pass
- [x] Run `npm run test -- allied-card-by-id.spec.ts` — allied-by-id strategy unit tests pass
- [x] Run `npm run test:e2e -- salamander-tears.e2e-spec.ts` — full e2e: attack + 2 buff steps appear in order with same `powerId` when Arionis drops below threshold
- [x] Verify no re-trigger while Arionis is still below threshold
- [x] Verify no steps when Arionis is absent from the team