### PR TITLE
fix(007): add range and enum validation to BuffConditionDto threshold and operator

### DIFF
--- a/src/fight/http-api/dto/fight-data.dto.ts
+++ b/src/fight/http-api/dto/fight-data.dto.ts
@@ -12,6 +12,7 @@ import {
   IsDefined,
   ValidateIf,
   Min,
+  Max,
   IsNotIn,
   IsIn,
   ValidatorConstraint,
@@ -39,10 +40,12 @@ class BuffConditionDto {
 
   @IsOptional()
   @IsNumber()
+  @Min(0)
+  @Max(1)
   threshold?: number;
 
   @IsOptional()
-  @IsString()
+  @IsIn(['below', 'above'])
   operator?: string;
 }
 import { DamageType } from '../../core/cards/@types/damage/damage-type';

--- a/test/fight/other-skill-dto-validation.e2e-spec.ts
+++ b/test/fight/other-skill-dto-validation.e2e-spec.ts
@@ -282,4 +282,132 @@ describe('OtherSkillDto validation', () => {
         .expect(400);
     });
   });
+
+  describe('activationCondition threshold validation', () => {
+    it('returns 400 when threshold is below 0', () => {
+      const payload = basePayload([
+        {
+          kind: 'SHIELD',
+          name: 'Iron Wall',
+          rate: 0.3,
+          targetingStrategy: 'self',
+          activationCondition: {
+            type: 'health-threshold',
+            operator: 'below',
+            threshold: -0.1,
+          },
+        },
+      ]);
+
+      return request(app.getHttpServer())
+        .post('/fight')
+        .send(payload)
+        .expect(400);
+    });
+
+    it('returns 400 when threshold is above 1', () => {
+      const payload = basePayload([
+        {
+          kind: 'SHIELD',
+          name: 'Iron Wall',
+          rate: 0.3,
+          targetingStrategy: 'self',
+          activationCondition: {
+            type: 'health-threshold',
+            operator: 'below',
+            threshold: 1.5,
+          },
+        },
+      ]);
+
+      return request(app.getHttpServer())
+        .post('/fight')
+        .send(payload)
+        .expect(400);
+    });
+
+    it('returns 400 when operator is not a valid value', () => {
+      const payload = basePayload([
+        {
+          kind: 'SHIELD',
+          name: 'Iron Wall',
+          rate: 0.3,
+          targetingStrategy: 'self',
+          activationCondition: {
+            type: 'health-threshold',
+            operator: 'invalid-operator',
+            threshold: 0.3,
+          },
+        },
+      ]);
+
+      return request(app.getHttpServer())
+        .post('/fight')
+        .send(payload)
+        .expect(400);
+    });
+
+    it('accepts threshold of 0', () => {
+      const payload = basePayload([
+        {
+          kind: 'SHIELD',
+          name: 'Iron Wall',
+          rate: 0.3,
+          targetingStrategy: 'self',
+          activationCondition: {
+            type: 'health-threshold',
+            operator: 'below',
+            threshold: 0,
+          },
+        },
+      ]);
+
+      return request(app.getHttpServer())
+        .post('/fight')
+        .send(payload)
+        .expect(200);
+    });
+
+    it('accepts threshold of 1', () => {
+      const payload = basePayload([
+        {
+          kind: 'SHIELD',
+          name: 'Iron Wall',
+          rate: 0.3,
+          targetingStrategy: 'self',
+          activationCondition: {
+            type: 'health-threshold',
+            operator: 'below',
+            threshold: 1,
+          },
+        },
+      ]);
+
+      return request(app.getHttpServer())
+        .post('/fight')
+        .send(payload)
+        .expect(200);
+    });
+
+    it('accepts operator "above"', () => {
+      const payload = basePayload([
+        {
+          kind: 'SHIELD',
+          name: 'Iron Wall',
+          rate: 0.3,
+          targetingStrategy: 'self',
+          activationCondition: {
+            type: 'health-threshold',
+            operator: 'above',
+            threshold: 0.7,
+          },
+        },
+      ]);
+
+      return request(app.getHttpServer())
+        .post('/fight')
+        .send(payload)
+        .expect(200);
+    });
+  });
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #341

- Add `@Min(0) @Max(1)` to `BuffConditionDto.threshold` — prevents out-of-range values (e.g. `undefined`, `-0.1`, `1.5`) from silently causing the `AllyHealthBelowThresholdTrigger` to never fire
- Replace `@IsString()` with `@IsIn(['below', 'above'])` on `BuffConditionDto.operator` — rejects unknown operator strings while supporting both valid values used by SHIELD and alteration conditions

## Test plan

- [x] `returns 400 when threshold is below 0`
- [x] `returns 400 when threshold is above 1`
- [x] `returns 400 when operator is not a valid value`
- [x] `accepts threshold of 0` (boundary)
- [x] `accepts threshold of 1` (boundary)
- [x] `accepts operator "above"` (SHIELD use-case)
- [x] All 630 unit tests pass
- [x] All 88 e2e tests pass
- [x] Build succeeds

https://claude.ai/code/session_01Satid2XoagdQ7F89XfTZt2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Satid2XoagdQ7F89XfTZt2)_