### PR TITLE
test(007): fix multi-assertion it blocks and add missing ally-health unit tests

### DIFF
--- a/src/fight/core/card-action/__tests__/action_stage.spec.ts
+++ b/src/fight/core/card-action/__tests__/action_stage.spec.ts
@@ -26,6 +26,8 @@ import {
   BuffReport,
   DebuffReport,
 } from '../../fight-simulator/@types/alteration-report';
+import { AlterationSkill } from '../../cards/skills/alteration-skill';
+import { AllyHealthBelowThresholdTrigger } from '../../trigger/ally-health-below-threshold-trigger';
 
 class UnknownSpecial implements Special {
   name = 'unknown';
@@ -326,6 +328,150 @@ describe('ActionStage', () => {
         expect(() => actionStage.computeNextAction([attacker])).toThrow(
           'Unknown special kind: unknownKind',
         );
+      });
+    });
+  });
+
+  describe('ally-health dispatch', () => {
+    const ARIONIS_ID = 'arionis-01';
+    const HIGH_ENERGY = new SpecialAttack(
+      'special',
+      [new DamageComposition(DamageType.PHYSICAL, 1)],
+      999,
+      POSITION_BASED,
+    );
+
+    function makeObserverCard(allyId: string, threshold: number): FightingCard {
+      const buffSkill = new AlterationSkill({
+        name: 'Watch Out',
+        polarity: 'buff',
+        attributeType: 'attack',
+        rate: 0.1,
+        duration: 1,
+        trigger: new AllyHealthBelowThresholdTrigger(allyId, threshold),
+        targetingStrategy: new Launcher(),
+      });
+      return new FightingCard(
+        'observer-01',
+        'Observer',
+        {
+          attack: 10,
+          defense: 0,
+          health: 1000,
+          speed: 100,
+          agility: 0,
+          accuracy: 100,
+          criticalChance: 0,
+        },
+        {
+          simpleAttack: SIMPLE_ATTACK,
+          special: HIGH_ENERGY,
+          others: [buffSkill],
+        },
+        { dodge: new SimpleDodge() },
+        Element.PHYSICAL,
+      );
+    }
+
+    describe('when ally is hit (non-dodge)', () => {
+      let steps: ReturnType<ActionStage['computeNextAction']>;
+      let arionis: FightingCard;
+
+      beforeEach(() => {
+        const attacker = makeCard(HIGH_ENERGY);
+        arionis = new FightingCard(
+          ARIONIS_ID,
+          'Arionis',
+          {
+            attack: 10,
+            defense: 0,
+            health: 200,
+            speed: 100,
+            agility: 0,
+            accuracy: 100,
+            criticalChance: 0,
+          },
+          { simpleAttack: SIMPLE_ATTACK, special: HIGH_ENERGY, others: [] },
+          { dodge: new SimpleDodge() },
+          Element.PHYSICAL,
+        );
+        const observer = makeObserverCard(ARIONIS_ID, 0.6);
+        const player1 = new Player('Player 1', [attacker]);
+        const player2 = new Player('Player 2', [arionis, observer]);
+        const actionStage = new ActionStage(
+          player1,
+          player2,
+          { onCardDeath: [] },
+          new DeathSkillHandler(player1, player2),
+        );
+        steps = actionStage.computeNextAction([attacker]);
+      });
+
+      it('emits a buff step from the observer ally-health trigger', () => {
+        expect(steps.some((s) => s.kind === StepKind.Buff)).toBe(true);
+      });
+    });
+
+    describe('when the hit is dodged', () => {
+      let steps: ReturnType<ActionStage['computeNextAction']>;
+      let arionis: FightingCard;
+
+      beforeEach(() => {
+        const LOW_ACCURACY = new SimpleAttack(
+          'attack',
+          [new DamageComposition(DamageType.PHYSICAL, 1)],
+          POSITION_BASED,
+        );
+        const attacker = new FightingCard(
+          faker.string.uuid(),
+          'Attacker',
+          {
+            attack: 100,
+            defense: 0,
+            health: 1000,
+            speed: 100,
+            agility: 0,
+            accuracy: 0,
+            criticalChance: 0,
+          },
+          { simpleAttack: LOW_ACCURACY, special: HIGH_ENERGY, others: [] },
+          { dodge: new SimpleDodge() },
+          Element.PHYSICAL,
+        );
+        arionis = new FightingCard(
+          ARIONIS_ID,
+          'Arionis',
+          {
+            attack: 10,
+            defense: 0,
+            health: 200,
+            speed: 100,
+            agility: 1,
+            accuracy: 100,
+            criticalChance: 0,
+          },
+          { simpleAttack: SIMPLE_ATTACK, special: HIGH_ENERGY, others: [] },
+          { dodge: new SimpleDodge() },
+          Element.PHYSICAL,
+        );
+        const observer = makeObserverCard(ARIONIS_ID, 0.6);
+        const player1 = new Player('Player 1', [attacker]);
+        const player2 = new Player('Player 2', [arionis, observer]);
+        const actionStage = new ActionStage(
+          player1,
+          player2,
+          { onCardDeath: [] },
+          new DeathSkillHandler(player1, player2),
+        );
+        steps = actionStage.computeNextAction([attacker]);
+      });
+
+      it('does not emit a buff step from the observer', () => {
+        expect(steps.some((s) => s.kind === StepKind.Buff)).toBe(false);
+      });
+
+      it('does not set lastAttacker on the dodging card', () => {
+        expect(arionis.lastAttacker).toBeUndefined();
       });
     });
   });

