### PR TITLE
fix(007): register LINKED_ALLY and LAST_ATTACKER_OF_ALLY in targeting-strategy-factory

### DIFF
--- a/src/fight/http-api/__test__/fight.controller.spec.ts
+++ b/src/fight/http-api/__test__/fight.controller.spec.ts
@@ -1411,5 +1411,172 @@ describe('FightController', () => {
         /Unknown card selector strategy/,
       );
     });
+
+    it('throws when buildTargetingStrategy receives an unknown strategy name', () => {
+      const data: FightDataDto = {
+        cardSelectorStrategy: CardSelectorStrategy.PLAYER_BY_PLAYER,
+        player1: {
+          name: 'P1',
+          deck: [
+            {
+              ...baseCard,
+              skills: {
+                ...baseCard.skills,
+                others: [
+                  {
+                    kind: SkillKind.HEALING,
+                    name: 'Heal',
+                    rate: 0.3,
+                    targetingStrategy: 'unknown-strategy' as any,
+                    event: TriggerEvent.TURN_END,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        player2: { name: 'P2', deck: [] },
+      };
+
+      expect(() => fightController.startFight(data)).toThrow(
+        /Unknown targeting strategy/,
+      );
+    });
+  });
+
+  describe('when a skill uses linked-ally targeting strategy', () => {
+    const allyId = 'ally-01';
+
+    beforeEach(() => {
+      fightData = {
+        cardSelectorStrategy: CardSelectorStrategy.PLAYER_BY_PLAYER,
+        player1: {
+          name: 'P1',
+          deck: [
+            {
+              id: 'card-01',
+              name: 'Healer',
+              attack: 10,
+              defense: 5,
+              health: 100,
+              speed: 3,
+              agility: 10,
+              accuracy: 50,
+              criticalChance: 0,
+              skills: {
+                special: {
+                  kind: SpecialKind.ATTACK,
+                  name: 'Special',
+                  damages: [{ type: DamageType.PHYSICAL, rate: 2 }],
+                  energy: 9999,
+                  targetingStrategy: TargetingStrategy.POSITION_BASED,
+                },
+                simpleAttack: {
+                  name: 'Attack',
+                  damages: [{ type: DamageType.PHYSICAL, rate: 1.0 }],
+                  targetingStrategy: TargetingStrategy.POSITION_BASED,
+                },
+                others: [
+                  {
+                    kind: SkillKind.HEALING,
+                    name: 'Linked Heal',
+                    rate: 0.3,
+                    targetingStrategy: TargetingStrategy.LINKED_ALLY,
+                    event: TriggerEvent.TURN_END,
+                    targetCardId: allyId,
+                  },
+                ],
+              },
+              behaviors: { dodge: DodgeStrategy.SIMPLE_DODGE },
+            },
+          ],
+        },
+        player2: { name: 'P2', deck: [] },
+      };
+
+      fightController.startFight(fightData);
+    });
+
+    it('creates the healing skill with an allied-card-by-id targeting strategy', () => {
+      fightSimulatorStub.validatePlayer1FirstCard((card) => {
+        expect((card as any).skills[0].targetingStrategy.id).toBe(
+          'allied-card-by-id',
+        );
+      });
+    });
+
+    it('creates the allied-card-by-id strategy with the correct allyId', () => {
+      fightSimulatorStub.validatePlayer1FirstCard((card) => {
+        expect((card as any).skills[0].targetingStrategy.allyId).toBe(allyId);
+      });
+    });
+  });
+
+  describe('when a skill uses last-attacker-of-ally targeting strategy', () => {
+    const allyId = 'ally-02';
+
+    beforeEach(() => {
+      fightData = {
+        cardSelectorStrategy: CardSelectorStrategy.PLAYER_BY_PLAYER,
+        player1: {
+          name: 'P1',
+          deck: [
+            {
+              id: 'card-01',
+              name: 'Avenger',
+              attack: 10,
+              defense: 5,
+              health: 100,
+              speed: 3,
+              agility: 10,
+              accuracy: 50,
+              criticalChance: 0,
+              skills: {
+                special: {
+                  kind: SpecialKind.ATTACK,
+                  name: 'Special',
+                  damages: [{ type: DamageType.PHYSICAL, rate: 2 }],
+                  energy: 9999,
+                  targetingStrategy: TargetingStrategy.POSITION_BASED,
+                },
+                simpleAttack: {
+                  name: 'Attack',
+                  damages: [{ type: DamageType.PHYSICAL, rate: 1.0 }],
+                  targetingStrategy: TargetingStrategy.POSITION_BASED,
+                },
+                others: [
+                  {
+                    kind: SkillKind.HEALING,
+                    name: 'Revenge Heal',
+                    rate: 0.3,
+                    targetingStrategy: TargetingStrategy.LAST_ATTACKER_OF_ALLY,
+                    event: TriggerEvent.TURN_END,
+                    targetCardId: allyId,
+                  },
+                ],
+              },
+              behaviors: { dodge: DodgeStrategy.SIMPLE_DODGE },
+            },
+          ],
+        },
+        player2: { name: 'P2', deck: [] },
+      };
+
+      fightController.startFight(fightData);
+    });
+
+    it('creates the healing skill with a last-attacker-of-ally targeting strategy', () => {
+      fightSimulatorStub.validatePlayer1FirstCard((card) => {
+        expect((card as any).skills[0].targetingStrategy.id).toBe(
+          'last-attacker-of-ally',
+        );
+      });
+    });
+
+    it('creates the last-attacker-of-ally strategy with the correct allyId', () => {
+      fightSimulatorStub.validatePlayer1FirstCard((card) => {
+        expect((card as any).skills[0].targetingStrategy.allyId).toBe(allyId);
+      });
+    });
   });
 });

--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -369,7 +369,10 @@ export class FightController {
           skillData.name,
           skillData.rate,
           this.buildTriggerForSkill(skillData),
-          buildTargetingStrategy(skillData.targetingStrategy),
+          buildTargetingStrategy(
+            skillData.targetingStrategy,
+            skillData.targetCardId,
+          ),
           skillData.powerId,
           skillData.activationLimit,
           skillData.endEvent,
@@ -429,6 +432,7 @@ export class FightController {
           trigger: this.buildTriggerForSkill(skillData),
           targetingStrategy: buildTargetingStrategy(
             skillData.targetingStrategy,
+            skillData.targetCardId,
           ),
           activationCondition: alterationCondition,
           activationLimit: skillData.activationLimit,
@@ -488,7 +492,10 @@ export class FightController {
               skillData.name,
               skillData.hits,
               caDamages,
-              buildTargetingStrategy(skillData.targetingStrategy),
+              buildTargetingStrategy(
+                skillData.targetingStrategy,
+                skillData.targetCardId,
+              ),
               skillData.amplifier ?? 0,
               caEffects,
               caComboFinisher,
@@ -496,7 +503,10 @@ export class FightController {
           : new SimpleAttack(
               skillData.name,
               caDamages,
-              buildTargetingStrategy(skillData.targetingStrategy),
+              buildTargetingStrategy(
+                skillData.targetingStrategy,
+                skillData.targetCardId,
+              ),
               caEffects,
             );
         return new ConditionalAttack(
@@ -524,7 +534,10 @@ export class FightController {
         }
         return new TargetingOverrideSkill(
           skillData.name,
-          buildTargetingStrategy(skillData.targetingStrategy),
+          buildTargetingStrategy(
+            skillData.targetingStrategy,
+            skillData.targetCardId,
+          ),
           skillData.terminationEvent,
           this.buildTriggerForSkill(skillData),
           skillData.powerId,
@@ -552,7 +565,10 @@ export class FightController {
         return new ShieldSkill(
           skillData.name,
           skillData.rate,
-          buildTargetingStrategy(skillData.targetingStrategy),
+          buildTargetingStrategy(
+            skillData.targetingStrategy,
+            skillData.targetCardId,
+          ),
           new HealthThresholdCondition(
             skillData.activationCondition.operator as 'below' | 'above',
             skillData.activationCondition.threshold,

--- a/src/fight/http-api/targeting-strategy-factory.ts
+++ b/src/fight/http-api/targeting-strategy-factory.ts
@@ -4,9 +4,12 @@ import { TargetedLineThree } from '../core/targeting-card-strategies/targeted-li
 import { AllOwnerCards } from '../core/targeting-card-strategies/all-owner-cards';
 import { AllAllies } from '../core/targeting-card-strategies/all-allies';
 import { Launcher } from '../core/targeting-card-strategies/launcher';
+import { AlliedCardByIdStrategy } from '../core/targeting-card-strategies/allied-card-by-id';
+import { LastAttackerOfAllyTargetingStrategy } from '../core/targeting-card-strategies/last-attacker-of-ally';
 import { TargetingStrategy } from './dto/fight-data.dto';
+import { TargetingCardStrategy } from '../core/targeting-card-strategies/targeting-card-strategy';
 
-const STRATEGY_MAP = {
+const STATIC_STRATEGY_MAP: Record<string, TargetingCardStrategy> = {
   [TargetingStrategy.ALL_ALLIES]: new AllAllies(),
   [TargetingStrategy.ALL_OWNER_CARD]: new AllOwnerCards(),
   [TargetingStrategy.LINE_THREE]: new TargetedLineThree(),
@@ -15,6 +18,21 @@ const STRATEGY_MAP = {
   [TargetingStrategy.TARGET_ALL]: new TargetedAll(),
 };
 
-export function buildTargetingStrategy(strategyName: string) {
-  return STRATEGY_MAP[strategyName];
+export function buildTargetingStrategy(
+  strategyName: string,
+  targetCardId?: string,
+): TargetingCardStrategy {
+  if (strategyName === TargetingStrategy.LINKED_ALLY) {
+    if (!targetCardId)
+      throw new Error(`${strategyName} strategy requires targetCardId`);
+    return new AlliedCardByIdStrategy(targetCardId);
+  }
+  if (strategyName === TargetingStrategy.LAST_ATTACKER_OF_ALLY) {
+    if (!targetCardId)
+      throw new Error(`${strategyName} strategy requires targetCardId`);
+    return new LastAttackerOfAllyTargetingStrategy(targetCardId);
+  }
+  const strategy = STATIC_STRATEGY_MAP[strategyName];
+  if (!strategy) throw new Error(`Unknown targeting strategy: ${strategyName}`);
+  return strategy;
 }


### PR DESCRIPTION
## Summary

- `LINKED_ALLY` and `LAST_ATTACKER_OF_ALLY` were defined in the `TargetingStrategy` enum but missing from `buildTargetingStrategy()`'s strategy map, causing a silent `undefined` return and a runtime `TypeError` at fight time
- `buildTargetingStrategy` now accepts an optional `targetCardId` and builds `AlliedCardByIdStrategy` / `LastAttackerOfAllyTargetingStrategy` accordingly
- Throws a meaningful error when `targetCardId` is missing for those strategies, and throws on any unknown strategy name instead of returning `undefined`
- All `createOtherSkill` call sites in the controller now forward `skillData.targetCardId`

## Test plan

- [ ] All 630 existing tests pass (`./node_modules/.bin/jest`)
- [ ] New tests verify HEALING skill with `linked-ally` creates `AlliedCardByIdStrategy` with correct `allyId`
- [ ] New tests verify HEALING skill with `last-attacker-of-ally` creates `LastAttackerOfAllyTargetingStrategy` with correct `allyId`
- [ ] New test verifies unknown strategy name now throws `Unknown targeting strategy` instead of silently returning `undefined`
- [ ] Build passes (`npm run build`)

Closes #340

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVMM6cw342xcCSfiC2F4HH)_