### PR TITLE
fix(008): prevent ally-health event from firing on death-dealing hits

### DIFF
--- a/src/fight/core/card-action/action-stage.ts
+++ b/src/fight/core/card-action/action-stage.ts
@@ -303,28 +303,6 @@ export class ActionStage {
         );
       }
 
-      if (!damageDealt.dodge) {
-        defensiveCard.lastAttacker = attackerCard;
-        const damagedCardPlayer = this.player1.ownCard(defensiveCard)
-          ? this.player1
-          : this.player2;
-        const allyHealthContext: FightingContext = {
-          sourcePlayer: damagedCardPlayer,
-          opponentPlayer:
-            damagedCardPlayer === this.player1 ? this.player2 : this.player1,
-          lastAttacker: attackerCard,
-        };
-        damagedCardPlayer.playableCards
-          .filter((c) => c !== defensiveCard)
-          .forEach((caster) => {
-            const results = caster.launchSkills(
-              `ally-health-${defensiveCard.id}`,
-              allyHealthContext,
-            );
-            report.statusChanges.push(...skillResultsToSteps(caster, results));
-          });
-      }
-
       if (defensiveCard.isDead() && !reportedDeaths.has(defensiveCard)) {
         reportedDeaths.add(defensiveCard);
         this.notifyDeath(defensiveCard, attackerCard);
@@ -335,6 +313,29 @@ export class ActionStage {
         });
         report.statusChanges.push(...this.deathSkillHandler.drainSteps());
       } else if (!defensiveCard.isDead()) {
+        if (!damageDealt.dodge) {
+          defensiveCard.lastAttacker = attackerCard;
+          const damagedCardPlayer = this.player1.ownCard(defensiveCard)
+            ? this.player1
+            : this.player2;
+          const allyHealthContext: FightingContext = {
+            sourcePlayer: damagedCardPlayer,
+            opponentPlayer:
+              damagedCardPlayer === this.player1 ? this.player2 : this.player1,
+            lastAttacker: attackerCard,
+          };
+          damagedCardPlayer.playableCards
+            .filter((c) => c !== defensiveCard)
+            .forEach((caster) => {
+              const results = caster.launchSkills(
+                `ally-health-${defensiveCard.id}`,
+                allyHealthContext,
+              );
+              report.statusChanges.push(
+                ...skillResultsToSteps(caster, results),
+              );
+            });
+        }
         if (damageDealt.effects?.length) {
           for (const effect of damageDealt.effects) {
             report.statusChanges.push({


### PR DESCRIPTION
## ✅ Type of PR

- [x] Bug Fix

## 🗒️ Description

L'événement `ally-health-*` était dispatché inconditionnellement après tout coup non-dodgé, y compris les coups fatals. Les link skills se déclenchaient alors sur un ally en cours de mort, produisant un ordre de steps incorrect et un état de jeu invalide.

Le dispatch est désormais déplacé à l'intérieur du guard `else if (!defensiveCard.isDead())`, de sorte qu'il ne s'exécute que si le défenseur survit au coup.

Closes #339

## 🚶‍➡️ Behavior

- **Avant** : un coup fatal déclenchait la link skill sur l'ally mourant avant que la mort ne soit traitée, produisant un step ordering incorrect
- **Après** : l'événement `ally-health-*` n'est dispatché que si le défenseur est encore vivant après le coup

## 🧪 Steps to test

- [ ] Simuler un combat où une link skill réagit à `ally-health-below` sur un ally
- [ ] Vérifier qu'un coup fatal ne déclenche **pas** la link skill
- [ ] Vérifier que la link skill se déclenche correctement quand le coup n'est pas fatal mais passe le seuil de santé