--- a/src/fight/core/targeting-card-strategies/__tests__/allied-card-by-id.spec.ts
+++ b/src/fight/core/targeting-card-strategies/__tests__/allied-card-by-id.spec.ts
@@ -23,7 +23,11 @@ describe('AlliedCardByIdStrategy', () => {
 
     it('returns the ally card', () => {
       expect(
-        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+        strategy.targetedCards(
+          createFightingCard(),
+          sourcePlayer,
+          opponentPlayer,
+        ),
       ).toEqual([ally]);
     });
   });
@@ -41,7 +45,11 @@ describe('AlliedCardByIdStrategy', () => {
 
     it('returns empty array', () => {
       expect(
-        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+        strategy.targetedCards(
+          createFightingCard(),
+          sourcePlayer,
+          opponentPlayer,
+        ),
       ).toEqual([]);
     });
   });
@@ -57,7 +65,11 @@ describe('AlliedCardByIdStrategy', () => {
 
     it('returns empty array', () => {
       expect(
-        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+        strategy.targetedCards(
+          createFightingCard(),
+          sourcePlayer,
+          opponentPlayer,
+        ),
       ).toEqual([]);
     });
   });

--- a/src/fight/core/targeting-card-strategies/__tests__/last-attacker-of-ally.spec.ts
+++ b/src/fight/core/targeting-card-strategies/__tests__/last-attacker-of-ally.spec.ts
@@ -17,7 +17,11 @@ describe('LastAttackerOfAllyTargetingStrategy', () => {
   describe('when ally has no lastAttacker recorded', () => {
     it('returns empty array', () => {
       expect(
-        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+        strategy.targetedCards(
+          createFightingCard(),
+          sourcePlayer,
+          opponentPlayer,
+        ),
       ).toEqual([]);
     });
   });
@@ -32,7 +36,11 @@ describe('LastAttackerOfAllyTargetingStrategy', () => {
 
     it('returns the last attacker card', () => {
       expect(
-        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+        strategy.targetedCards(
+          createFightingCard(),
+          sourcePlayer,
+          opponentPlayer,
+        ),
       ).toEqual([attacker]);
     });
   });
@@ -46,7 +54,11 @@ describe('LastAttackerOfAllyTargetingStrategy', () => {
 
     it('returns empty array', () => {
       expect(
-        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+        strategy.targetedCards(
+          createFightingCard(),
+          sourcePlayer,
+          opponentPlayer,
+        ),
       ).toEqual([]);
     });
   });
@@ -58,7 +70,11 @@ describe('LastAttackerOfAllyTargetingStrategy', () => {
 
     it('returns empty array', () => {
       expect(
-        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+        strategy.targetedCards(
+          createFightingCard(),
+          sourcePlayer,
+          opponentPlayer,
+        ),
       ).toEqual([]);
     });
   });
@@ -69,13 +85,19 @@ describe('LastAttackerOfAllyTargetingStrategy', () => {
     beforeEach(() => {
       attacker = createFightingCard();
       sourcePlayer = new Player('source', [createFightingCard()]);
-      opponentPlayer = new Player('opponent', [createFightingCard({ id: ALLY_ID })]);
+      opponentPlayer = new Player('opponent', [
+        createFightingCard({ id: ALLY_ID }),
+      ]);
       opponentPlayer.allCards[0].lastAttacker = attacker;
     });
 
     it('finds ally via fallback and returns last attacker', () => {
       expect(
-        strategy.targetedCards(createFightingCard(), sourcePlayer, opponentPlayer),
+        strategy.targetedCards(
+          createFightingCard(),
+          sourcePlayer,
+          opponentPlayer,
+        ),
       ).toEqual([attacker]);
     });
   });

--- a/src/fight/core/trigger/__tests__/ally-health-below-threshold-trigger.spec.ts
+++ b/src/fight/core/trigger/__tests__/ally-health-below-threshold-trigger.spec.ts
@@ -70,14 +70,38 @@ describe('AllyHealthBelowThresholdTrigger', () => {
   });
 
   describe('ally absent from context', () => {
-    it('is a silent no-op when ally is not in sourcePlayer', () => {
+    it('does not throw when ally is not found', () => {
       const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
       const context: FightingContext = {
         sourcePlayer: { allCards: [] } as unknown as Player,
-        opponentPlayer: {} as unknown as Player,
+        opponentPlayer: { allCards: [] } as unknown as Player,
       };
       expect(() => trigger.activate(EVENT_ID, context)).not.toThrow();
+    });
+
+    it('is not triggered when ally is not found', () => {
+      const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
+      const context: FightingContext = {
+        sourcePlayer: { allCards: [] } as unknown as Player,
+        opponentPlayer: { allCards: [] } as unknown as Player,
+      };
+      trigger.activate(EVENT_ID, context);
       expect(trigger.isTriggered(EVENT_ID)).toBe(false);
+    });
+  });
+
+  describe('player-resolution branch: lastAttacker in sourcePlayer', () => {
+    it('finds the ally in opponentPlayer and fires the trigger', () => {
+      const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
+      const ally = makeAlly(ALLY_ID, 0.2);
+      const attacker = { id: 'attacker-01' } as unknown as FightingCard;
+      const context: FightingContext = {
+        sourcePlayer: { allCards: [attacker] } as unknown as Player,
+        opponentPlayer: { allCards: [ally] } as unknown as Player,
+        lastAttacker: attacker,
+      };
+      trigger.activate(EVENT_ID, context);
+      expect(trigger.isTriggered(EVENT_ID)).toBe(true);
     });
   });
 });

--- a/src/fight/core/trigger/activatable-trigger.ts
+++ b/src/fight/core/trigger/activatable-trigger.ts
@@ -5,6 +5,8 @@ export interface ActivatableTrigger extends Trigger {
   activate(triggerId: string, context: FightingContext): void;
 }
 
-export function isActivatableTrigger(trigger: Trigger): trigger is ActivatableTrigger {
+export function isActivatableTrigger(
+  trigger: Trigger,
+): trigger is ActivatableTrigger {
   return typeof (trigger as ActivatableTrigger).activate === 'function';
 }

--- a/test/fight/salamander-tears.e2e-spec.ts
+++ b/test/fight/salamander-tears.e2e-spec.ts
@@ -319,22 +319,23 @@ describe('Salamander Tears — link skill trigger', () => {
     expect(buffSteps).toHaveLength(2);
   });
 
-  it('buff steps target Arionis', () => {
+  it('buff steps all target Arionis', () => {
     const buffSteps = stepEntries.filter(
       ([, s]) => s.kind === 'buff' && s.powerId === 'salamander-tears',
     );
-    buffSteps.forEach(([, step]) => {
-      expect(step.alterations[0].target.id).toBe(ARIONIS_ID);
-    });
+    expect(buffSteps.map(([, s]) => s.alterations[0].target.id)).toEqual([
+      ARIONIS_ID,
+      ARIONIS_ID,
+    ]);
   });
 
-  it('buff steps have remainingTurns of 5', () => {
+  it('buff steps all have remainingTurns of 5', () => {
     const buffSteps = stepEntries.filter(
       ([, s]) => s.kind === 'buff' && s.powerId === 'salamander-tears',
     );
-    buffSteps.forEach(([, step]) => {
-      expect(step.alterations[0].remainingTurns).toBe(5);
-    });
+    expect(buffSteps.map(([, s]) => s.alterations[0].remainingTurns)).toEqual([
+      5, 5,
+    ]);
   });
 
   it('attack buff has rate-based value (attack +10%)', () => {


### PR DESCRIPTION
## ✅ Type of PR

- [x] Bug Fix

## 🗒️ Description

Fixes two test quality issues flagged in #343 and #344:

- Split `it` blocks that contained multiple `expect` calls into separate, single-assertion tests.
- Added three missing unit tests for the `ally-health` dispatch block in `action-stage.ts`.
- Prettier reformatted 3 incidentally touched files (no logic change).

## 🚶‍➡️ Behavior

- `ally-health-below-threshold-trigger.spec.ts`: the "ally absent from context" `it` was split into two (`does not throw` + `is not triggered`). A new describe block exercises the **player-resolution branch** where `lastAttacker` is present in `sourcePlayer.allCards`.
- `salamander-tears.e2e-spec.ts`: the two `forEach`-with-expectations tests are replaced with array-level `toEqual` assertions — one expectation per `it`.
- `action_stage.spec.ts`: three new unit tests cover the `if (!damageDealt.dodge)` block:
  - **non-dodge hit** → observer's ally-health trigger fires → a `Buff` step appears in output.
  - **dodged hit** → trigger does NOT fire → no `Buff` step in output.
  - **dodged hit** → `lastAttacker` is NOT set on the dodging card.

## 🧪 Steps to test

- [ ] `npm test -- src/fight/core/trigger/__tests__/ally-health-below-threshold-trigger.spec.ts` — 9 tests pass
- [ ] `npm test -- src/fight/core/card-action/__tests__/action_stage.spec.ts` — 13 tests pass
- [ ] `npm run test:e2e -- test/fight/salamander-tears.e2e-spec.ts` — 10 tests pass
- [ ] `npm run test:cov` — full suite (624 tests) passes

Closes #343
Closes #344