### PR TITLE
fix(007): allyHealthContext hardcodes player1/player2 — fix ally-health trigger for player2

### DIFF
--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -309,8 +309,9 @@ export class ActionStage {
           ? this.player1
           : this.player2;
         const allyHealthContext: FightingContext = {
-          sourcePlayer: this.player1,
-          opponentPlayer: this.player2,
+          sourcePlayer: damagedCardPlayer,
+          opponentPlayer:
+            damagedCardPlayer === this.player1 ? this.player2 : this.player1,
           lastAttacker: attackerCard,
         };
         damagedCardPlayer.playableCards

--- a/src/fight/core/trigger/__tests__/ally-health-below-threshold-trigger.spec.ts
+++ b/src/fight/core/trigger/__tests__/ally-health-below-threshold-trigger.spec.ts
@@ -90,8 +90,21 @@ describe('AllyHealthBelowThresholdTrigger', () => {
     });
   });
 
-  describe('player-resolution branch: lastAttacker in sourcePlayer', () => {
-    it('finds the ally in opponentPlayer and fires the trigger', () => {
+  describe('sourcePlayer is always the ally owner', () => {
+    it('fires when ally is in sourcePlayer regardless of lastAttacker', () => {
+      const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
+      const ally = makeAlly(ALLY_ID, 0.2);
+      const attacker = { id: 'attacker-01' } as unknown as FightingCard;
+      const context: FightingContext = {
+        sourcePlayer: { allCards: [ally] } as unknown as Player,
+        opponentPlayer: { allCards: [attacker] } as unknown as Player,
+        lastAttacker: attacker,
+      };
+      trigger.activate(EVENT_ID, context);
+      expect(trigger.isTriggered(EVENT_ID)).toBe(true);
+    });
+
+    it('does not fire when ally is only in opponentPlayer', () => {
       const trigger = new AllyHealthBelowThresholdTrigger(ALLY_ID, THRESHOLD);
       const ally = makeAlly(ALLY_ID, 0.2);
       const attacker = { id: 'attacker-01' } as unknown as FightingCard;
@@ -101,7 +114,7 @@ describe('AllyHealthBelowThresholdTrigger', () => {
         lastAttacker: attacker,
       };
       trigger.activate(EVENT_ID, context);
-      expect(trigger.isTriggered(EVENT_ID)).toBe(true);
+      expect(trigger.isTriggered(EVENT_ID)).toBe(false);
     });
   });
 });

--- a/src/fight/core/trigger/ally-health-below-threshold-trigger.ts
+++ b/src/fight/core/trigger/ally-health-below-threshold-trigger.ts
@@ -20,19 +20,9 @@ export class AllyHealthBelowThresholdTrigger implements ActivatableTrigger {
   activate(triggerId: string, context: FightingContext): void {
     if (triggerId !== `ally-health-${this.monitoredAllyId}`) return;
 
-    const attackerPlayer =
-      context.lastAttacker &&
-      context.sourcePlayer.allCards.some((c) => c === context.lastAttacker)
-        ? context.sourcePlayer
-        : context.opponentPlayer;
-    const allyPlayer =
-      attackerPlayer === context.sourcePlayer
-        ? context.opponentPlayer
-        : context.sourcePlayer;
-
-    const ally =
-      allyPlayer.allCards.find((c) => c.id === this.monitoredAllyId) ??
-      attackerPlayer.allCards?.find((c) => c.id === this.monitoredAllyId);
+    const ally = context.sourcePlayer.allCards.find(
+      (c) => c.id === this.monitoredAllyId,
+    );
     if (!ally) return;
 
     const nowBelow = ally.healthRatio < this.threshold;


### PR DESCRIPTION
# fix(007): allyHealthContext hardcodes player1/player2 — fix ally-health trigger for player2

## ✅ Type of PR

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

`allyHealthContext` in `action-stage.ts` was always passing `player1`/`player2` hardcoded, regardless of which player owns the damaged card. `AllyHealthBelowThresholdTrigger.activate()` then had to guess the correct player via fragile logic with a double-fallback — only coincidentally correct when player1 attacked.

Fixes #338

## 🚶‍➡️ Behavior

- The `ally-health-below` trigger now fires correctly regardless of which player owns the damaged card
- `sourcePlayer` in `allyHealthContext` is now always the damaged card's team
- `AllyHealthBelowThresholdTrigger.activate()` simplified: removed the 9-line player-resolution block, replaced with a single `context.sourcePlayer.allCards.find(...)` call
- Tests updated: the test asserting the old broken behavior is replaced by two tests covering the correct behavior

## 🧪 Steps to test

- [ ] Configure a fight where player2 has a card with an `ally-health-below` skill monitoring one of its allies
- [ ] Have player1 attack that ally until its health drops below the configured threshold
- [ ] Verify the skill triggers (it did not trigger before this fix)
- [ ] Verify the same scenario with player1 as the damaged party still works correctly