### PR TITLE
fix(007): normalize duration:0 to Infinity in ally-health-below ALTERATION branch

### DIFF
--- a/src/fight/http-api/fight.controller.ts
+++ b/src/fight/http-api/fight.controller.ts
@@ -400,7 +400,8 @@ export class FightController {
             polarity: skillData.polarity,
             attributeType: this.mapAlterationType(skillData.buffType),
             rate: skillData.rate,
-            duration: skillData.duration ?? 0,
+            duration:
+              skillData.duration === 0 ? Infinity : (skillData.duration ?? 0),
             trigger: new AllyHealthBelowThresholdTrigger(
               skillData.targetCardId,
               skillData.activationCondition.threshold,


### PR DESCRIPTION
## Summary

- Fixes #342
- The `ally-health-below` early-return branch in `fight.controller.ts` was using `skillData.duration ?? 0` raw, leaving `duration: 0` as `0` instead of normalizing it to `Infinity`
- Applied the same normalization already used in the normal ALTERATION branch: `skillData.duration === 0 ? Infinity : (skillData.duration ?? 0)`

## Test plan

- [ ] All 630 existing tests pass (`npm run test:cov`)
- [ ] Build succeeds (`npm run build`)
- [ ] A buff with `duration: 0` on the `ally-health-below` path now behaves as infinite/event-bound (not a 0-turn buff that expires immediately)

https://claude.ai/code/session_01TqJ9HtzX6QwNP9ACBnrm4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqJ9HtzX6QwNP9ACBnrm4p)_